### PR TITLE
Make attackers table sortable and cleanup time display.

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -30,7 +30,7 @@ def get_templates() -> Jinja2Templates:
     return _templates
 
 
-def _format_ts(value, time_only=False):
+def _format_ts(value):
     """Custom Jinja2 filter for formatting ISO timestamps."""
     if not value:
         return "N/A"
@@ -39,7 +39,7 @@ def _format_ts(value, time_only=False):
             value = datetime.fromisoformat(value)
         except (ValueError, TypeError):
             return value
-    if time_only:
+    if value.date() == datetime.now().date():
         return value.strftime("%H:%M:%S")
     return value.strftime("%m/%d/%Y %H:%M:%S")
 

--- a/src/templates/jinja2/dashboard/partials/attackers_table.html
+++ b/src/templates/jinja2/dashboard/partials/attackers_table.html
@@ -25,8 +25,16 @@
                 hx-swap="innerHTML">
                 Total Requests
             </th>
-            <th>First Seen</th>
-            <th>Last Seen</th>
+            <th class="sortable {% if sort_by == 'first_seen' %}{{ sort_order }}{% endif %}"
+                hx-get="{{ dashboard_path }}/htmx/attackers?page=1&sort_by=first_seen&sort_order={% if sort_by == 'first_seen' and sort_order == 'desc' %}asc{% else %}desc{% endif %}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML">
+                First Seen</th>
+            <th class="sortable {% if sort_by == 'last_seen' %}{{ sort_order }}{% endif %}"
+                hx-get="{{ dashboard_path }}/htmx/attackers?page=1&sort_by=last_seen&sort_order={% if sort_by == 'last_seen' and sort_order == 'desc' %}asc{% else %}desc{% endif %}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML">
+                Last Seen</th>
             <th>Location</th>
         </tr>
     </thead>

--- a/src/templates/jinja2/dashboard/partials/suspicious_table.html
+++ b/src/templates/jinja2/dashboard/partials/suspicious_table.html
@@ -22,7 +22,7 @@
                 </td>
                 <td>{{ activity.path | e }}</td>
                 <td style="word-break: break-all;">{{ (activity.user_agent | default(''))[:80] | e }}</td>
-                <td>{{ activity.timestamp | format_ts(time_only=True) }}</td>
+                <td>{{ activity.timestamp | format_ts }}</td>
             </tr>
             <tr class="ip-stats-row" style="display: none;">
                 <td colspan="4" class="ip-stats-cell">


### PR DESCRIPTION
This update makes the Attackers by Total Requests table sortable by First Seen and Last Seen.

It also changes the way datetimes are being displayed everywhere: Only show the time when the event happened today, show the full datetime when the event happened on another day.