### PR TITLE
fix: mark requests as banned in state for proper response handling

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -136,6 +136,10 @@ def create_app() -> FastAPI:
 
         response: Response = await call_next(request)
 
+        # Banned requests are already logged by BanCheckMiddleware
+        if getattr(request.state, "banned", False):
+            return response
+
         client_ip = get_client_ip(request)
         path = request.url.path
         method = request.method

--- a/src/middleware/ban_check.py
+++ b/src/middleware/ban_check.py
@@ -30,6 +30,7 @@ class BanCheckMiddleware(BaseHTTPMiddleware):
             get_access_logger().info(
                 f"[BANNED] [{request.method}] {client_ip} - {request.url.path}"
             )
+            request.state.banned = True
             retry_after = int(ban_info["remaining_ban_seconds"])
             return Response(
                 status_code=429,


### PR DESCRIPTION
Fix duplicated logs

```
[2026-03-24 16:37:02] INFO - [BANNED] [GET] 104.23.176.6 - /hGqV7yAMrXT
[2026-03-24 16:37:02] INFO - [GET] 104.23.176.6 - /hGqV7yAMrXT - 429
```