### PR TITLE
fix connection exception issue

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -131,14 +131,7 @@ def create_app() -> FastAPI:
     async def access_log_middleware(request: Request, call_next):
         from dependencies import get_client_ip
 
-        try:
-            response: Response = await call_next(request)
-        except ConnectionResetError:
-            client_ip = get_client_ip(request)
-            path = request.url.path
-            method = request.method
-            get_access_logger().info(f"[BANNED] [{method}] {client_ip} - {path}")
-            raise
+        response: Response = await call_next(request)
 
         client_ip = get_client_ip(request)
         path = request.url.path

--- a/src/middleware/ban_check.py
+++ b/src/middleware/ban_check.py
@@ -12,13 +12,6 @@ from starlette.responses import Response
 from dependencies import get_client_ip
 
 
-class ConnectionResetResponse(Response):
-    """Response that abruptly closes the connection without sending data."""
-
-    async def __call__(self, scope, receive, send):
-        raise ConnectionResetError()
-
-
 class BanCheckMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         # Skip ban check for dashboard routes
@@ -31,7 +24,15 @@ class BanCheckMiddleware(BaseHTTPMiddleware):
         tracker = request.app.state.tracker
 
         if tracker.is_banned_ip(client_ip):
-            return ConnectionResetResponse()
+            from logger import get_access_logger
+
+            get_access_logger().info(
+                f"[BANNED] [{request.method}] {client_ip} - {request.url.path}"
+            )
+            transport = request.scope.get("transport")
+            if transport:
+                transport.close()
+            return Response(status_code=500)
 
         response = await call_next(request)
         return response


### PR DESCRIPTION
This pull request refactors the handling of banned IPs in middleware, replacing abrupt connection resets with a logged event and a standardized HTTP response. The changes improve clarity and maintainability of ban enforcement, while ensuring proper logging of banned access attempts.

Improvements to ban enforcement and logging:

* Removed the custom `ConnectionResetResponse` class and replaced abrupt connection resets with a standard HTTP 500 response, making ban handling more predictable and easier to maintain.
* Added logging for banned IP access attempts directly in the `BanCheckMiddleware`, ensuring that every banned request is properly recorded.

Codebase simplification:

* Removed unnecessary exception handling for `ConnectionResetError` in the `access_log_middleware`, since banned requests are now handled by the middleware and logged appropriately.