### PR TITLE
fix: correct logic for flagging stale IPs for reevaluation

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -815,7 +815,7 @@ class DatabaseManager:
     def flag_stale_ips_for_reevaluation(self) -> int:
         """
         Flag IPs for reevaluation where:
-        - last_seen is older than the configured retention period
+        - last_seen is newer than the configured retention period
         - last_analysis is more than 5 days ago
 
         Returns:
@@ -833,7 +833,7 @@ class DatabaseManager:
             count = (
                 session.query(IpStats)
                 .filter(
-                    IpStats.last_seen <= last_seen_cutoff,
+                    IpStats.last_seen >= last_seen_cutoff,
                     IpStats.last_analysis <= last_analysis_cutoff,
                     IpStats.need_reevaluation == False,
                     IpStats.manual_category == False,


### PR DESCRIPTION
This pull request updates the logic for flagging IPs that need reevaluation in the `src/database.py` file. The main change is that the criteria for selecting IPs based on their `last_seen` timestamp has been reversed, so that only IPs seen more recently than the retention period are considered for reevaluation.

**Logic change for IP reevaluation:**

* Updated the docstring in `get_ips_needing_reevaluation` to state that IPs are flagged if their `last_seen` is newer (not older) than the configured retention period.
* Changed the query filter in `flag_stale_ips_for_reevaluation` so that `IpStats.last_seen >= last_seen_cutoff` is used instead of `<=`, aligning the code with the new intended logic.