### PR TITLE
Fix/ai call api

### DIFF
--- a/src/generative_ai.py
+++ b/src/generative_ai.py
@@ -466,7 +466,7 @@ async def generate_html_for_path(
     timeout = get_timeout()
 
     try:
-        logger.debug(
+        logger.info(
             f"[AI GENERATION] Generating response for path: {path} with {provider} (timeout: {timeout}s)"
         )
         logger.debug(f"Using model: {model}")


### PR DESCRIPTION
This pull request makes minor improvements to the `src/generative_ai.py` module, focusing on default parameter values and logging clarity.

- API call handler improvements:
  * The `_call_api` function now sets default values for the `reasoning_enabled` and `reasoning_effort` parameters, making them optional in function calls and improving usability. (`src/generative_ai.py`)

- Logging enhancements:
  * Changed the log level from `debug` to `info` for the main generation event in `generate_html_for_path`, ensuring that important generation events are more visible in logs. (`src/generative_ai.py`)