### PR TITLE
Fix: update EXPORTS_DIR path to ensure correct directory structure

### DIFF
--- a/src/tasks/top_attacking_ips.py
+++ b/src/tasks/top_attacking_ips.py
@@ -22,7 +22,7 @@ TASK_CONFIG = {
     "run_when_loaded": True,
 }
 
-EXPORTS_DIR = "exports"
+EXPORTS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "exports")
 OUTPUT_FILE = os.path.join(EXPORTS_DIR, "malicious_ips.txt")
 
 


### PR DESCRIPTION
This pull request makes a minor update to the `src/tasks/top_attacking_ips.py` file, changing the way the `EXPORTS_DIR` path is defined to ensure it is always relative to the project root rather than the current working directory. This improves reliability when running the script from different locations.

* Updated `EXPORTS_DIR` to use an absolute path based on the script's location, ensuring consistent export directory resolution.