### PR TITLE
Fix: private ips timed out

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.1.9
-appVersion: 2.1.9
+version: 2.1.10
+appVersion: 2.1.10
 keywords:
   - honeypot
   - security

--- a/src/middleware/ban_check.py
+++ b/src/middleware/ban_check.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from dependencies import get_client_ip
+from ip_utils import is_local_or_private_ip
 
 
 class BanCheckMiddleware(BaseHTTPMiddleware):
@@ -23,6 +24,12 @@ class BanCheckMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         client_ip = get_client_ip(request)
+
+        # Private/local/reserved IPs (e.g. k8s health-check sources) are never
+        # banned, so skip the ban check entirely for them.
+        if is_local_or_private_ip(client_ip):
+            return await call_next(request)
+
         tracker = request.app.state.tracker
 
         from logger import get_app_logger

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -5,6 +5,7 @@ import re
 import urllib.parse
 
 from database import DatabaseManager, get_database
+from ip_utils import is_local_or_private_ip
 from wordlists import get_wordlists
 
 logger = logging.getLogger("krawl")
@@ -239,6 +240,11 @@ class AccessTracker:
         Returns:
             The page visit count (0 when increment_page_visit is False or on error)
         """
+        # Private/local/reserved IPs (e.g. k8s health-check sources) are never
+        # tracked, categorized, or banned.
+        if is_local_or_private_ip(ip):
+            return 0
+
         # Skip if this is the server's own IP
         from config import get_config
 
@@ -396,6 +402,10 @@ class AccessTracker:
         Returns:
             The updated page visit count for this IP
         """
+        # Private/local/reserved IPs are never tracked or banned.
+        if is_local_or_private_ip(client_ip):
+            return 0
+
         from config import get_config
 
         config = get_config()


### PR DESCRIPTION
This pull request improves how private, local, and reserved IP addresses are handled throughout the codebase to ensure they are never banned or tracked. The main changes add checks to skip ban and tracking logic for these types of IPs, which is especially important for excluding sources like Kubernetes health checks from these mechanisms.

**Ban and tracking logic improvements:**

* Updated `BanCheckMiddleware` in `src/middleware/ban_check.py` to skip ban checks for private, local, or reserved IP addresses by using the new `is_local_or_private_ip` utility. [[1]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7R15) [[2]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7R27-R32)
* Updated `record_access` and `increment_page_visit` methods in `src/tracker.py` to skip tracking and categorization for private, local, or reserved IPs, returning immediately if such an IP is detected. [[1]](diffhunk://#diff-229deb342c5697840c90530aa1cd46644b4ccacda0439f830d30cf93fd1301f5R243-R247) [[2]](diffhunk://#diff-229deb342c5697840c90530aa1cd46644b4ccacda0439f830d30cf93fd1301f5R405-R408)

**Codebase consistency:**

* Imported `is_local_or_private_ip` from `ip_utils` in both `src/middleware/ban_check.py` and `src/tracker.py` to ensure consistent IP address handling throughout the application. [[1]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7R15) [[2]](diffhunk://#diff-229deb342c5697840c90530aa1cd46644b4ccacda0439f830d30cf93fd1301f5R8)