### PR TITLE
fix: remove unnecessary quotes from backups.enabled in configmap.yaml

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
     backups:
       path: {{ .Values.config.backups.path | quote }}
       cron: {{ .Values.config.backups.cron | quote }}
-      enabled: {{ .Values.config.backups.enabled | quote }}
+      enabled: {{ .Values.config.backups.enabled }}
     exports:
       path: {{ .Values.config.exports.path | quote }}
     database:


### PR DESCRIPTION
This pull request makes a small adjustment to the `helm/templates/configmap.yaml` file. The change removes quoting from the `enabled` value in the backups configuration, allowing it to be rendered as a boolean instead of a string.

* [`helm/templates/configmap.yaml`](diffhunk://#diff-bfc6a602171deb9937fdee53ff0c20b633450fe90d995958f68b1e0035175ccbL28-R28): Changed `backups.enabled` to render without quotes, so it is treated as a boolean value.