### PR TITLE
Fix broken healthcheck

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.1.10
-appVersion: 2.1.10
+version: 2.1.11
+appVersion: 2.1.11
 keywords:
   - honeypot
   - security

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -143,9 +143,21 @@ spec:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         startupProbe:
+          {{- $secret := .Values.config.dashboard.secret_path }}
+          {{- if $secret }}
+          # Probe the health endpoint under the secret dashboard prefix, which
+          # is exempt from ban/deception tracking. Path is built dynamically
+          # from config.dashboard.secret_path.
           httpGet:
-            path: /
+            path: /{{ $secret | trimPrefix "/" | trimSuffix "/" }}/healthz
             port: http
+          {{- else }}
+          # secret_path is auto-generated at runtime and unknowable here, so the
+          # HTTP health path can't be templated. Fall back to a TCP check, which
+          # verifies the server is up without hitting the honeypot catch-all.
+          tcpSocket:
+            port: http
+          {{- end }}
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5

--- a/kubernetes/krawl-all-in-one-deploy.yaml
+++ b/kubernetes/krawl-all-in-one-deploy.yaml
@@ -523,6 +523,17 @@ spec:
             requests:
               cpu: 100m
               memory: 64Mi
+        # TCP startup probe: verifies the server is accepting connections
+        # without hitting the honeypot catch-all, so probes are never counted
+        # toward bans or served a 429. For an HTTP health check under the secret
+        # dashboard prefix, use the Helm chart with config.dashboard.secret_path set.
+        startupProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
       volumes:
       - name: config
         configMap:

--- a/src/app.py
+++ b/src/app.py
@@ -248,8 +248,16 @@ def create_app() -> FastAPI:
         if getattr(request.state, "banned", False):
             return response
 
-        client_ip = get_client_ip(request)
         path = request.url.path
+
+        # Don't log health probes — they fire every few seconds and add noise.
+        # The probe path is derived from the (possibly auto-generated) secret.
+        config = request.app.state.config
+        health_path = "/" + config.dashboard_secret_path.lstrip("/") + "/healthz"
+        if path == health_path:
+            return response
+
+        client_ip = get_client_ip(request)
         method = request.method
         status = response.status_code
         access_logger = get_access_logger()

--- a/src/routes/dashboard.py
+++ b/src/routes/dashboard.py
@@ -37,6 +37,17 @@ def _get_krawl_version() -> str:
 KRAWL_VERSION = _get_krawl_version()
 
 
+@router.get("/healthz", include_in_schema=False)
+async def healthz():
+    """Liveness/readiness/startup probe target.
+
+    Lives under the secret dashboard prefix, so it inherits that prefix's
+    exemption from the ban-check and deception middleware — probes are never
+    tracked, counted toward bans, or served a 429.
+    """
+    return JSONResponse({"status": "ok"})
+
+
 @router.get("/metrics", include_in_schema=False)
 async def metrics_endpoint(request: Request):
     if not get_config().metrics_enabled:


### PR DESCRIPTION
This pull request improves the reliability and accuracy of health checks for the Krawl honeypot server by introducing a dedicated HTTP health probe endpoint under the secret dashboard prefix, ensuring probes are not counted toward bans or logged as regular traffic. It also updates the Helm chart and deployment manifests to use this new health check mechanism, and suppresses health probe requests from access logs to reduce noise.

**Health check improvements:**

* Added a new `/healthz` endpoint under the secret dashboard prefix, exempt from ban and deception tracking, for use as a liveness/readiness/startup probe.
* Updated the Helm deployment template to use the secret dashboard path for the HTTP health probe if `config.dashboard.secret_path` is set, otherwise falling back to a TCP probe.
* Modified the all-in-one Kubernetes deployment to use a TCP startup probe, ensuring probes are never counted toward bans or logged as honeypot traffic.

**Logging improvements:**

* Suppressed access log entries for health probe requests to reduce log noise and avoid logging frequent, automated probe traffic.

**Version bump:**

* Updated `version` and `appVersion` in `helm/Chart.yaml` from `2.1.10` to `2.1.11` to reflect these changes.