### PR TITLE
Feat: adding ServiceMonitor and fixing metrics

### DIFF
--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -58,3 +58,20 @@ Ingress is ENABLED. Your service will be available at:
   - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
 {{- end }}
 {{- end }}
+
+{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.config.metrics.enabled .Values.config.dashboard.secret_path }}
+
+Prometheus ServiceMonitor is ENABLED. Prometheus will scrape:
+  /{{ .Values.config.dashboard.secret_path | trimPrefix "/" }}/metrics (port {{ .Values.service.port }})
+{{- else if not .Values.config.metrics.enabled }}
+
+WARNING: serviceMonitor.enabled is true but config.metrics.enabled is false —
+the ServiceMonitor was NOT created. Set config.metrics.enabled=true to scrape metrics.
+{{- else }}
+
+WARNING: serviceMonitor.enabled is true but config.dashboard.secret_path is not set —
+the ServiceMonitor was NOT created. The metrics path is /<secret_path>/metrics, so set
+config.dashboard.secret_path to a fixed value to enable scraping.
+{{- end }}
+{{- end }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -28,6 +28,8 @@ data:
       warmup_pages: {{ .Values.config.dashboard.warmup_pages }}
       warmup_aggregation: {{ .Values.config.dashboard.warmup_aggregation }}
       top_n_min_count: {{ .Values.config.dashboard.top_n_min_count }}
+    metrics:
+      enabled: {{ .Values.config.metrics.enabled }}
     backups:
       path: {{ .Values.config.backups.path | quote }}
       cron: {{ .Values.config.backups.cron | quote }}

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- /*
+Prometheus Operator ServiceMonitor for Krawl's /metrics endpoint.
+
+Rendered only when metrics are exposed AND a fixed dashboard secret path is set.
+The metrics endpoint lives at /<dashboard.secret_path>/metrics, so when the
+secret path is null/blank (auto-generated at runtime) Prometheus cannot know the
+URL and we omit the resource entirely.
+*/ -}}
+{{- if and .Values.serviceMonitor.enabled .Values.config.metrics.enabled .Values.config.dashboard.secret_path }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "krawl.fullname" . }}
+  labels:
+    {{- include "krawl.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "krawl.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: /{{ .Values.config.dashboard.secret_path | trimPrefix "/" }}/metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -30,6 +30,24 @@ service:
   # Preserve source IP when using LoadBalancer
   externalTrafficPolicy: Local
 
+# Prometheus Operator ServiceMonitor for scraping the /metrics endpoint.
+# Requires the ServiceMonitor CRD (monitoring.coreos.com/v1) in the cluster.
+# The resource is only rendered when ALL of the following are true:
+#   - serviceMonitor.enabled is true
+#   - config.metrics.enabled is true
+#   - config.dashboard.secret_path is set (the metrics path is
+#     /<secret_path>/metrics, so an auto-generated/blank path can't be scraped)
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  # Extra labels so your Prometheus's serviceMonitorSelector matches this
+  # resource (e.g. release: kube-prometheus-stack).
+  labels: {}
+  honorLabels: false
+  relabelings: []
+  metricRelabelings: []
+
 ingress:
   enabled: true
   className: "traefik"
@@ -90,6 +108,8 @@ config:
     warmup_pages: 10  # Number of pages to pre-warm per table panel (attacks, attackers, credentials, honeypot)
     warmup_aggregation: true  # Pre-compute full top_paths/top_ua aggregations for instant any-page serving (recommended for scalable)
     top_n_min_count: 5  # Minimum access count to include a path/user-agent in top-N panels (set to 1 to disable)
+  metrics:
+    enabled: true  # Expose Prometheus metrics at /<dashboard.secret_path>/metrics
   backups:
     path: "backups"
     enabled: false

--- a/src/database.py
+++ b/src/database.py
@@ -892,16 +892,10 @@ class DatabaseManager:
             timestamp=timestamp,
         )
         session.add(history_entry)
-
-        try:
-            import metrics_counters as mc
-
-            if new_category:
-                mc.increment("clients_total", new_category)
-            if old_category:
-                mc.increment("clients_total", old_category, amount=-1)
-        except Exception as e:
-            applogger.error(f"Metric counter update failed: {e}")
+        # Note: clients_total is NOT maintained as a +new/-old delta counter.
+        # It is current-state and recomputed live from count_category at scrape
+        # time (see metrics.refresh_from_counters), which is cheap (indexed) and
+        # avoids the unbounded drift a delta accrues under retention deletes.
 
     def get_category_history(self, ip: str) -> List[Dict[str, Any]]:
         """
@@ -1712,7 +1706,9 @@ class DatabaseManager:
             "suspicious_accesses": mc.get("suspicious_accesses"),
             "honeypot_triggered": mc.get("honeypot_triggered"),
             "honeypot_ips": mc.get("honeypot_ips"),
-            "unique_attackers": mc.get("clients_total", "attacker"),
+            # clients_total is current-state (recomputed live), not a cumulative
+            # counter — read it straight from the indexed category count.
+            "unique_attackers": self.count_category("attacker"),
         }
 
     def _compute_dashboard_counts_sql(self) -> Dict[str, int]:
@@ -1833,6 +1829,46 @@ class DatabaseManager:
             return {(r.metric, r.label or ""): int(r.value) for r in rows}
         except Exception as e:
             applogger.error(f"Error reading metrics summary: {e}")
+            return {}
+        finally:
+            self.close_session()
+
+    def get_heavy_summary(self) -> Dict[str, int]:
+        """Load the persisted heavy-aggregate snapshot as {metric: value}.
+
+        Only the cumulative current-snapshot rows (empty label); excludes the
+        '_deleted' tally rows.
+        """
+        session = self.session
+        try:
+            rows = (
+                session.query(MetricsSummary)
+                .filter(MetricsSummary.label == "")
+                .all()
+            )
+            return {r.metric: int(r.value) for r in rows}
+        except Exception as e:
+            applogger.error(f"Error reading heavy summary: {e}")
+            return {}
+        finally:
+            self.close_session()
+
+    def get_deleted_tallies(self) -> Dict[str, int]:
+        """Load the cumulative 'deleted' tallies as {metric: value}.
+
+        These accumulate what retention removes so reconciliation can keep
+        cumulative metrics absolute: reconciled = count(current rows) + tally.
+        """
+        session = self.session
+        try:
+            rows = (
+                session.query(MetricsSummary)
+                .filter(MetricsSummary.label == "_deleted")
+                .all()
+            )
+            return {r.metric: int(r.value) for r in rows}
+        except Exception as e:
+            applogger.error(f"Error reading deleted tallies: {e}")
             return {}
         finally:
             self.close_session()

--- a/src/database.py
+++ b/src/database.py
@@ -894,7 +894,7 @@ class DatabaseManager:
         session.add(history_entry)
         # Note: clients_total is NOT maintained as a +new/-old delta counter.
         # It is current-state and recomputed live from count_category at scrape
-        # time (see metrics.refresh_from_counters), which is cheap (indexed) and
+        # time (see metrics.KrawlMetricsCollector), which is cheap (indexed) and
         # avoids the unbounded drift a delta accrues under retention deletes.
 
     def get_category_history(self, ip: str) -> List[Dict[str, Any]]:

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -138,14 +138,21 @@ def refresh_from_counters() -> None:
     honeypot_ips.set(c.get("honeypot_ips"))
     credentials_captured.set(c.get("credentials_captured"))
 
-    for category in CATEGORIES:
-        clients_total.labels(category).set(c.get("clients_total", category))
-
     attack_detections.clear()
     for key, value in c.get_all().items():
         if key.startswith("attack_detections|"):
             attack_type = key.split("|", 1)[1]
             attack_detections.labels(attack_type).set(value)
+
+    # clients_total is current-state ("how many IPs are classified X right now"),
+    # not a cumulative counter, so recompute it live from the indexed category
+    # counts. This is cheap (4 COUNTs) and avoids the unbounded delta drift that
+    # produced negative values.
+    from database import get_database
+
+    db = get_database()
+    for category in CATEGORIES:
+        clients_total.labels(category).set(db.count_category(category))
 
 
 def refresh_ai(db) -> None:

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,15 +1,28 @@
 """
-Central Prometheus metric definitions and refresh helpers for Krawl.
+Central Prometheus metric definitions for Krawl.
 
 Metrics are exposed at /{dashboard_secret}/metrics by the ASGI app mounted
-in src/app.py. Refresh helpers are called from existing background tasks
-(analyze_ips, dashboard_warmup) so we don't add any new cron entries.
+in src/app.py.
+
+Two families of metrics:
+
+- Cumulative totals (accesses, unique IPs/paths, honeypot, credentials, attack
+  detections) are "total ever observed" values maintained in the cache counter
+  store (see metrics_counters). They are exposed as proper Prometheus *counters*
+  via KrawlMetricsCollector, which reads the values in batch at scrape time so
+  every pod reports the shared totals and rate()/increase() work as expected.
+
+- Current-state gauges (clients_total, reevaluation/enrichment/lock counts,
+  warmup durations) are point-in-time values. clients_total is recomputed live
+  in the collector; the rest are set by background tasks (analyze_ips,
+  dashboard_warmup).
 """
 
 import re
 import time
 
 from prometheus_client import Gauge, REGISTRY
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
 from config import get_config
 from logger import get_app_logger
@@ -19,63 +32,92 @@ app_logger = get_app_logger()
 CATEGORIES = ("attacker", "good_crawler", "bad_crawler", "regular_user")
 
 
+def _enabled() -> bool:
+    return bool(get_config().metrics_enabled)
+
+
 # ----------------------
-# Metric definitions
+# Cumulative counters (cache-backed, exposed via custom collector)
 # ----------------------
 
-# requests
-accesses = Gauge(
-    "accesses",
-    "Total HTTP accesses recorded by Krawl",
-    namespace="krawl",
-    registry=REGISTRY,
-)
-unique_ips = Gauge(
-    "unique_ips",
-    "Number of distinct client IPs observed",
-    namespace="krawl",
-    registry=REGISTRY,
-)
-unique_paths = Gauge(
-    "unique_paths",
-    "Number of distinct request paths observed",
-    namespace="krawl",
-    registry=REGISTRY,
+# (cache counter key, exposed metric name, help text). The exposed series get a
+# "_total" suffix per Prometheus counter convention (e.g. krawl_accesses_total).
+_CUMULATIVE = (
+    ("total_accesses", "krawl_accesses", "Total HTTP accesses recorded by Krawl"),
+    ("unique_ips", "krawl_unique_ips", "Number of distinct client IPs observed"),
+    ("unique_paths", "krawl_unique_paths", "Number of distinct request paths observed"),
+    ("honeypot_triggered", "krawl_honeypot_triggers", "Total honeypot trigger events"),
+    (
+        "honeypot_ips",
+        "krawl_honeypot_ips",
+        "Distinct IPs that have triggered a honeypot path at least once",
+    ),
+    (
+        "credentials_captured",
+        "krawl_credentials_captured",
+        "Total captured credential login attempts",
+    ),
 )
 
-# detection
-clients_total = Gauge(
-    "clients_total",
-    "Number of IPs per classification category",
-    labelnames=["category"],
-    namespace="krawl",
-    registry=REGISTRY,
-)
-honeypot_triggers = Gauge(
-    "honeypot_triggers",
-    "Total honeypot trigger events",
-    namespace="krawl",
-    registry=REGISTRY,
-)
-honeypot_ips = Gauge(
-    "honeypot_ips",
-    "Distinct IPs that have triggered a honeypot path at least once",
-    namespace="krawl",
-    registry=REGISTRY,
-)
-credentials_captured = Gauge(
-    "credentials_captured",
-    "Total captured credential login attempts",
-    namespace="krawl",
-    registry=REGISTRY,
-)
-attack_detections = Gauge(
-    "attack_detections",
-    "Attack detections grouped by attack type",
-    labelnames=["attack_type"],
-    namespace="krawl",
-    registry=REGISTRY,
-)
+
+class KrawlMetricsCollector:
+    """Collector for cache-backed counters + current-state clients_total.
+
+    Invoked by prometheus_client during scrape (generate_latest). Reads the
+    cumulative counters from the cache in a single batched call, exposes them as
+    counters, and recomputes clients_total live from the indexed category counts.
+    """
+
+    def collect(self):
+        if not _enabled():
+            return
+
+        import metrics_counters as c
+
+        values = c.get_many([key for key, _, _ in _CUMULATIVE])
+        for key, name, doc in _CUMULATIVE:
+            yield CounterMetricFamily(name, doc, value=values.get(key, 0))
+
+        attacks = CounterMetricFamily(
+            "krawl_attack_detections",
+            "Attack detections grouped by attack type",
+            labels=["attack_type"],
+        )
+        for ckey, value in c.get_all().items():
+            if ckey.startswith("attack_detections|"):
+                attacks.add_metric([ckey.split("|", 1)[1]], value)
+        yield attacks
+
+        # clients_total is current-state ("how many IPs are classified X right
+        # now"), not cumulative — recompute live (4 indexed COUNTs). This avoids
+        # the unbounded delta drift that previously produced negative values.
+        clients = GaugeMetricFamily(
+            "krawl_clients_total",
+            "Number of IPs per classification category",
+            labels=["category"],
+        )
+        try:
+            from database import get_database
+
+            db = get_database()
+            for category in CATEGORIES:
+                clients.add_metric([category], db.count_category(category))
+        except Exception as e:
+            app_logger.error(f"collect clients_total failed: {e}")
+        yield clients
+
+
+# Register the collector once (guard against re-import in test/reload paths).
+_collector = KrawlMetricsCollector()
+try:
+    REGISTRY.register(_collector)
+except ValueError:
+    pass
+
+
+# ----------------------
+# Current-state gauges (set by background tasks)
+# ----------------------
 
 # ai
 generated_pages_today = Gauge(
@@ -113,47 +155,9 @@ dashboard_warmup_duration_seconds = Gauge(
 )
 
 
-def _enabled() -> bool:
-    return bool(get_config().metrics_enabled)
-
-
 # ----------------------
-# Refresh helpers
+# Refresh helpers (current-state gauges, called by background tasks)
 # ----------------------
-
-def refresh_from_counters() -> None:
-    """Populate counter-backed gauges from the live cache counters.
-
-    Called at scrape time so every pod reports the shared values (each pod has
-    its own in-process Prometheus registry).
-    """
-    if not _enabled():
-        return
-    import metrics_counters as c
-
-    accesses.set(c.get("total_accesses"))
-    unique_ips.set(c.get("unique_ips"))
-    unique_paths.set(c.get("unique_paths"))
-    honeypot_triggers.set(c.get("honeypot_triggered"))
-    honeypot_ips.set(c.get("honeypot_ips"))
-    credentials_captured.set(c.get("credentials_captured"))
-
-    attack_detections.clear()
-    for key, value in c.get_all().items():
-        if key.startswith("attack_detections|"):
-            attack_type = key.split("|", 1)[1]
-            attack_detections.labels(attack_type).set(value)
-
-    # clients_total is current-state ("how many IPs are classified X right now"),
-    # not a cumulative counter, so recompute it live from the indexed category
-    # counts. This is cheap (4 COUNTs) and avoids the unbounded delta drift that
-    # produced negative values.
-    from database import get_database
-
-    db = get_database()
-    for category in CATEGORIES:
-        clients_total.labels(category).set(db.count_category(category))
-
 
 def refresh_ai(db) -> None:
     if not _enabled():

--- a/src/metrics_counters.py
+++ b/src/metrics_counters.py
@@ -152,7 +152,7 @@ def needs_seed() -> bool:
     return True
 
 
-# Heavy aggregates persisted in metrics_summary (and recomputed once on first run).
+# Heavy aggregates persisted in metrics_summary (and recomputed from SQL).
 HEAVY_METRICS = (
     "total_accesses",
     "unique_ips",
@@ -162,50 +162,110 @@ HEAVY_METRICS = (
     "honeypot_ips",
 )
 
-_CATEGORIES = ("attacker", "good_crawler", "bad_crawler", "regular_user")
+# Cumulative metrics whose true total-ever = count(current rows) + deleted tally.
+# Other heavy metrics are preserved by retention (suspicious/honeypot rows are
+# never purged), so their current count already equals the cumulative total.
+_TALLIED_METRICS = ("total_accesses", "unique_ips")
+
+_RECONCILE_LOCK = "krawl:counter:_reconcile_lock"
+
+
+def _acquire_reconcile_lock(ttl: int = 600) -> bool:
+    """Return True if this process should run the (expensive) full recompute.
+
+    Scalable: a short-lived Redis lock so only one pod recomputes per window.
+    Standalone: always True (single process).
+    """
+    if get_backend() == "scalable":
+        r = get_redis_client()
+        if r is not None:
+            return bool(r.set(_RECONCILE_LOCK, "1", nx=True, ex=ttl))
+        return True
+    return True
+
+
+def _recompute_heavy(db) -> None:
+    """Recompute heavy counters as cumulative absolutes from the DB + tallies.
+
+    For tallied metrics, cumulative = count(current rows) + deleted tally, so
+    they stay "total ever observed" even after retention purges benign rows.
+    The seen-paths set is left untouched (append-only distinct-ever); we only
+    keep the unique_paths counter aligned to its cardinality.
+    """
+    counts = db._compute_dashboard_counts_sql()
+    tallies = db.get_deleted_tallies()
+    for metric in HEAVY_METRICS:
+        if metric == "unique_paths":
+            continue  # backed by the append-only seen-paths set
+        base = int(counts.get(metric, 0) or 0)
+        if metric in _TALLIED_METRICS:
+            base += int(tallies.get(metric, 0) or 0)
+        set_value(metric, "", base)
+    set_value("unique_paths", "", scard("paths"))
+    db.upsert_metrics_summary({(m, ""): get(m) for m in HEAVY_METRICS})
+
+
+def _recompute_cheap(db) -> None:
+    """Recompute cumulative metrics that are cheap and preserved by retention."""
+    set_value("credentials_captured", "", db.count_credentials())
+    # attack_detections rows are preserved by retention (they hang off suspicious
+    # logs), so the current per-type count equals the cumulative total.
+    for entry in db.get_attack_types_stats(limit=100).get("attack_types", []):
+        set_value("attack_detections", entry["type"], int(entry["count"]))
 
 
 def bootstrap(db) -> None:
     """
     Seed live counters at startup. Idempotent and safe across pods.
 
-    In scalable mode only the first pod (per needs_seed) runs this; in standalone
-    it runs every boot. Heavy aggregates load from metrics_summary, or are
-    recomputed once from SQL if the table is empty. Cheap labeled counters
-    (categories, attack types) are recomputed from their indexed queries. The
-    seen-paths set is rebuilt from distinct paths.
+    In scalable mode only the first pod (per needs_seed) seeds; in standalone it
+    runs every boot. Heavy aggregates load from the persisted snapshot (fast,
+    avoids a full scan on every pod start) or are recomputed from SQL on first
+    run. clients_total is NOT seeded here — it is recomputed live at scrape time.
     """
     if not needs_seed():
         return
 
     try:
-        summary = db.get_metrics_summary()
-        if summary:
-            for (metric, label), value in summary.items():
-                set_value(metric, label, value)
-        else:
-            counts = db._compute_dashboard_counts_sql()
-            persisted = {}
-            for metric in HEAVY_METRICS:
-                value = int(counts.get(metric, 0) or 0)
+        # Seen-paths distinctness set: rebuild only if absent (e.g. Redis wiped).
+        # It is append-only across restarts, so we never shrink it here.
+        if scard("paths") == 0:
+            seed_set("paths", db.get_distinct_paths())
+
+        heavy = db.get_heavy_summary()
+        if heavy:
+            for metric, value in heavy.items():
                 set_value(metric, "", value)
-                persisted[(metric, "")] = value
-            db.upsert_metrics_summary(persisted)
+            # Keep unique_paths at least the cumulative we last persisted, even
+            # if the set was rebuilt from a smaller current-distinct after a wipe.
+            set_value(
+                "unique_paths", "", max(scard("paths"), int(heavy.get("unique_paths", 0)))
+            )
+        else:
+            _recompute_heavy(db)
 
-        # Cheap counters (indexed queries) — recomputed every seed.
-        set_value("credentials_captured", "", db.count_credentials())
-
-        for category in _CATEGORIES:
-            set_value("clients_total", category, db.count_category(category))
-
-        for entry in db.get_attack_types_stats(limit=100).get("attack_types", []):
-            set_value("attack_detections", entry["type"], int(entry["count"]))
-
-        # Seen-paths distinctness set + keep unique_paths consistent with it.
-        seed_set("paths", db.get_distinct_paths())
-        set_value("unique_paths", "", scard("paths"))
+        _recompute_cheap(db)
     except Exception:
         # Never block startup on metrics seeding.
         import logging
 
         logging.getLogger("krawl").exception("metrics_counters.bootstrap failed")
+
+
+def reconcile(db) -> None:
+    """
+    Recompute cumulative counters from source, correcting any event-driven drift.
+
+    Called at startup (via bootstrap) and right after each db-retention run — the
+    only thing that deletes data. Guarded by a Redis lock so just one pod runs
+    the full scan. Does not touch clients_total (recomputed live at scrape).
+    """
+    if not _acquire_reconcile_lock():
+        return
+    try:
+        _recompute_heavy(db)
+        _recompute_cheap(db)
+    except Exception:
+        import logging
+
+        logging.getLogger("krawl").exception("metrics_counters.reconcile failed")

--- a/src/metrics_counters.py
+++ b/src/metrics_counters.py
@@ -71,24 +71,49 @@ def set_value(metric: str, label: str = "", value: int = 0) -> None:
         _counters[_key(metric, label)] = int(value)
 
 
+def get_many(metrics) -> Dict[str, int]:
+    """Batch-read unlabeled counters as {metric: value}.
+
+    Scalable: a single Redis MGET (one round-trip instead of one GET each).
+    Standalone: locked dict reads.
+    """
+    metrics = list(metrics)
+    if get_backend() == "scalable":
+        r = get_redis_client()
+        if r is not None:
+            if not metrics:
+                return {}
+            raw = r.mget([f"{_COUNTER_PREFIX}{m}" for m in metrics])
+            return {m: (int(v) if v else 0) for m, v in zip(metrics, raw)}
+    with _lock:
+        return {m: _counters.get(m, 0) for m in metrics}
+
+
 def get_all() -> Dict[str, int]:
     """Return all counters as {encoded_key: value}. Excludes distinctness sets."""
     if get_backend() == "scalable":
         r = get_redis_client()
         out: Dict[str, int] = {}
         if r is not None:
+            keys = []
             cursor = 0
             while True:
-                cursor, keys = r.scan(
+                cursor, batch = r.scan(
                     cursor, match=f"{_COUNTER_PREFIX}*", count=200
                 )
-                for full in keys:
-                    if full.startswith(_SET_PREFIX) or full == _SEED_MARKER:
-                        continue
-                    raw = r.get(full)
-                    out[full[len(_COUNTER_PREFIX):]] = int(raw) if raw else 0
+                keys.extend(
+                    k
+                    for k in batch
+                    if not k.startswith(_SET_PREFIX) and k != _SEED_MARKER
+                )
                 if cursor == 0:
                     break
+            if keys:
+                raw = r.mget(keys)
+                out = {
+                    k[len(_COUNTER_PREFIX):]: (int(v) if v else 0)
+                    for k, v in zip(keys, raw)
+                }
         return out
     with _lock:
         return dict(_counters)

--- a/src/routes/dashboard.py
+++ b/src/routes/dashboard.py
@@ -41,10 +41,12 @@ KRAWL_VERSION = _get_krawl_version()
 async def metrics_endpoint(request: Request):
     if not get_config().metrics_enabled:
         raise HTTPException(status_code=404)
-    import metrics
+    # generate_latest() invokes KrawlMetricsCollector.collect(), which does
+    # blocking cache/DB reads — run it off the event loop.
+    import asyncio
 
-    metrics.refresh_from_counters()
-    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+    content = await asyncio.to_thread(generate_latest)
+    return Response(content=content, media_type=CONTENT_TYPE_LATEST)
 
 
 @router.get("")

--- a/src/tasks/db_retention.py
+++ b/src/tasks/db_retention.py
@@ -7,7 +7,7 @@ Periodically deletes old records based on configured retention_days.
 
 from datetime import datetime, timedelta
 
-from sqlalchemy import or_
+from sqlalchemy import or_, delete as sa_delete
 
 from database import get_database
 from dashboard_cache import invalidate_table_cache
@@ -40,6 +40,7 @@ def main():
             AttackDetection,
             IpStats,
             CategoryHistory,
+            MetricsSummary,
         )
 
         config = get_config()
@@ -85,15 +86,29 @@ def main():
             .distinct()
         )
 
-        # Delete stale IPs, but keep those linked to suspicious logs
-        ips_deleted = (
-            session.query(IpStats)
-            .filter(
+        # Delete stale IPs, but keep those linked to suspicious logs.
+        # Use RETURNING so we tally exactly the rows THIS run deleted — under
+        # per-pod scheduling the second pod deletes 0 rows and tallies nothing,
+        # keeping the cumulative counts correct without cross-pod coordination.
+        deleted_rows = session.execute(
+            sa_delete(IpStats)
+            .where(
                 IpStats.last_seen < cutoff,
                 ~IpStats.ip.in_(preserved_ips),
             )
-            .delete(synchronize_session=False)
-        )
+            .returning(IpStats.total_requests)
+        ).fetchall()
+        ips_deleted = len(deleted_rows)
+        deleted_accesses = sum(int(r[0] or 0) for r in deleted_rows)
+
+        # Accumulate what we removed into the cumulative "deleted" tallies, so
+        # reconciliation keeps total_accesses / unique_ips absolute (total-ever,
+        # not just retained rows): reconciled = count(current rows) + tally.
+        if ips_deleted:
+            _bump_deleted_tally(session, MetricsSummary, "unique_ips", ips_deleted)
+            _bump_deleted_tally(
+                session, MetricsSummary, "total_accesses", deleted_accesses
+            )
 
         # Delete old category history, but keep records for preserved IPs
         history_deleted = (
@@ -119,6 +134,15 @@ def main():
                 f"older than {retention_days} days"
             )
 
+        # Recompute cumulative counters from (current rows + deleted tallies) now
+        # that data was purged. Lock-guarded so only one pod runs the scan.
+        try:
+            import metrics_counters
+
+            metrics_counters.reconcile(db)
+        except Exception as e:
+            app_logger.error(f"Error reconciling metrics after retention: {e}")
+
     except Exception as e:
         app_logger.error(f"Error during DB retention cleanup: {e}")
     finally:
@@ -126,3 +150,30 @@ def main():
             db.close_session()
         except Exception as e:
             app_logger.error(f"Error closing DB session after retention cleanup: {e}")
+
+
+def _bump_deleted_tally(session, MetricsSummary, metric: str, amount: int) -> None:
+    """Add `amount` to the cumulative (metric, '_deleted') tally row in-session.
+
+    Runs inside the retention transaction so the tally and the deletes commit
+    atomically.
+    """
+    if amount <= 0:
+        return
+    row = (
+        session.query(MetricsSummary)
+        .filter(MetricsSummary.metric == metric, MetricsSummary.label == "_deleted")
+        .first()
+    )
+    if row:
+        row.value = int(row.value) + int(amount)
+        row.updated_at = datetime.now()
+    else:
+        session.add(
+            MetricsSummary(
+                metric=metric,
+                label="_deleted",
+                value=int(amount),
+                updated_at=datetime.now(),
+            )
+        )


### PR DESCRIPTION
This pull request introduces Prometheus metrics support for the Krawl application, including Helm chart integration for ServiceMonitor, improvements to metrics collection, and codebase simplification for more accurate and efficient metrics reporting. The changes ensure that cumulative and current-state metrics are correctly exposed, and that ServiceMonitor resources are only created when all required conditions are met.

**Prometheus Metrics & ServiceMonitor Integration:**

* Added a `serviceMonitor` section to `helm/values.yaml` and a new `helm/templates/servicemonitor.yaml` template, enabling Prometheus Operator to scrape metrics only when metrics are enabled and a fixed dashboard secret path is set. Clear user guidance and warnings are provided in `helm/templates/NOTES.txt` for misconfigurations. [[1]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R33-R50) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R111-R112) [[3]](diffhunk://#diff-0f938e82d7c9e7da70c41523ccd0de2555354d8b624b142029ad18db7aa8e70eR1-R40) [[4]](diffhunk://#diff-c606b50e0f037cd86433ac7464a37b72ba9c259b239fa78ac3a612ae46612af3R61-R77)

**Metrics Collection Refactor:**

* Replaced per-metric Gauge registration with a custom `KrawlMetricsCollector` that exposes cumulative counters as Prometheus counters and recomputes `clients_total` live at scrape time, ensuring accurate, non-drifting values. [[1]](diffhunk://#diff-595e88de1f402f9e039ff56a467520ba15c29cdd5ca8f328091369c1440bae28L2-R25) [[2]](diffhunk://#diff-595e88de1f402f9e039ff56a467520ba15c29cdd5ca8f328091369c1440bae28R35-R120)
* Removed the previous delta-based update logic for `clients_total` in `src/database.py`, switching to live recomputation to avoid drift and negative values. [[1]](diffhunk://#diff-a973c3fe6c0b21eab804cedc4e98a209c807dec75176677101a433024b9a7f83L895-R898) [[2]](diffhunk://#diff-a973c3fe6c0b21eab804cedc4e98a209c807dec75176677101a433024b9a7f83L1715-R1711)

**Performance and Efficiency Improvements:**

* Implemented batch counter reads (`get_many`) and optimized `get_all` in `metrics_counters.py` for efficient Redis access, reducing round-trips and improving scalability.

**Additional Database Metrics Helpers:**

* Added `get_heavy_summary` and `get_deleted_tallies` methods to the database layer for reading persisted aggregate metric snapshots and retention tallies, supporting reconciliation and absolute cumulative metrics.

**Configuration Updates:**

* Added `config.metrics.enabled` to the Helm configmap and values, ensuring metrics exposure can be toggled via configuration. [[1]](diffhunk://#diff-bfc6a602171deb9937fdee53ff0c20b633450fe90d995958f68b1e0035175ccbR31-R32) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R111-R112)

These changes collectively enable robust, accurate, and scalable Prometheus monitoring for Krawl, with clear configuration and operational guidance.