### PR TITLE
Added llama.cpp and ollama self-hosted alternative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ data/
 *.sqlite
 *.sqlite3
 backups/
+models/
 
 # Temporary files
 *.tmp

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ By wasting attacker resources, Krawl helps clearly distinguish malicious behavio
 
 It features:
 
+- **[AI Generated Deception Pages](docs/ai_generation.md)**: **Let attackers help generate your fake vulnerable attack surface**
 - **Spider Trap Pages**: Infinite random links to waste crawler resources based on the [spidertrap project](https://github.com/adhdproject/spidertrap)
 - **Fake Login Pages**: WordPress, phpMyAdmin, admin panels
 - **Honeypot Paths**: Advertised in robots.txt to catch scanners
@@ -81,7 +82,6 @@ It features:
 - **Real-time Dashboard**: Monitor suspicious activity
 - **Customizable Wordlists**: Easy JSON-based configuration
 - **Random Error Injection**: Mimic real server behavior
-- **[AI Generated Deception Pages](docs/ai_generation.md)**: Fake vulnerable HTML template generated on request
 
 You can easily expose Krawl alongside your other services to shield them from web crawlers and malicious users using a reverse proxy. For more details, see the [Reverse Proxy documentation](docs/reverse-proxy.md).
 

--- a/config.yaml
+++ b/config.yaml
@@ -94,10 +94,14 @@ crawl:
 tarpit:
   enabled: false  # Opt-in: trap AI agents with slow responses and random text
   delay_seconds: 5  # Extra delay (seconds) added to each response when tarpit is active
+
+### AI-Generated Deception pages. Here it can be used either OpenRouter or OpenAI as provider, but also self-hosted LLMs with an API-compatible endpoint 
+### by setting the provider to "openai" and pointing the openai_base_url to the local LLM server URL. Note that the krawl-llm is the service name of the llama.cpp server in the docker-compose.yaml.
 ai:
   enabled: false
   provider: "openrouter"  # "openrouter" or "openai"
-# openai_base_url: "https://api.openai.com/v1" is only needed if provider is set to "openai" and you want to use a custom endpoint to reach different models
+  # openai_base_url: "https://api.openai.com/v1" # this is only needed if provider is set to "openai" and you want to use a custom endpoint to reach different models
+  # openai_base_url: "http://krawl-llm:8080/v1"
   api_key: "" # set your OpenAI or OpenRouter API key here
   model: "" # for example nvidia/nemotron-3-super-120b-a12b:free or gpt-5.1-mini
   timeout: 60  # Request timeout in seconds for API calls

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,31 +1,125 @@
 ---
-# THIS IS FOR DEVELOPMENT PURPOSES
+# Scalable mode: Krawl + PostgreSQL + Redis
+# Usage: docker compose -f docker/docker-compose.scalable.yaml up -d
+#
+# !! IMPORTANT: Change the default PostgreSQL and Redis passwords before deploying to production !!
 services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: krawl-postgres
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_DB: krawl
+      POSTGRES_USER: krawl
+      POSTGRES_PASSWORD: krawl
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U krawl -d krawl"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: krawl-redis
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  ### Default LLM service using llama.cpp. You can switch to Ollama or another LLM server by commenting/uncommenting the relevant sections below.
+  ### Make sure to select the GGUF model file using the repo and file parameters in the command section: https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md
+  llama.cpp:
+    image: ghcr.io/ggml-org/llama.cpp:server
+    container_name: krawl-llm
+    ports:
+      - "8080:8080"
+    # environment:
+    #  - HF_TOKEN=${HF_TOKEN:-}
+    volumes:
+      - ./models:/models
+      - llm_cache:/root/.cache
+    restart: unless-stopped
+    command: >
+      --hf-repo Qwen/Qwen1.5-1.8B-Chat-GGUF
+      --hf-file qwen1_5-1_8b-chat-q4_k_m.gguf
+      --port 8080
+      --host 0.0.0.0
+      -n -1
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  ### ALTERNATIVE: Use Ollama instead of llama.cpp. Specify the model in the command section https://docs.ollama.com/docker#docker
+  ### Remember to specify the "model" parameter also in the config.yaml file.
+  # ollama:
+  #     image: ollama/ollama:latest
+  #     container_name: krawl-llm
+  #     ports:
+  #       - "8080:8080"
+  #     environment:
+  #       - OLLAMA_MODELS=/models
+  #       - OLLAMA_HOST=0.0.0.0:8080
+  #     volumes:
+  #       - ./models:/models
+  #       - llm_cache:/root/.ollama
+  #     restart: unless-stopped
+  #     entrypoint: >
+  #       sh -c "
+  #         /bin/ollama serve &
+  #         until /bin/ollama list > /dev/null 2>&1; do
+  #           sleep 2;
+  #         done;
+  #         /bin/ollama pull qwen:1.8b;
+  #         wait
+  #       "
+  #     healthcheck:
+  #       test: ["CMD", "/bin/ollama", "list"]
+  #       interval: 10s
+  #       timeout: 5s
+  #       retries: 5
+
   krawl:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/blessedrebus/krawl:2.0.1-dev
     container_name: krawl-server
     ports:
       - "5000:5000"
     environment:
       - CONFIG_LOCATION=config.yaml
+      - KRAWL_MODE=scalable
+      - KRAWL_POSTGRES_HOST=postgres
+      - KRAWL_POSTGRES_PORT=5432
+      - KRAWL_POSTGRES_USER=krawl
+      - KRAWL_POSTGRES_PASSWORD=krawl
+      - KRAWL_POSTGRES_DATABASE=krawl
+      - KRAWL_REDIS_HOST=redis
+      - KRAWL_REDIS_PORT=6379
       # Uncomment to set a custom dashboard password (auto-generated if not set)
       # - KRAWL_DASHBOARD_PASSWORD=your-secret-password
-      # set this to change timezone, alternatively mount /etc/timezone or /etc/localtime based on the time system management of the host environment
-      # - TZ=${TZ}
+      # Set this to change timezone
+      # - TZ=Europe/Rome
     volumes:
       - ./wordlists.json:/app/wordlists.json:ro
       - ./config.yaml:/app/config.yaml:ro
       - ./logs:/app/logs
-      - ./data:/app/data
       - ./backups:/app/backups
     restart: unless-stopped
-    develop:
-      watch:
-        - path: ./Dockerfile
-          action: rebuild
-        - path: ./src/
-          action: rebuild
-        - path: ./docker-compose.yaml
-          action: rebuild
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  redis_data:
+  llm_cache:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,28 +36,28 @@ services:
 
   ### Default LLM service using llama.cpp. You can switch to Ollama or another LLM server by commenting/uncommenting the relevant sections below.
   ### Make sure to select the GGUF model file using the repo and file parameters in the command section: https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md
-  llama.cpp:
-    image: ghcr.io/ggml-org/llama.cpp:server
-    container_name: krawl-llm
-    ports:
-      - "8080:8080"
-    # environment:
-    #  - HF_TOKEN=${HF_TOKEN:-}
-    volumes:
-      - ./models:/models
-      - llm_cache:/root/.cache
-    restart: unless-stopped
-    command: >
-      --hf-repo Qwen/Qwen1.5-1.8B-Chat-GGUF
-      --hf-file qwen1_5-1_8b-chat-q4_k_m.gguf
-      --port 8080
-      --host 0.0.0.0
-      -n -1
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+  # llama.cpp:
+  #   image: ghcr.io/ggml-org/llama.cpp:server
+  #   container_name: krawl-llm
+  #   ports:
+  #     - "8080:8080"
+  #   # environment:
+  #   #  - HF_TOKEN=${HF_TOKEN:-}
+  #   volumes:
+  #     - ./models:/models
+  #     - llm_cache:/root/.cache
+  #   restart: unless-stopped
+  #   command: >
+  #     --hf-repo Qwen/Qwen1.5-1.8B-Chat-GGUF
+  #     --hf-file qwen1_5-1_8b-chat-q4_k_m.gguf
+  #     --port 8080
+  #     --host 0.0.0.0
+  #     -n -1
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 5
 
   ### ALTERNATIVE: Use Ollama instead of llama.cpp. Specify the model in the command section https://docs.ollama.com/docker#docker
   ### Remember to specify the "model" parameter also in the config.yaml file.

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -1,0 +1,31 @@
+---
+# THIS IS FOR DEVELOPMENT PURPOSES
+services:
+  krawl:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: krawl-server
+    ports:
+      - "5000:5000"
+    environment:
+      - CONFIG_LOCATION=config.yaml
+      # Uncomment to set a custom dashboard password (auto-generated if not set)
+      # - KRAWL_DASHBOARD_PASSWORD=your-secret-password
+      # set this to change timezone, alternatively mount /etc/timezone or /etc/localtime based on the time system management of the host environment
+      # - TZ=${TZ}
+    volumes:
+      - ./wordlists.json:/app/wordlists.json:ro
+      - ./config.yaml:/app/config.yaml:ro
+      - ./logs:/app/logs
+      - ./data:/app/data
+      - ./backups:/app/backups
+    restart: unless-stopped
+    develop:
+      watch:
+        - path: ./Dockerfile
+          action: rebuild
+        - path: ./src/
+          action: rebuild
+        - path: ./docker-compose.yaml
+          action: rebuild

--- a/docker/docker-compose.scalable.yaml
+++ b/docker/docker-compose.scalable.yaml
@@ -34,8 +34,54 @@ services:
       timeout: 5s
       retries: 5
 
+  ### Default LLM service using llama.cpp. You can switch to Ollama or another LLM server by commenting/uncommenting the relevant sections below.
+  ### Make sure to select the GGUF model file using the repo and file parameters in the command section: https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md
+  # llm:
+  #   image: ghcr.io/ggml-org/llama.cpp:server
+  #   container_name: krawl-llm
+  #   ports:
+  #     - "8080:8080"
+  #   environment:
+  #     - HF_TOKEN=${HF_TOKEN:-}
+  #   volumes:
+  #     - ./models:/models
+  #     - llm_cache:/root/.cache
+  #   restart: unless-stopped
+  #   command: >
+  #     --hf-repo Qwen/Qwen1.5-1.8B-Chat-GGUF # set your desired model here in the GGUF format
+  #     --hf-file qwen1_5-1_8b-chat-q4_k_m.gguf
+  #     --port 8080
+  #     --host 0.0.0.0
+  #     -n -1
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 5
+
+  ### ALTERNATIVE: Use Ollama instead of llama.cpp. Specify the model in the command section https://docs.ollama.com/docker#docker
+  ### Remember to specify the "model" parameter also in the config.yaml file.
+  # ollama:
+  #   image: ollama/ollama:latest
+  #   container_name: krawl-llm
+  #   ports:
+  #     - "8080:8080"
+  #   environment:
+  #     - OLLAMA_MODELS=/models
+  #     - OLLAMA_HOST=0.0.0.0:8080
+  #   volumes:
+  #     - ./models:/models
+  #     - llm_cache:/root/.ollama
+  #   restart: unless-stopped
+  #   command: serve; ollama pull qwen1.5:1.8b; # set your desired model here
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-f", "http://localhost:8080/api/tags"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 5
+
   krawl:
-    image: ghcr.io/blessedrebus/krawl:latest
+    image: ghcr.io/blessedrebus/krawl:2.0.1-dev
     container_name: krawl-server
     ports:
       - "5000:5000"
@@ -68,3 +114,4 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  llm_cache:

--- a/docs/ai_generation.md
+++ b/docs/ai_generation.md
@@ -1,26 +1,18 @@
 # AI-Generated Deception Pages
+Krawl AI Deception generation is used to trick attackers into generating useful deception pages. In this way **attackers help generate your fake vulnerable attack surface**.
 
-Krawl can automatically generate realistic deception pages using AI models from OpenRouter or OpenAI APIs. This feature creates unique, plausible honeypot pages on-the-fly to attract and deceive attackers.
-
-## Features
-
-- **Dynamic Page Generation**: Creates unique HTML pages for any request path
-- **AI Provider Support**: OpenRouter and OpenAI
-- **Smart Caching**: Caches generated pages to avoid redundant API calls
-- **Daily Rate Limiting**: Control API costs with configurable daily request limits
-- **Fallback Behavior**: Gracefully falls back to standard honeypot when disabled or limit reached
-- **Cached Page Serving**: Serve previously cached pages even when AI generation is disabled
+Krawl can automatically generate realistic deception pages using AI models from OpenRouter, OpenAI APIs or self-hosted LLMs. This feature creates unique, plausible honeypot pages on-the-fly to attract and deceive attackers.
 
 ## Configuration
 
-### Enable AI Generation
+### Enable AI Generation with external services (OpenRouter / OpenAI)
 
 Set in `config.yaml`:
 ```yaml
 ai:
   enabled: true
   provider: "openrouter"  # or "openai"
-  openai_base_url: "your-custom-base-url" #optional for custom API endpoints
+  # openai_base_url: "your-custom-base-url" #optional for custom API endpoints
   api_key: "your-api-key-here"
   model: "nvidia/nemotron-3-super-120b-a12b:free"
   timeout: 60
@@ -41,6 +33,16 @@ export KRAWL_AI_TIMEOUT=60
 export KRAWL_AI_MAX_DAILY_REQUESTS=10
 ```
 
+### Enable AI Generation with self-hosted LLMs
+
+Krawl can be configured to use a self-hosted LLM to generate deception pages using [llama.cpp](https://github.com/ggml-org/llama.cpp) or [ollama](https://ollama.com/).
+
+The [docker-compose setup](../docker-compose.yaml) includes both **llama.cpp** and **Ollama** as optional services.
+
+The LLM endpoint can be configured via `openai_base_url` environment variable pointing to the local service because it is OpenAI compatible. For docker deployments it can be used `http://krawl-llm:8080/v1` as endpoint because it is the service name of the llm.
+
+For detailed configuration options, see [Self-Hosted LLM](#self-hosted-llm-recommended-for-privacy) section below.
+
 ## Supported Providers
 
 ### OpenRouter
@@ -56,6 +58,78 @@ To use AI Generation without charges, use **Free Models** like `nvidia/nemotron-
 Commercial API with various models. A small model like `gpt-5.1-mini` is more than enough for this use case.
 
 **Register**: https://openai.com/api
+
+### Self-Hosted LLM
+For maximum privacy and cost efficiency, Krawl can run with self-hosted LLMs using **llama.cpp** or **Ollama**, either through Docker Compose deployments or on external CPU / GPU-backed instances.
+
+**llama.cpp** is a lightweight C++ inference engine that runs GGUF models directly with minimal overhead, offering maximum raw performance and low memory usage. It provides a simple HTTP server and is ideal when you need full control over a single model.
+
+**Ollama** builds on top of llama.cpp and adds a convenient model management layer, making deployment and model switching easier. The tradeoff is a small performance overhead compared to running llama.cpp directly.
+
+See both [llama.cpp](https://github.com/ggml-org/llama.cpp) and [Ollama](https://docs.ollama.com/) documentation to choose the best engine for your setup.
+
+In our tests, we used models like [Qwen 1.5-1.8B](https://huggingface.co/Qwen/Qwen1.5-1.8B) and [Qwen3.5-4B](https://huggingface.co/Qwen/Qwen3.5-4B) to perform basic **JSON, TXT, and fake vulnerable static HTML page** generation. In order to modify the result on your scenario, modify the  [prompt section](../config.yaml)  in the config.yaml file
+
+In general, the larger the model parameter count, the more polished, realistic, and complex the generated HTML pages tend to be.
+
+> [!NOTE]
+> If you do want to use external LLMs (not hosted on docker) just change the `openai_base_url` pointing to your LLMs APIs endpoint
+
+#### Option 1: llama.cpp with Docker Compose
+
+- Deploy the [docker-compose.yaml](../docker-compose.yaml) uncommenting the preferred LLM
+- Specify the model from HuggingFace on first run with **repo/model** standard and specify the GGUF file name. [See GGUF documentation for more information](https://huggingface.co/docs/hub/gguf-llamacpp).
+```yaml
+command: >
+  --hf-repo Qwen/Qwen1.5-1.8B-Chat-GGUF
+  --hf-file qwen1_5-1_8b-chat-q4_k_m.gguf
+  --port 8080
+  --host 0.0.0.0
+  -n -1
+```
+- Exposes LLM API on your chosen port. Default is `8080`.
+
+**Configuration**:
+```yaml
+ai:
+  enabled: true
+  provider: "openai"  # OpenAI compatible engine 
+  api_key: "krawl"    # Keep this for compatibility
+  timeout: 60
+  max_daily_requests: 1000  # No API cost, can be higher
+```
+
+You can specify the **HuggingFace Token** with the env variable
+```bash
+HF_TOKEN=your_hf_token
+```
+
+#### Option 2: Ollama with Docker Compose
+
+- Set up the alternative service in [docker-compose.yaml](../docker-compose.yaml) uncommenting ollama
+- Modify the entrypoint with your desired model [from the ollama library](https://ollama.com/library)
+```yaml
+entrypoint: >
+  sh -c "
+    /bin/ollama serve &
+    until /bin/ollama list > /dev/null 2>&1; do
+      sleep 2;
+    done;
+    /bin/ollama pull qwen:1.8b;
+    wait
+```
+- Exposes LLM API on your chosen port. Default is `8080`.
+
+**Configuration**:
+```yaml
+ai:
+  enabled: true
+  provider: "openai"  # OpenAI compatible engine 
+  api_key: "krawl"    # Keep this for compatibility
+  model: "qwen:1.8b-chat"  # Model name on Ollama. This is required to build the request
+  timeout: 60
+  max_daily_requests: 1000  # No API cost, can be higher
+```
 
 ## How It Works
 
@@ -91,8 +165,7 @@ ai:
 
 When limit is reached:
 - New requests fall back to standard honeypot behavior
-- Previously cached pages continue to be served
-- Warning logged: "Daily AI generation limit reached"
+- **Previously cached pages continue to be served**
 
 ### Cost Estimation
 
@@ -108,6 +181,8 @@ When limit is reached:
 - 1,000 pages/month: ~$1.00
 
 **Using OpenRouter Free Model**: $0 (rate limited, no charge)
+
+**Using self-hosted LLMs**: $0 (unlimited, no charge)
 
 ## Customization
 
@@ -143,25 +218,3 @@ Access generated pages tab in the Krawl dashboard:
 3. View all generated pages
 4. See generation timestamps and access counts
 5. Manage and delete cached pages
-
-### Set the Daily Quota
-
-Option 1: Increase limit
-```yaml
-ai:
-  max_daily_requests: 20
-```
-
-If you want to disable AI, it is possible to keep serving cached pages
-```yaml
-ai:
-  enabled: false  # Cached pages still served
-```
-
-### Cached Page Serving Issues
-
-Cached pages are managed in the dashboard **Deception** tab:
-- View all cached pages
-- See access statistics
-- Delete individual pages or by date range
-- Bulk operations available

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.0.2
-appVersion: 2.0.2
+version: 2.0.3
+appVersion: 2.0.3
 keywords:
   - honeypot
   - security

--- a/src/app.py
+++ b/src/app.py
@@ -339,7 +339,8 @@ def _setup_openapi(application: FastAPI, dashboard_prefix: str) -> None:
 
     @application.get(f"{dashboard_prefix}/docs", include_in_schema=False)
     async def swagger_ui():
-        return HTMLResponse(f"""<!DOCTYPE html>
+        return HTMLResponse(
+            f"""<!DOCTYPE html>
 <html><head>
 <title>Krawl API Docs</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css">
@@ -347,7 +348,8 @@ def _setup_openapi(application: FastAPI, dashboard_prefix: str) -> None:
 <div id="swagger-ui"></div>
 <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
 <script>SwaggerUIBundle({{url: "{openapi_url}", dom_id: "#swagger-ui"}})</script>
-</body></html>""")
+</body></html>"""
+        )
 
 
 app = create_app()

--- a/src/migrations/add_performance_indexes.py
+++ b/src/migrations/add_performance_indexes.py
@@ -44,10 +44,12 @@ def add_performance_indexes(db_path: str) -> bool:
         # Index 1: attack_type for efficient GROUP BY operations
         if not index_exists(cursor, "ix_attack_detections_attack_type"):
             print("Adding index on attack_detections.attack_type...")
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE INDEX ix_attack_detections_attack_type 
                 ON attack_detections(attack_type)
-            """)
+            """
+            )
             indexes_added.append("ix_attack_detections_attack_type")
         else:
             indexes_existed.append("ix_attack_detections_attack_type")
@@ -57,10 +59,12 @@ def add_performance_indexes(db_path: str) -> bool:
             print(
                 "Adding composite index on attack_detections(attack_type, access_log_id)..."
             )
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE INDEX ix_attack_detections_type_log 
                 ON attack_detections(attack_type, access_log_id)
-            """)
+            """
+            )
             indexes_added.append("ix_attack_detections_type_log")
         else:
             indexes_existed.append("ix_attack_detections_type_log")

--- a/src/migrations/add_raw_request_column.py
+++ b/src/migrations/add_raw_request_column.py
@@ -46,10 +46,12 @@ def add_raw_request_column(db_path: str) -> bool:
 
         # Add the column
         print("Adding 'raw_request' column to access_logs table...")
-        cursor.execute("""
+        cursor.execute(
+            """
             ALTER TABLE access_logs 
             ADD COLUMN raw_request TEXT
-        """)
+        """
+        )
 
         conn.commit()
         conn.close()


### PR DESCRIPTION
Added llama.cpp and Ollama as self-hosted alternatives to cloud AI providers for honeypot page generation as suggested in #176 
Updated documentation