### PR TITLE
feat: highlight suspicious access logs in the dashboard and remove ra…

### DIFF
--- a/src/templates/jinja2/dashboard/partials/access_by_ip_table.html
+++ b/src/templates/jinja2/dashboard/partials/access_by_ip_table.html
@@ -31,7 +31,7 @@
     </thead>
     <tbody>
         {% for log in items %}
-        <tr class="ip-row" data-ip="{{ log.ip | e }}">
+        <tr class="ip-row{% if log.is_suspicious %} access-row-suspicious{% endif %}" data-ip="{{ log.ip | e }}">
             <td class="rank">{{ loop.index + (pagination.page - 1) * pagination.page_size }}</td>
             <td>
                 <div class="path-cell-container">
@@ -44,7 +44,7 @@
             <td>{{ (log.user_agent | default(''))[:50] | e }}</td>
             <td>{{ log.timestamp | format_ts }}</td>
             <td>
-                {% if log.id %}
+                {% if log.is_suspicious and log.id %}
                 <button class="view-btn" @click="viewRawRequest({{ log.id }})" title="View Request">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6z"/></svg>
                     <span class="view-btn-tooltip">View Request</span>

--- a/src/templates/static/css/dashboard.css
+++ b/src/templates/static/css/dashboard.css
@@ -2003,6 +2003,13 @@ tbody {
 .view-btn:hover .view-btn-tooltip {
     opacity: 1;
 }
+.access-row-suspicious {
+    border-left: 3px solid #f85149;
+    background: rgba(248, 81, 73, 0.06);
+}
+.access-row-suspicious:hover {
+    background: rgba(248, 81, 73, 0.12);
+}
 .inspect-btn {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
This pull request enhances the visibility of suspicious access entries in the dashboard's "Access by IP" table. Suspicious rows are now visually highlighted and the "View Request" button is only shown for these entries.

**UI enhancements for suspicious access entries:**

* Suspicious access rows in the `access_by_ip_table.html` table are now given an `access-row-suspicious` class, which visually highlights them.
* Added CSS styles in `dashboard.css` to highlight suspicious rows with a colored border and background, including a hover effect.

**Button visibility logic:**

* The "View Request" button is now only shown for suspicious log entries that have an `id`, making it easier to focus on potentially problematic access attempts.…w request button