### PR TITLE
fix: correct count query for tracked IPs in DatabaseManager

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -2717,7 +2717,7 @@ class DatabaseManager:
         """Get all tracked IPs, paginated. Reads only from tracked_ips table."""
         session = self.session
         try:
-            total = session.query(func.count(TrackedIp.id)).scalar() or 0
+            total = session.query(func.count(TrackedIp.ip)).scalar() or 0
             total_pages = max(1, (total + page_size - 1) // page_size)
 
             tracked_rows = (


### PR DESCRIPTION
This pull request includes a small change to the `get_tracked_ips_paginated` function in `src/database.py`, updating the count query to use `TrackedIp.ip` instead of `TrackedIp.id` when determining the total number of tracked IPs.