### PR TITLE
Implement exponential backoff for ban multiplier

### DIFF
--- a/src/database/core.py
+++ b/src/database/core.py
@@ -38,6 +38,19 @@ from sanitizer import (
 
 applogger = get_app_logger()
 
+# Cap the exponential ban backoff so ban_multiplier never overflows the
+# Integer (int4) column. With the default 600s base ban, 2**10 = 1024 caps the
+# effective ban at roughly a week — repeat offenders saturate here instead of
+# growing unbounded and crashing the persist with "integer out of range".
+MAX_BAN_EXPONENT = 10
+
+
+def _ban_multiplier_for(total_violations: int) -> int:
+    """Exponential backoff multiplier, clamped to avoid int4 overflow."""
+    exponent = min(max(total_violations - 1, 0), MAX_BAN_EXPONENT)
+    return 2**exponent
+
+
 # ── Access-log write buffer (scalable mode) ──────────────────────────
 # Instead of INSERT-per-request over the network, access log entries are
 # buffered in memory and flushed in bulk every few seconds by a background task.
@@ -561,7 +574,7 @@ class DatabaseManager:
 
             if max_pages_limit > 0 and page_visit_count >= max_pages_limit:
                 ip_stats.total_violations = (ip_stats.total_violations or 0) + 1
-                ip_stats.ban_multiplier = 2 ** (ip_stats.total_violations - 1)
+                ip_stats.ban_multiplier = _ban_multiplier_for(ip_stats.total_violations)
                 ip_stats.ban_timestamp = now
                 # Invalidate cached ban info so the new ban is enforced immediately
                 from dashboard_cache import delete_cached_short
@@ -603,7 +616,7 @@ class DatabaseManager:
 
             if ip_stats.page_visit_count >= max_pages_limit:
                 ip_stats.total_violations = (ip_stats.total_violations or 0) + 1
-                ip_stats.ban_multiplier = 2 ** (ip_stats.total_violations - 1)
+                ip_stats.ban_multiplier = _ban_multiplier_for(ip_stats.total_violations)
                 ip_stats.ban_timestamp = datetime.now()
 
             session.commit()


### PR DESCRIPTION
This pull request addresses a potential integer overflow issue in the IP ban logic by capping the exponential backoff multiplier used for repeat offenders. The main change is to ensure that the ban multiplier does not exceed the storage limits of the database, preventing crashes due to "integer out of range" errors.

**Ban logic improvements:**

* Introduced a new constant `MAX_BAN_EXPONENT` and a helper function `_ban_multiplier_for` in `src/database/core.py` to cap the exponential ban multiplier at `2**10`, preventing integer overflow in the database.
* Updated the ban multiplier calculation in both `_update_ip_stats` and `increment_page_visit` methods to use `_ban_multiplier_for` instead of calculating `2 ** (total_violations - 1)` directly, ensuring the cap is enforced everywhere the multiplier is set. [[1]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64L564-R577) [[2]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64L606-R619)…verflow