### PR TITLE
fix: improve cache efficiency by removing unnecessary SQLite PRAGMAs

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -26,9 +26,6 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
     cursor.execute("PRAGMA busy_timeout=30000")
     cursor.execute("PRAGMA synchronous=NORMAL")
     cursor.execute("PRAGMA wal_autocheckpoint=5000")
-    cursor.execute("PRAGMA cache_size=-65536")
-    cursor.execute("PRAGMA temp_store=MEMORY")
-    cursor.execute("PRAGMA mmap_size=30000000")
     cursor.close()
 
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the SQLite configuration in the `set_sqlite_pragma` function. The change removes several PRAGMA settings related to cache size, temporary storage, and memory mapping.

* Removed `PRAGMA cache_size`, `PRAGMA temp_store`, and `PRAGMA mmap_size` settings from the `set_sqlite_pragma` function in `src/database.py`, simplifying the database initialization and potentially reducing memory usage.