### PR TITLE
Updated README for clarity and RouterOS guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ This file can either be mounted from the Docker container into another system or
 curl https://your-krawl-instance/<DASHBOARD-PATH>/api/download/malicious_ips.txt
 ```
 
-This file can be used to [update a set of firewall rules](https://www.allthingstech.ch/using-opnsense-and-ip-blocklists-to-block-malicious-traffic), for example on OPNsense and pfSense, enabling automatic blocking of malicious IPs or using IPtables
+This file enables automatic blocking of malicious traffic across various platforms. You can use it to update firewall rules on:
+* [OPNsense and pfSense](https://www.allthingstech.ch/using-opnsense-and-ip-blocklists-to-block-malicious-traffic)
+* [RouterOS](https://rentry.co/krawl-routeros)
+* IPtables
 
 ## IP Reputation
 Krawl [uses tasks that analyze recent traffic to build and continuously update an IP reputation](src/tasks/analyze_ips.py) score. It runs periodically and evaluates each active IP address based on multiple behavioral indicators to classify it as an attacker, crawler, or regular user. Thresholds are fully customizable.
@@ -358,3 +361,4 @@ Use responsibly and in compliance with applicable laws and regulations.
 
 ## Star History
 <img src="https://api.star-history.com/svg?repos=BlessedRebuS/Krawl&type=Date" width="600" alt="Star History Chart" />
+


### PR DESCRIPTION
Made and added a RouterOS auto-pull guide for malicious_ips.txt. The script validates I changed the wording in readme to fit the different guides and made it a list for quick eyes scanning the text. 

Script confirmed to work on my own RB4011iGS+ Mikrotik router, running RouterOS 7.21.2 (2026-Jan-29)

<img width="1078" height="130" alt="image" src="https://github.com/user-attachments/assets/909b00ef-11de-4aee-a2a6-7278206da352" />

