### PR TITLE
Fix/adjust helm values

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -198,6 +198,31 @@ The following table lists the main configuration parameters of the Krawl chart a
 | `ingress.className` | Ingress class name | `traefik` |
 | `ingress.hosts[0].host` | Ingress hostname | `krawl.example.com` |
 
+### External Traefik / Reverse Proxy Setup
+
+If you're using Traefik in a separate namespace (e.g., `cattle-system`) or running a reverse proxy like nginx in front of Traefik, you must configure both the Traefik service and deployment to preserve the real client IP. This ensures Krawl receives the actual attacker IP instead of the proxy's IP.
+
+**Apply these patches to your Traefik deployment** (replace `cattle-system` with your Traefik namespace and `<IP>` with your actual IP if needed):
+
+1. **Patch the Traefik Service** to use local traffic policy:
+
+```bash
+kubectl patch svc traefik -n cattle-system -p '{"spec":{"externalTrafficPolicy":"Local"}}'
+```
+
+2. **Patch the Traefik Deployment** to add trusted IPs to the entrypoints:
+
+```bash
+kubectl patch deployment traefik -n cattle-system --type=json -p='[
+  {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--entrypoints.web.forwardedHeaders.trustedIPs=<IP>"},
+  {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--entrypoints.websecure.forwardedHeaders.trustedIPs=<IP>"}
+]'
+```
+
+> **Note**: These patches must be reapplied after any Traefik upgrade. Consider adding them to your cluster initialization automation or Traefik Helm values if using a Traefik Helm chart.
+
+The Krawl service already includes `externalTrafficPolicy: Local` by default to preserve source IPs at the service level.
+
 ### Server Configuration
 
 | Parameter | Description | Default |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       {{- end }}
       labels:
         {{- include "krawl.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: krawl
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -127,6 +128,14 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
+        startupProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
       volumes:
       - name: config
         configMap:

--- a/helm/templates/network-policy.yaml
+++ b/helm/templates/network-policy.yaml
@@ -9,6 +9,7 @@ spec:
   podSelector:
     matchLabels:
       {{- include "krawl.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: krawl
   {{- with .Values.networkPolicy.policyTypes }}
   policyTypes:
     {{- toYaml . | nindent 4 }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.externalTrafficPolicy }}
+  {{- if and .Values.service.externalTrafficPolicy (ne .Values.service.type "ClusterIP") }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   sessionAffinity: ClientIP
@@ -24,3 +24,4 @@ spec:
     name: http
   selector:
     {{- include "krawl.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: krawl

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       {{- include "krawl.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: krawl
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
The krawl service selector is matching both krawl AND ollama pods because both use the same `krawl.selectorLabels`.

Added `app.kubernetes.io/component: krawl` to the krawl deployment and updated the service selector to distinguish between them.

