### PR TITLE
Feat/redis and external db implementation

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -73,6 +73,7 @@ class DatabaseManager:
             return
 
         from config import get_config
+
         sql_echo = get_config().log_level == "DEBUG"
 
         self._mode = mode

--- a/src/middleware/ban_check.py
+++ b/src/middleware/ban_check.py
@@ -5,6 +5,8 @@ Middleware for checking if client IP is banned.
 Returns 429 Too Many Requests with a Retry-After header for banned IPs.
 """
 
+import asyncio
+
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -23,7 +25,12 @@ class BanCheckMiddleware(BaseHTTPMiddleware):
         client_ip = get_client_ip(request)
         tracker = request.app.state.tracker
 
-        ban_info = tracker.get_ban_info(client_ip)
+        from logger import get_app_logger
+
+        get_app_logger().debug(
+            f"[BanCheck] Checking ban for {client_ip} - {request.url.path}"
+        )
+        ban_info = await asyncio.to_thread(tracker.get_ban_info, client_ip)
         if ban_info["is_banned"]:
             from logger import get_access_logger
 

--- a/src/middleware/deception.py
+++ b/src/middleware/deception.py
@@ -5,7 +5,6 @@ Middleware for deception response detection (path traversal, XXE, command inject
 Short-circuits the request if a deception response is triggered.
 """
 
-import asyncio
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -25,6 +24,7 @@ class DeceptionMiddleware(BaseHTTPMiddleware):
         if path.startswith(dashboard_prefix):
             return await call_next(request)
 
+        get_app_logger().debug(f"[Deception] Processing {request.method} {path}")
         query = request.url.query or ""
         method = request.method
 
@@ -85,9 +85,12 @@ class DeceptionMiddleware(BaseHTTPMiddleware):
                 f"[{attack_type_log} DETECTED] {client_ip} - {path[:100]} - Method: {method}"
             )
 
-            # Record access
+            # Record access (run in thread to avoid blocking event loop)
+            import asyncio
+
             tracker = request.app.state.tracker
-            tracker.record_access(
+            await asyncio.to_thread(
+                tracker.record_access,
                 ip=client_ip,
                 path=path,
                 user_agent=user_agent,

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -6,6 +6,7 @@ Migrated from handler.py dashboard API endpoints.
 All endpoints are prefixed with the secret dashboard path.
 """
 
+import asyncio
 import hashlib
 import hmac
 import os
@@ -169,9 +170,11 @@ async def ban_override(request: Request, body: BanOverrideRequest):
         )
 
     if body.action == "ban":
-        success = db.force_ban_ip(body.ip)
+        success = await asyncio.to_thread(db.force_ban_ip, body.ip)
     else:
-        success = db.set_ban_override(body.ip, action_map[body.action])
+        success = await asyncio.to_thread(
+            db.set_ban_override, body.ip, action_map[body.action]
+        )
 
     if success:
         get_app_logger().info(f"Ban override: {body.action} on IP {body.ip}")
@@ -197,9 +200,9 @@ async def track_ip(request: Request, body: TrackIpRequest):
 
     db = get_db()
     if body.action == "track":
-        success = db.track_ip(body.ip)
+        success = await asyncio.to_thread(db.track_ip, body.ip)
     elif body.action == "untrack":
-        success = db.untrack_ip(body.ip)
+        success = await asyncio.to_thread(db.untrack_ip, body.ip)
     else:
         return JSONResponse(
             content={"error": "Invalid action. Use: track, untrack"},
@@ -223,7 +226,7 @@ async def all_ip_stats(request: Request):
 
     db = get_db()
     try:
-        ip_stats_list = db.get_ip_stats(limit=500)
+        ip_stats_list = await asyncio.to_thread(db.get_ip_stats, limit=500)
         result = {"ips": ip_stats_list}
         set_cached_table("api:all_ip_stats", result)
         return JSONResponse(
@@ -248,8 +251,12 @@ async def attackers(
     page_size = min(max(1, page_size), 100)
 
     try:
-        result = db.get_attackers_paginated(
-            page=page, page_size=page_size, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_attackers_paginated,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -283,8 +290,12 @@ async def all_ips(
 
     db = get_db()
     try:
-        result = db.get_all_ips_paginated(
-            page=page, page_size=page_size, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_all_ips_paginated,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -296,7 +307,7 @@ async def all_ips(
 async def ip_stats(ip_address: str, request: Request):
     db = get_db()
     try:
-        stats = db.get_ip_stats_by_ip(ip_address)
+        stats = await asyncio.to_thread(db.get_ip_stats_by_ip, ip_address)
         if stats:
             return JSONResponse(content=stats, headers=_no_cache_headers())
         else:
@@ -321,8 +332,12 @@ async def honeypot(
     page_size = min(max(1, page_size), 100)
 
     try:
-        result = db.get_honeypot_paginated(
-            page=page, page_size=page_size, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_honeypot_paginated,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -343,8 +358,12 @@ async def credentials(
     page_size = min(max(1, page_size), 100)
 
     try:
-        result = db.get_credentials_paginated(
-            page=page, page_size=page_size, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_credentials_paginated,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -365,8 +384,12 @@ async def top_ips(
     page_size = min(max(1, page_size), 100)
 
     try:
-        result = db.get_top_ips_paginated(
-            page=page, page_size=page_size, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_top_ips_paginated,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -387,8 +410,12 @@ async def top_paths(
     page_size = min(max(1, page_size), 100)
 
     try:
-        result = db.get_top_paths_paginated(
-            page=page, page_size=page_size, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_top_paths_paginated,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -409,8 +436,12 @@ async def top_user_agents(
     page_size = min(max(1, page_size), 100)
 
     try:
-        result = db.get_top_user_agents_paginated(
-            page=page, page_size=page_size, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_top_user_agents_paginated,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -433,7 +464,9 @@ async def attack_types_stats(
 
     db = get_db()
     try:
-        result = db.get_attack_types_stats(limit=limit, ip_filter=ip_filter)
+        result = await asyncio.to_thread(
+            db.get_attack_types_stats, limit=limit, ip_filter=ip_filter
+        )
         set_cached_table(cache_key, result)
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -454,8 +487,12 @@ async def attack_types(
     page_size = min(max(1, page_size), 100)
 
     try:
-        result = db.get_attack_types_paginated(
-            page=page, page_size=page_size, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_attack_types_paginated,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
@@ -467,7 +504,7 @@ async def attack_types(
 async def raw_request(log_id: int, request: Request):
     db = get_db()
     try:
-        raw = db.get_raw_request_by_id(log_id)
+        raw = await asyncio.to_thread(db.get_raw_request_by_id, log_id)
         if raw is None:
             return JSONResponse(
                 content={"error": "Raw request not found"}, status_code=404

--- a/src/routes/dashboard.py
+++ b/src/routes/dashboard.py
@@ -27,10 +27,14 @@ async def dashboard_page(request: Request):
         stats = get_cached("stats")
         suspicious = get_cached("suspicious")
     else:
+        import asyncio
+
         db = get_db()
-        stats = db.get_dashboard_counts()
-        suspicious = db.get_recent_suspicious(limit=10)
-        cred_result = db.get_credentials_paginated(page=1, page_size=1)
+        stats = await asyncio.to_thread(db.get_dashboard_counts)
+        suspicious = await asyncio.to_thread(db.get_recent_suspicious, 10)
+        cred_result = await asyncio.to_thread(
+            db.get_credentials_paginated, page=1, page_size=1
+        )
         stats["credential_count"] = cred_result["pagination"]["total"]
 
     templates = get_templates()
@@ -47,9 +51,11 @@ async def dashboard_page(request: Request):
 
 @router.get("/ip/{ip_address:path}")
 async def ip_page(ip_address: str, request: Request):
+    import asyncio
+
     db = get_db()
     try:
-        stats = db.get_ip_stats_by_ip(ip_address)
+        stats = await asyncio.to_thread(db.get_ip_stats_by_ip, ip_address)
         config = request.app.state.config
         dashboard_path = "/" + config.dashboard_secret_path.lstrip("/")
 

--- a/src/routes/honeypot.py
+++ b/src/routes/honeypot.py
@@ -61,6 +61,7 @@ async def _track_honeypot_request(request: Request):
     client_ip = get_client_ip(request)
     user_agent = request.headers.get("User-Agent", "")
     path = request.url.path
+    get_app_logger().debug(f"[HoneypotDep] {request.method} {path} from {client_ip}")
 
     body = ""
     if request.method in ("POST", "PUT"):
@@ -77,7 +78,10 @@ async def _track_honeypot_request(request: Request):
 
     # Record if attack pattern detected OR path is a honeypot trap
     if attack_findings or tracker.is_honeypot_path(path):
-        tracker.record_access(
+        import asyncio
+
+        await asyncio.to_thread(
+            tracker.record_access,
             ip=client_ip,
             path=path,
             user_agent=user_agent,
@@ -202,8 +206,12 @@ async def credential_capture_post(request: Request, path: str):
             credential_line = f"{timestamp}|{client_ip}|{username or 'N/A'}|{password or 'N/A'}|{full_path}"
             credential_logger.info(credential_line)
 
-            tracker.record_credential_attempt(
-                client_ip, full_path, username or "N/A", password or "N/A"
+            await asyncio.to_thread(
+                tracker.record_credential_attempt,
+                client_ip,
+                full_path,
+                username or "N/A",
+                password or "N/A",
             )
 
             access_logger.warning(
@@ -394,6 +402,8 @@ async def trap_page(request: Request, path: str):
     user_agent = request.headers.get("User-Agent", "")
     full_path = f"/{path}" if path else "/"
 
+    app_logger.debug(f"[TrapPage] {client_ip} - {full_path}")
+
     # Check wordpress-like paths
     if "wordpress" in full_path.lower():
         return HTMLResponse(html_templates.wordpress())
@@ -405,7 +415,8 @@ async def trap_page(request: Request, path: str):
     if not tracker.detect_attack_type(full_path) and not tracker.is_honeypot_path(
         full_path
     ):
-        tracker.record_access(
+        await asyncio.to_thread(
+            tracker.record_access,
             ip=client_ip,
             path=full_path,
             user_agent=user_agent,
@@ -423,11 +434,19 @@ async def trap_page(request: Request, path: str):
     await asyncio.sleep(config.delay / 1000.0)
 
     # Increment page visit counter
-    current_visit_count = tracker.increment_page_visit(client_ip)
+    current_visit_count = await asyncio.to_thread(
+        tracker.increment_page_visit, client_ip
+    )
 
-    # Generate page
-    page_html = _generate_page(
-        config, tracker, client_ip, full_path, current_visit_count, request.app
+    # Generate page (sync function with DB calls, run in thread)
+    page_html = await asyncio.to_thread(
+        _generate_page,
+        config,
+        tracker,
+        client_ip,
+        full_path,
+        current_visit_count,
+        request.app,
     )
 
     # Decrement canary counter

--- a/src/routes/htmx.py
+++ b/src/routes/htmx.py
@@ -5,6 +5,8 @@ HTMX fragment endpoints.
 Server-rendered HTML partials for table pagination, sorting, IP details, and search.
 """
 
+import asyncio
+
 from fastapi import APIRouter, Request, Response, Query
 from fastapi.responses import HTMLResponse
 
@@ -38,8 +40,12 @@ async def htmx_honeypot(
         result = cached
     else:
         db = get_db()
-        result = db.get_honeypot_paginated(
-            page=page, page_size=5, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_honeypot_paginated,
+            page=page,
+            page_size=5,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         set_cached_table(cache_key, result)
 
@@ -83,8 +89,12 @@ async def htmx_top_ips(
         result = cached
     else:
         db = get_db()
-        result = db.get_top_ips_paginated(
-            page=max(1, page), page_size=8, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_top_ips_paginated,
+            page=max(1, page),
+            page_size=8,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
 
     templates = get_templates()
@@ -126,8 +136,12 @@ async def htmx_top_paths(
         result = cached
     else:
         db = get_db()
-        result = db.get_top_paths_paginated(
-            page=max(1, page), page_size=5, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_top_paths_paginated,
+            page=max(1, page),
+            page_size=5,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
 
     templates = get_templates()
@@ -169,8 +183,12 @@ async def htmx_top_ua(
         result = cached
     else:
         db = get_db()
-        result = db.get_top_user_agents_paginated(
-            page=max(1, page), page_size=5, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_top_user_agents_paginated,
+            page=max(1, page),
+            page_size=5,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
 
     templates = get_templates()
@@ -204,8 +222,12 @@ async def htmx_attackers(
         result = cached
     else:
         db = get_db()
-        result = db.get_attackers_paginated(
-            page=page, page_size=25, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_attackers_paginated,
+            page=page,
+            page_size=25,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         set_cached_table(cache_key, result)
 
@@ -246,7 +268,8 @@ async def htmx_access_logs_by_ip(
         result = cached
     else:
         db = get_db()
-        result = db.get_access_logs_paginated(
+        result = await asyncio.to_thread(
+            db.get_access_logs_paginated,
             page=page,
             page_size=25,
             ip_filter=ip_filter,
@@ -291,8 +314,12 @@ async def htmx_credentials(
         result = cached
     else:
         db = get_db()
-        result = db.get_credentials_paginated(
-            page=page, page_size=5, sort_by=sort_by, sort_order=sort_order
+        result = await asyncio.to_thread(
+            db.get_credentials_paginated,
+            page=page,
+            page_size=5,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         set_cached_table(cache_key, result)
 
@@ -328,7 +355,8 @@ async def htmx_attacks(
         result = cached
     else:
         db = get_db()
-        result = db.get_attack_types_paginated(
+        result = await asyncio.to_thread(
+            db.get_attack_types_paginated,
             page=page,
             page_size=5,
             sort_by=sort_by,
@@ -384,7 +412,7 @@ async def htmx_patterns(
     else:
         db = get_db()
         # Get all attack type stats and paginate manually
-        result = db.get_attack_types_stats(limit=100)
+        result = await asyncio.to_thread(db.get_attack_types_stats, limit=100)
         set_cached_table(cache_key, result)
     all_patterns = [
         {"pattern": item["type"], "count": item["count"]}
@@ -419,7 +447,7 @@ async def htmx_patterns(
 @router.get("/htmx/ip-insight/{ip_address:path}")
 async def htmx_ip_insight(ip_address: str, request: Request):
     db = get_db()
-    stats = db.get_ip_stats_by_ip(ip_address)
+    stats = await asyncio.to_thread(db.get_ip_stats_by_ip, ip_address)
 
     if not stats:
         stats = {"ip": ip_address, "total_requests": "N/A"}
@@ -429,7 +457,7 @@ async def htmx_ip_insight(ip_address: str, request: Request):
     stats["blocklist_memberships"] = list(list_on.keys()) if list_on else []
     stats["reverse_dns"] = stats.get("reverse")
 
-    is_tracked = db.is_ip_tracked(ip_address)
+    is_tracked = await asyncio.to_thread(db.is_ip_tracked, ip_address)
 
     templates = get_templates()
     return templates.TemplateResponse(
@@ -450,7 +478,7 @@ async def htmx_ip_insight(ip_address: str, request: Request):
 @router.get("/htmx/ip-detail/{ip_address:path}")
 async def htmx_ip_detail(ip_address: str, request: Request):
     db = get_db()
-    stats = db.get_ip_stats_by_ip(ip_address)
+    stats = await asyncio.to_thread(db.get_ip_stats_by_ip, ip_address)
 
     if not stats:
         stats = {"ip": ip_address, "total_requests": "N/A"}
@@ -460,7 +488,7 @@ async def htmx_ip_detail(ip_address: str, request: Request):
     stats["blocklist_memberships"] = list(list_on.keys()) if list_on else []
     stats["reverse_dns"] = stats.get("reverse")
 
-    is_tracked = db.is_ip_tracked(ip_address)
+    is_tracked = await asyncio.to_thread(db.is_ip_tracked, ip_address)
 
     templates = get_templates()
     return templates.TemplateResponse(
@@ -488,7 +516,9 @@ async def htmx_search(
         return Response(content="", media_type="text/html")
 
     db = get_db()
-    result = db.search_attacks_and_ips(query=q, page=max(1, page), page_size=20)
+    result = await asyncio.to_thread(
+        db.search_attacks_and_ips, query=q, page=max(1, page), page_size=20
+    )
 
     templates = get_templates()
     return templates.TemplateResponse(
@@ -543,7 +573,9 @@ async def htmx_ban_attackers(
         )
 
     db = get_db()
-    result = db.get_attackers_paginated(page=max(1, page), page_size=page_size)
+    result = await asyncio.to_thread(
+        db.get_attackers_paginated, page=max(1, page), page_size=page_size
+    )
     templates = get_templates()
     return templates.TemplateResponse(
         request,
@@ -592,7 +624,9 @@ async def htmx_tracked_ips_list(
         )
 
     db = get_db()
-    result = db.get_tracked_ips_paginated(page=max(1, page), page_size=page_size)
+    result = await asyncio.to_thread(
+        db.get_tracked_ips_paginated, page=max(1, page), page_size=page_size
+    )
     templates = get_templates()
     return templates.TemplateResponse(
         request,
@@ -617,7 +651,9 @@ async def htmx_ban_overrides(
         )
 
     db = get_db()
-    result = db.get_ban_overrides_paginated(page=max(1, page), page_size=page_size)
+    result = await asyncio.to_thread(
+        db.get_ban_overrides_paginated, page=max(1, page), page_size=page_size
+    )
     templates = get_templates()
     return templates.TemplateResponse(
         request,

--- a/src/tasks/dashboard_warmup.py
+++ b/src/tasks/dashboard_warmup.py
@@ -56,20 +56,37 @@ def main():
         # --- Server-rendered data (stats cards + suspicious table) ---
         stats = _timed("get_dashboard_counts", db.get_dashboard_counts)
 
-        cred_result = _timed("get_credentials_paginated", lambda: db.get_credentials_paginated(page=1, page_size=1))
+        cred_result = _timed(
+            "get_credentials_paginated",
+            lambda: db.get_credentials_paginated(page=1, page_size=1),
+        )
         stats["credential_count"] = cred_result["pagination"]["total"]
 
-        suspicious = _timed("get_recent_suspicious", lambda: db.get_recent_suspicious(limit=10))
+        suspicious = _timed(
+            "get_recent_suspicious", lambda: db.get_recent_suspicious(limit=10)
+        )
 
         # --- HTMX Overview tables (first page, default sort) ---
-        top_ips = _timed("get_top_ips_paginated", lambda: db.get_top_ips_paginated(page=1, page_size=8))
-        top_ua = _timed("get_top_user_agents_paginated", lambda: db.get_top_user_agents_paginated(page=1, page_size=5))
-        top_paths = _timed("get_top_paths_paginated", lambda: db.get_top_paths_paginated(page=1, page_size=5))
+        top_ips = _timed(
+            "get_top_ips_paginated",
+            lambda: db.get_top_ips_paginated(page=1, page_size=8),
+        )
+        top_ua = _timed(
+            "get_top_user_agents_paginated",
+            lambda: db.get_top_user_agents_paginated(page=1, page_size=5),
+        )
+        top_paths = _timed(
+            "get_top_paths_paginated",
+            lambda: db.get_top_paths_paginated(page=1, page_size=5),
+        )
 
         # --- Map data (default: top 100 IPs by total_requests) ---
-        map_ips = _timed("get_all_ips_paginated", lambda: db.get_all_ips_paginated(
-            page=1, page_size=100, sort_by="total_requests", sort_order="desc"
-        ))
+        map_ips = _timed(
+            "get_all_ips_paginated",
+            lambda: db.get_all_ips_paginated(
+                page=1, page_size=100, sort_by="total_requests", sort_order="desc"
+            ),
+        )
 
         # Store everything in the cache (overwrites previous values)
         set_cached("stats", stats)


### PR DESCRIPTION
## Summary

Fixes critical event loop blocking in scalable mode (MariaDB over network) by wrapping all synchronous SQLAlchemy database calls in `asyncio.to_thread()` across every async route handler and middleware.

When running against a remote MariaDB (vs local SQLite), synchronous DB calls block the uvicorn async event loop for the duration of each network round-trip. This caused the entire server to freeze — no request could be processed while any DB query was in flight. With SQLite the latency was sub-millisecond and invisible; with MariaDB over the network it caused multi-second hangs and cascading timeouts.

## Changes

### `asyncio.to_thread()` migration

**Middleware** (previously completed, included for completeness):
- `middleware/ban_check.py` — `tracker.get_ban_info()`
- `middleware/deception.py` — `tracker.record_access()`

**Honeypot routes** (previously completed):
- `routes/honeypot.py` — `tracker.record_access()` (3 locations), `tracker.increment_page_visit()`, `tracker.record_credential_attempt()`, `_generate_page()`

**Dashboard routes** (previously completed + new):
- `routes/dashboard.py` — `db.get_dashboard_counts()`, `db.get_recent_suspicious()`, `db.get_credentials_paginated()`, `db.get_ip_stats_by_ip()`

**HTMX fragment routes** (new — 17 calls):
- `routes/htmx.py` — `get_honeypot_paginated`, `get_top_ips_paginated`, `get_top_paths_paginated`, `get_top_user_agents_paginated`, `get_attackers_paginated` (×2), `get_access_logs_paginated`, `get_credentials_paginated`, `get_attack_types_paginated`, `get_attack_types_stats`, `get_ip_stats_by_ip` (×2), `is_ip_tracked` (×2), `search_attacks_and_ips`, `get_tracked_ips_paginated`, `get_ban_overrides_paginated`

**API routes** (new — 16 calls):
- `routes/api.py` — `force_ban_ip`, `set_ban_override`, `track_ip`, `untrack_ip`, `get_ip_stats`, `get_attackers_paginated`, `get_all_ips_paginated`, `get_ip_stats_by_ip`, `get_honeypot_paginated`, `get_credentials_paginated`, `get_top_ips_paginated`, `get_top_paths_paginated`, `get_top_user_agents_paginated`, `get_attack_types_stats`, `get_attack_types_paginated`, `get_raw_request_by_id`

### Debug logging

Added `DEBUG`-level logs to aid troubleshooting in scalable deployments:
- `middleware/ban_check.py` — logs each ban check with IP and path
- `middleware/deception.py` — logs each request entering deception detection
- `routes/honeypot.py` — logs honeypot dependency execution and trap page generation
