### PR TITLE
Feat: improved timedout ips insight

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -55,6 +55,7 @@ Point-in-time values. `krawl_clients_total` is recomputed live at scrape time; t
 | `krawl_ips_needing_reevaluation` | IPs currently flagged for reevaluation by the analyzer |
 | `krawl_unenriched_ips` | IPs awaiting geolocation/reputation enrichment (capped at 1000) |
 | `krawl_auth_locked_ips` | IPs currently locked out from dashboard authentication |
+| `krawl_timed_out_ips` | IPs currently serving an automatic rate-limit time-ban |
 | `krawl_dashboard_warmup_duration_seconds` | Last observed duration of each dashboard warmup sub-step, labeled by `step` |
 
 ## Grafana Dashboard

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.2.0
-appVersion: 2.2.0
+version: 2.2.1
+appVersion: 2.2.1
 keywords:
   - honeypot
   - security

--- a/src/database/ip_stats.py
+++ b/src/database/ip_stats.py
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
 
 applogger = get_app_logger()
 
+# Mirror of MAX_BAN_EXPONENT in database/core.py (2 ** 10). Used only as a
+# coarse lower-bound to bound the timed-out candidate scan.
+_MAX_BAN_MULTIPLIER = 1024
+
 
 class IpStatsRepo:
     """Queries and mutations centered on the ip_stats table."""
@@ -106,6 +110,7 @@ class IpStatsRepo:
                     IpStats.total_violations,
                     IpStats.ban_multiplier,
                     IpStats.ban_override,
+                    IpStats.timeout_exempt,
                 )
                 .filter(IpStats.ip == sanitized_ip)
                 .first()
@@ -121,7 +126,13 @@ class IpStatsRepo:
                 set_cached_short(f"ban:{sanitized_ip}", result)
                 return result
 
-            ban_timestamp, violations_raw, multiplier_raw, ban_override = row
+            (
+                ban_timestamp,
+                violations_raw,
+                multiplier_raw,
+                ban_override,
+                timeout_exempt,
+            ) = row
             violations = violations_raw or 0
             multiplier = multiplier_raw or 1
 
@@ -138,6 +149,16 @@ class IpStatsRepo:
                 )
                 return result
             if ban_override is False:
+                result = {
+                    "is_banned": False,
+                    "violations": violations,
+                    "ban_multiplier": multiplier,
+                    "remaining_ban_seconds": 0,
+                }
+                set_cached_short(f"ban:{sanitized_ip}", result)
+                return result
+
+            if timeout_exempt:
                 result = {
                     "is_banned": False,
                     "violations": violations,
@@ -235,6 +256,34 @@ class IpStatsRepo:
         except Exception as e:
             session.rollback()
             applogger.error(f"Error force-banning {sanitized_ip}: {e}")
+            return False
+        finally:
+            self._db.close_session()
+
+    def set_timeout_exempt(self, ip: str, exempt: bool) -> bool:
+        """
+        Exempt an IP from (or re-enable) the automatic time-ban.
+        exempt=True: the rate-limit 429 is not enforced for this IP.
+        exempt=False: reset to automatic timeout behaviour.
+
+        Returns True if the IP exists and was updated.
+        """
+        from dashboard_cache import delete_cached_short
+
+        session = self._db.session
+        sanitized_ip = sanitize_ip(ip)
+        ip_stats = session.query(IpStats).filter(IpStats.ip == sanitized_ip).first()
+        if not ip_stats:
+            return False
+
+        ip_stats.timeout_exempt = exempt
+        try:
+            session.commit()
+            delete_cached_short(f"ban:{sanitized_ip}")
+            return True
+        except Exception as e:
+            session.rollback()
+            applogger.error(f"Error setting timeout_exempt for {sanitized_ip}: {e}")
             return False
         finally:
             self._db.close_session()
@@ -987,6 +1036,160 @@ class IpStatsRepo:
                     "page": page,
                     "page_size": page_size,
                     "total": total_ips,
+                    "total_pages": total_pages,
+                },
+            }
+        finally:
+            self._db.close_session()
+
+    def _timedout_candidates(self, session, ban_duration_seconds: int) -> list[IpStats]:
+        """
+        Rows currently serving an automatic time-ban, newest ban first.
+
+        Currently timed out := ban_timestamp set and within
+        ban_duration_seconds * ban_multiplier, ban_override is NULL
+        (force ban/unban are shown elsewhere), and not timeout_exempt.
+
+        A coarse SQL lower-bound on ban_timestamp bounds the scan; the exact
+        per-row window is computed in Python (dialect-agnostic, mirrors the
+        per-request logic in get_ban_info).
+        """
+        coarse_floor = datetime.now() - timedelta(
+            seconds=ban_duration_seconds * _MAX_BAN_MULTIPLIER
+        )
+        rows = (
+            session.query(IpStats)
+            .filter(
+                IpStats.ban_timestamp.isnot(None),
+                IpStats.ban_override.is_(None),
+                or_(
+                    IpStats.timeout_exempt.is_(None),
+                    IpStats.timeout_exempt.is_(False),
+                ),
+                IpStats.ban_timestamp >= coarse_floor,
+            )
+            .order_by(IpStats.ban_timestamp.desc())
+            .all()
+        )
+        now = datetime.now()
+        live = []
+        for r in rows:
+            multiplier = r.ban_multiplier or 1
+            effective = ban_duration_seconds * multiplier
+            elapsed = (now - r.ban_timestamp).total_seconds()
+            if elapsed < effective:
+                live.append(r)
+        return live
+
+    def get_timedout_ips(self, ban_duration_seconds: int) -> list[str]:
+        """IP strings currently serving an automatic time-ban (for export)."""
+        session = self._db.session
+        try:
+            return [
+                r.ip for r in self._timedout_candidates(session, ban_duration_seconds)
+            ]
+        finally:
+            self._db.close_session()
+
+    def count_timed_out(self, ban_duration_seconds: int) -> int:
+        """Count of IPs currently serving an automatic time-ban."""
+        session = self._db.session
+        try:
+            return len(self._timedout_candidates(session, ban_duration_seconds))
+        finally:
+            self._db.close_session()
+
+    def get_timedout_ips_paginated(
+        self,
+        ban_duration_seconds: int,
+        page: int = 1,
+        page_size: int = 25,
+    ) -> dict[str, Any]:
+        """Paginated view of currently timed-out IPs with remaining time."""
+        session = self._db.session
+        try:
+            candidates = self._timedout_candidates(session, ban_duration_seconds)
+            total = len(candidates)
+            total_pages = max(1, (total + page_size - 1) // page_size)
+            page = max(1, page)
+            start = (page - 1) * page_size
+            window = candidates[start : start + page_size]
+
+            now = datetime.now()
+            items = []
+            for r in window:
+                multiplier = r.ban_multiplier or 1
+                effective = ban_duration_seconds * multiplier
+                elapsed = (now - r.ban_timestamp).total_seconds()
+                remaining = max(0, int(effective - elapsed))
+                items.append(
+                    {
+                        "ip": r.ip,
+                        "remaining_ban_seconds": remaining,
+                        "total_violations": r.total_violations or 0,
+                        "ban_multiplier": multiplier,
+                        "category": r.category,
+                        "country_code": r.country_code,
+                        "city": r.city,
+                        "last_seen": r.last_seen.isoformat() if r.last_seen else None,
+                    }
+                )
+
+            return {
+                "items": items,
+                "pagination": {
+                    "page": page,
+                    "page_size": page_size,
+                    "total": total,
+                    "total_pages": total_pages,
+                },
+            }
+        finally:
+            self._db.close_session()
+
+    def get_timeout_exempt_paginated(
+        self,
+        page: int = 1,
+        page_size: int = 25,
+    ) -> dict[str, Any]:
+        """Get all IPs with timeout_exempt=True, paginated."""
+        session = self._db.session
+        try:
+            base_query = session.query(IpStats).filter(IpStats.timeout_exempt.is_(True))
+            total = (
+                session.query(func.count(IpStats.ip))
+                .filter(IpStats.timeout_exempt.is_(True))
+                .scalar()
+                or 0
+            )
+            total_pages = max(1, (total + page_size - 1) // page_size)
+
+            results = (
+                base_query.order_by(IpStats.last_seen.desc())
+                .offset((max(1, page) - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+
+            items = []
+            for r in results:
+                items.append(
+                    {
+                        "ip": r.ip,
+                        "category": r.category,
+                        "total_requests": r.total_requests,
+                        "country_code": r.country_code,
+                        "city": r.city,
+                        "last_seen": r.last_seen.isoformat() if r.last_seen else None,
+                    }
+                )
+
+            return {
+                "items": items,
+                "pagination": {
+                    "page": max(1, page),
+                    "page_size": page_size,
+                    "total": total,
                     "total_pages": total_pages,
                 },
             }

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -106,6 +106,21 @@ class KrawlMetricsCollector:
             app_logger.error(f"collect clients_total failed: {e}")
         yield clients
 
+        timed_out = GaugeMetricFamily(
+            "krawl_timed_out_ips",
+            "IPs currently serving an automatic time-ban (timed out)",
+        )
+        try:
+            from config import get_config
+            from database import get_database
+
+            db = get_database()
+            duration = get_config().ban_duration_seconds
+            timed_out.add_metric([], db.ip_stats.count_timed_out(duration))
+        except Exception as e:
+            app_logger.error(f"collect timed_out_ips failed: {e}")
+        yield timed_out
+
 
 # Register the collector once (guard against re-import in test/reload paths).
 _collector = KrawlMetricsCollector()

--- a/src/migrations/runner.py
+++ b/src/migrations/runner.py
@@ -157,6 +157,17 @@ def _migrate_ban_override_column(engine: Engine) -> bool:
     return True
 
 
+def _migrate_timeout_exempt_column(engine: Engine) -> bool:
+    """Add timeout_exempt column to ip_stats if missing."""
+    if _column_exists(engine, "ip_stats", "timeout_exempt"):
+        return False
+    with engine.begin() as conn:
+        conn.execute(
+            text("ALTER TABLE ip_stats ADD COLUMN timeout_exempt BOOLEAN DEFAULT false")
+        )
+    return True
+
+
 def run_migrations(engine: Engine) -> None:
     """
     Check the database schema and apply any pending migrations.
@@ -202,6 +213,10 @@ def run_migrations(engine: Engine) -> None:
     _step(
         "add ban_override column to ip_stats",
         lambda: _migrate_ban_override_column(engine),
+    )
+    _step(
+        "add timeout_exempt column to ip_stats",
+        lambda: _migrate_timeout_exempt_column(engine),
     )
     _step(
         "performance indexes",

--- a/src/models.py
+++ b/src/models.py
@@ -220,6 +220,13 @@ class IpStats(Base):
         Boolean, nullable=True, default=None
     )
 
+    # Timeout exemption: when True, the automatic time-ban (rate-limit 429)
+    # is not enforced for this IP. Independent of ban_override and of firewall
+    # export — only suppresses the runtime timeout.
+    timeout_exempt: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=False
+    )
+
     __table_args__ = (
         Index("ix_ip_stats_category", "category"),
         Index("ix_ip_stats_need_reevaluation", "need_reevaluation"),

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -187,6 +187,36 @@ async def ban_override(request: Request, body: BanOverrideRequest):
     return JSONResponse(content={"error": "IP not found"}, status_code=404)
 
 
+class TimeoutExemptRequest(BaseModel):
+    ip: str
+    action: str  # "exempt" or "reset"
+
+
+@router.post("/api/timeout-exempt")
+async def timeout_exempt(request: Request, body: TimeoutExemptRequest):
+    if not verify_auth(request):
+        return JSONResponse(content={"error": "Unauthorized"}, status_code=401)
+
+    action_map = {"exempt": True, "reset": False}
+    if body.action not in action_map:
+        return JSONResponse(
+            content={"error": "Invalid action. Use: exempt, reset"},
+            status_code=400,
+        )
+
+    db = get_db()
+    success = await asyncio.to_thread(
+        db.ip_stats.set_timeout_exempt, body.ip, action_map[body.action]
+    )
+    if success:
+        get_app_logger().info(f"Timeout exempt: {body.action} on IP {body.ip}")
+        invalidate_table_cache()
+        return JSONResponse(
+            content={"success": True, "ip": body.ip, "action": body.action}
+        )
+    return JSONResponse(content={"error": "IP not found"}, status_code=404)
+
+
 # ── Protected IP Tracking API ────────────────────────────────────────
 
 
@@ -609,7 +639,13 @@ async def export_ips(
     categories: str = Query(...),
     fwtype: str = Query("raw"),
 ):
-    valid_categories = {"attacker", "bad_crawler", "regular_user", "good_crawler"}
+    valid_categories = {
+        "attacker",
+        "bad_crawler",
+        "regular_user",
+        "good_crawler",
+        "timed_out",
+    }
     cat_list = [c.strip() for c in categories.split(",") if c.strip()]
     if not cat_list or not all(c in valid_categories for c in cat_list):
         return JSONResponse(content={"error": "Invalid categories"}, status_code=400)
@@ -629,7 +665,19 @@ async def export_ips(
         config = request.app.state.config
         server_ip = config.get_server_ip()
 
-        ips = await asyncio.to_thread(db.ip_stats.get_ips_for_export, cat_list)
+        real_cats = [c for c in cat_list if c != "timed_out"]
+        ip_set: set[str] = set()
+        if real_cats:
+            ip_set.update(
+                await asyncio.to_thread(db.ip_stats.get_ips_for_export, real_cats)
+            )
+        if "timed_out" in cat_list:
+            ip_set.update(
+                await asyncio.to_thread(
+                    db.ip_stats.get_timedout_ips, config.ban_duration_seconds
+                )
+            )
+        ips = list(ip_set)
 
         from ip_utils import is_valid_public_ip
 

--- a/src/routes/htmx.py
+++ b/src/routes/htmx.py
@@ -876,3 +876,85 @@ async def htmx_ban_overrides(
             "pagination": result["pagination"],
         },
     )
+
+
+# ── Timed-Out IPs Panel ──────────────────────────────────────────────
+
+
+@router.get("/htmx/timedout")
+async def htmx_timedout(request: Request):
+    if not verify_auth(request):
+        return HTMLResponse(
+            '<div class="table-container" style="text-align:center;padding:80px 20px;">'
+            '<h1 style="color:#f0883e;font-size:48px;margin:20px 0 10px;">Nice try bozo</h1>'
+            "<br>"
+            '<img src="https://media0.giphy.com/media/v1.Y2lkPTZjMDliOTUyaHQ3dHRuN2wyOW1kZndjaHdkY2dhYzJ6d2gzMDJkNm53ZnNrdnNlZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mOY97EXNisstZqJht9/200w.gif" alt="Diddy">'
+            "</div>",
+            status_code=200,
+        )
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/timedout_panel.html",
+        {"dashboard_path": _dashboard_path(request)},
+    )
+
+
+@router.get("/htmx/timedout/active")
+async def htmx_timedout_active(
+    request: Request,
+    page: int = Query(1),
+    page_size: int = Query(25),
+):
+    if not verify_auth(request):
+        return HTMLResponse(
+            "<p style='color:#f85149;'>Unauthorized</p>", status_code=200
+        )
+
+    db = get_db()
+    duration = get_config().ban_duration_seconds
+    result = await asyncio.to_thread(
+        db.ip_stats.get_timedout_ips_paginated,
+        ban_duration_seconds=duration,
+        page=max(1, page),
+        page_size=page_size,
+    )
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/timedout_ips_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "items": result["items"],
+            "pagination": result["pagination"],
+        },
+    )
+
+
+@router.get("/htmx/timeout-exempt")
+async def htmx_timeout_exempt(
+    request: Request,
+    page: int = Query(1),
+    page_size: int = Query(25),
+):
+    if not verify_auth(request):
+        return HTMLResponse(
+            "<p style='color:#f85149;'>Unauthorized</p>", status_code=200
+        )
+
+    db = get_db()
+    result = await asyncio.to_thread(
+        db.ip_stats.get_timeout_exempt_paginated,
+        page=max(1, page),
+        page_size=page_size,
+    )
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/timeout_exempt_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "items": result["items"],
+            "pagination": result["pagination"],
+        },
+    )

--- a/src/templates/jinja2/dashboard/index.html
+++ b/src/templates/jinja2/dashboard/index.html
@@ -55,6 +55,7 @@
         </a>
         <a class="tab-button tab-right" :class="{ active: tab === 'tracked-ips' }" x-show="authenticated" x-cloak @click.prevent="switchToTrackedIps()" href="#tracked-ips">Tracked IPs</a>
         <a class="tab-button" :class="{ active: tab === 'banlist' }" x-show="authenticated" x-cloak @click.prevent="switchToBanlist()" href="#banlist">IP Banlist</a>
+        <a class="tab-button" :class="{ active: tab === 'timedout' }" x-show="authenticated" x-cloak @click.prevent="switchToTimedOut()" href="#timedout">Timed Out IPs</a>
         <a class="tab-button" :class="{ active: tab === 'deception' }" x-show="authenticated" x-cloak @click.prevent="switchToDeception()" href="#deception">Deception</a>
         {# Lock icon (not authenticated) #}
         <a class="tab-button tab-lock-btn" :class="{ 'tab-right': !authenticated }" @click.prevent="promptAuth()" x-show="!authenticated" href="#" title="Unlock protected panels">
@@ -242,6 +243,11 @@
     {# ==================== IP BANLIST TAB (protected, loaded via HTMX with server-side auth) ==================== #}
     <div x-show="tab === 'banlist'" x-cloak>
         <div id="banlist-htmx-container"></div>
+    </div>
+
+    {# ==================== TIMED OUT IPS TAB (protected, loaded via HTMX with server-side auth) ==================== #}
+    <div x-show="tab === 'timedout'" x-cloak>
+        <div id="timedout-htmx-container"></div>
     </div>
 
     {# ==================== DECEPTION TAB (protected, Generated templates) ==================== #}

--- a/src/templates/jinja2/dashboard/partials/export_modal.html
+++ b/src/templates/jinja2/dashboard/partials/export_modal.html
@@ -50,6 +50,13 @@
                             Good Crawlers
                         </span>
                     </label>
+                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+                        <input type="checkbox" value="timed_out" x-model="exportModal.categories" style="accent-color: #db61a2;" />
+                        <span style="display: inline-flex; align-items: center; gap: 6px;">
+                            <span style="width: 8px; height: 8px; border-radius: 50%; background: #db61a2; display: inline-block;"></span>
+                            Timed Out IPs
+                        </span>
+                    </label>
                 </div>
             </div>
 

--- a/src/templates/jinja2/dashboard/partials/timedout_ips_table.html
+++ b/src/templates/jinja2/dashboard/partials/timedout_ips_table.html
@@ -1,0 +1,54 @@
+{# HTMX fragment: currently timed-out IPs #}
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+    <span class="pagination-info">Page {{ pagination.page }}/{{ pagination.total_pages }} &mdash; {{ pagination.total }} timed out</span>
+    <div style="display: flex; gap: 8px;">
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/timedout/active?page={{ pagination.page - 1 }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page <= 1 %}disabled{% endif %}>Prev</button>
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/timedout/active?page={{ pagination.page + 1 }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page >= pagination.total_pages %}disabled{% endif %}>Next</button>
+    </div>
+</div>
+<table class="ip-stats-table">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>IP Address</th>
+            <th>Time Left</th>
+            <th>Violations</th>
+            <th>Multiplier</th>
+            <th>Category</th>
+            <th>Location</th>
+            <th>Last Seen</th>
+            <th style="width: 40px;"></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for ip in items %}
+        <tr>
+            <td class="rank">{{ loop.index + (pagination.page - 1) * pagination.page_size }}</td>
+            <td>{{ ip.ip | e }}</td>
+            <td class="timeout-countdown" data-remaining="{{ ip.remaining_ban_seconds }}" data-ip="{{ ip.ip | e }}">&mdash;</td>
+            <td>{{ ip.total_violations }}</td>
+            <td>&times;{{ ip.ban_multiplier }}</td>
+            <td><span class="category-badge category-{{ ip.category | default('unknown') | replace('_', '-') }}">{{ ip.category | default('unknown') | replace('_', ' ') | title }}</span></td>
+            <td>{{ ip.city | default('') | e }}{% if ip.city and ip.country_code %}, {% endif %}{{ ip.country_code | default('N/A') | e }}</td>
+            <td>{{ ip.last_seen | format_ts }}</td>
+            <td>
+                <button class="ban-icon-btn ban-icon-reset" onclick="timeoutExemptAction('{{ ip.ip | e }}', 'exempt')" title="Exempt from timeout">
+                    <span class="material-symbols-outlined" style="font-size:18px;">block</span>
+                    <span class="ban-icon-tooltip">Exempt</span>
+                </button>
+            </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="9" class="empty-state">No IPs are currently timed out</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+<script>if (typeof startTimeoutCountdowns === 'function') startTimeoutCountdowns();</script>

--- a/src/templates/jinja2/dashboard/partials/timedout_panel.html
+++ b/src/templates/jinja2/dashboard/partials/timedout_panel.html
@@ -1,0 +1,30 @@
+{# Timed-Out IPs panel #}
+<div>
+    <div class="table-container" style="margin-bottom: 20px;">
+        <h2>Currently Timed Out</h2>
+        <p style="color: #8b949e; font-size: 14px; margin-bottom: 16px;">
+            IPs serving an automatic rate-limit time-ban right now. The remaining time counts down live; expired entries drop on refresh.
+        </p>
+        <div id="timedout-active-container"
+             class="htmx-container"
+             hx-get="{{ dashboard_path }}/htmx/timedout/active?page=1"
+             hx-trigger="load"
+             hx-swap="innerHTML">
+            <div class="htmx-indicator">Loading...</div>
+        </div>
+    </div>
+
+    <div class="table-container">
+        <h2>Timeout-Exempt IPs</h2>
+        <p style="color: #8b949e; font-size: 14px; margin-bottom: 16px;">
+            IPs excluded from the automatic time-ban. Re-enable to subject them to timeouts again.
+        </p>
+        <div id="timeout-exempt-container"
+             class="htmx-container"
+             hx-get="{{ dashboard_path }}/htmx/timeout-exempt?page=1"
+             hx-trigger="load"
+             hx-swap="innerHTML">
+            <div class="htmx-indicator">Loading...</div>
+        </div>
+    </div>
+</div>

--- a/src/templates/jinja2/dashboard/partials/timeout_exempt_table.html
+++ b/src/templates/jinja2/dashboard/partials/timeout_exempt_table.html
@@ -1,0 +1,49 @@
+{# HTMX fragment: timeout-exempt IPs #}
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+    <span class="pagination-info">Page {{ pagination.page }}/{{ pagination.total_pages }} &mdash; {{ pagination.total }} exempt</span>
+    <div style="display: flex; gap: 8px;">
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/timeout-exempt?page={{ pagination.page - 1 }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page <= 1 %}disabled{% endif %}>Prev</button>
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/timeout-exempt?page={{ pagination.page + 1 }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page >= pagination.total_pages %}disabled{% endif %}>Next</button>
+    </div>
+</div>
+<table class="ip-stats-table">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>IP Address</th>
+            <th>Category</th>
+            <th>Total Requests</th>
+            <th>Location</th>
+            <th>Last Seen</th>
+            <th style="width: 40px;"></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for ip in items %}
+        <tr>
+            <td class="rank">{{ loop.index + (pagination.page - 1) * pagination.page_size }}</td>
+            <td>{{ ip.ip | e }}</td>
+            <td><span class="category-badge category-{{ ip.category | default('unknown') | replace('_', '-') }}">{{ ip.category | default('unknown') | replace('_', ' ') | title }}</span></td>
+            <td>{{ ip.total_requests }}</td>
+            <td>{{ ip.city | default('') | e }}{% if ip.city and ip.country_code %}, {% endif %}{{ ip.country_code | default('N/A') | e }}</td>
+            <td>{{ ip.last_seen | format_ts }}</td>
+            <td>
+                <button class="ban-icon-btn ban-icon-reset" onclick="timeoutExemptAction('{{ ip.ip | e }}', 'reset')" title="Re-enable timeout">
+                    <span class="material-symbols-outlined" style="font-size:18px;">timer</span>
+                    <span class="ban-icon-tooltip">Re-enable</span>
+                </button>
+            </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="7" class="empty-state">No timeout-exempt IPs</td></tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/src/templates/static/js/dashboard.js
+++ b/src/templates/static/js/dashboard.js
@@ -148,6 +148,8 @@ document.addEventListener('alpine:init', () => {
                 this.switchToAttacks();
             } else if (hash === 'banlist' && this.authenticated) {
                 this.switchToBanlist();
+            } else if (hash === 'timedout' && this.authenticated) {
+                this.switchToTimedOut();
             } else if (hash === 'tracked-ips' && this.authenticated) {
                 this.switchToTrackedIps();
             } else if (hash === 'deception' && this.authenticated) {
@@ -170,6 +172,8 @@ document.addEventListener('alpine:init', () => {
                         this.switchToAttacks();
                     } else if (h === 'banlist') {
                         if (this.authenticated) this.switchToBanlist();
+                    } else if (h === 'timedout') {
+                        if (this.authenticated) this.switchToTimedOut();
                     } else if (h === 'tracked-ips') {
                         if (this.authenticated) this.switchToTrackedIps();
                     } else if (h === 'deception') {
@@ -224,6 +228,22 @@ document.addEventListener('alpine:init', () => {
             });
         },
 
+        switchToTimedOut() {
+            if (!this.authenticated) return;
+            if (this.tab === 'timedout') return;  // Prevent duplicate loading
+            this.tab = 'timedout';
+            window.location.hash = '#timedout';
+            this.$nextTick(() => {
+                const container = document.getElementById('timedout-htmx-container');
+                if (container && typeof htmx !== 'undefined') {
+                    htmx.ajax('GET', `${this.dashboardPath}/htmx/timedout`, {
+                        target: '#timedout-htmx-container',
+                        swap: 'innerHTML'
+                    });
+                }
+            });
+        },
+
         switchToTrackedIps() {
             if (!this.authenticated) return;
             if (this.tab === 'tracked-ips') return;  // Prevent duplicate loading
@@ -264,7 +284,7 @@ document.addEventListener('alpine:init', () => {
                 });
             } catch {}
             this.authenticated = false;
-            if (this.tab === 'banlist' || this.tab === 'tracked-ips' || this.tab === 'deception') this.switchToOverview();
+            if (this.tab === 'banlist' || this.tab === 'tracked-ips' || this.tab === 'deception' || this.tab === 'timedout') this.switchToOverview();
         },
 
         promptAuth() {
@@ -1152,6 +1172,85 @@ window.ipBanAction = async function(ip, action) {
         }
     } catch {
         krawlModal.error('Request failed');
+    }
+};
+
+// Global timeout exempt/reset action (auth-gated)
+window.timeoutExemptAction = async function(ip, action) {
+    const data = getAlpineData('[x-data="dashboardApp()"]');
+    if (!data || !data.authenticated) {
+        if (data && typeof data.promptAuth === 'function') data.promptAuth();
+        return;
+    }
+    const safeIp = escapeHtml(ip);
+    const label = action === 'exempt' ? 'exempt from timeout' : 're-enable timeout for';
+    const confirmed = await krawlModal.confirm(`Are you sure you want to ${label} IP <strong>${safeIp}</strong>?`);
+    if (!confirmed) return;
+    try {
+        const resp = await fetch(`${window.__DASHBOARD_PATH__}/api/timeout-exempt`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify({ ip, action }),
+        });
+        const result = await resp.json().catch(() => ({}));
+        if (resp.ok) {
+            krawlModal.success(escapeHtml(result.message || `${action} successful for ${ip}`));
+            // Refresh both tables so the IP moves between them
+            const active = document.getElementById('timedout-active-container');
+            if (active && typeof htmx !== 'undefined') {
+                htmx.ajax('GET', `${window.__DASHBOARD_PATH__}/htmx/timedout/active?page=1`, {
+                    target: '#timedout-active-container', swap: 'innerHTML'
+                });
+            }
+            const exempt = document.getElementById('timeout-exempt-container');
+            if (exempt && typeof htmx !== 'undefined') {
+                htmx.ajax('GET', `${window.__DASHBOARD_PATH__}/htmx/timeout-exempt?page=1`, {
+                    target: '#timeout-exempt-container', swap: 'innerHTML'
+                });
+            }
+        } else {
+            krawlModal.error(escapeHtml(result.error || `Failed to ${action} IP ${ip}`));
+        }
+    } catch {
+        krawlModal.error('Request failed');
+    }
+};
+
+// Live per-row countdown for the Timed Out IPs table.
+let _timeoutCountdownTimer = null;
+
+function _formatRemaining(secs) {
+    if (secs <= 0) return 'Expired';
+    const h = Math.floor(secs / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    const s = secs % 60;
+    if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m`;
+    if (m > 0) return `${m}m ${String(s).padStart(2, '0')}s`;
+    return `${s}s`;
+}
+
+function _tickTimeoutCountdowns() {
+    const cells = document.querySelectorAll('.timeout-countdown');
+    if (cells.length === 0) {
+        if (_timeoutCountdownTimer) { clearInterval(_timeoutCountdownTimer); _timeoutCountdownTimer = null; }
+        return;
+    }
+    cells.forEach((cell) => {
+        let remaining = parseInt(cell.getAttribute('data-remaining'), 10);
+        if (isNaN(remaining)) return;
+        cell.textContent = _formatRemaining(remaining);
+        if (remaining > 0) {
+            cell.setAttribute('data-remaining', String(remaining - 1));
+        }
+    });
+}
+
+// Called from the table fragment after each HTMX swap, and on tab enter.
+window.startTimeoutCountdowns = function() {
+    _tickTimeoutCountdowns();  // paint immediately
+    if (!_timeoutCountdownTimer) {
+        _timeoutCountdownTimer = setInterval(_tickTimeoutCountdowns, 1000);
     }
 };
 


### PR DESCRIPTION
This pull request introduces a new "timed out IPs" feature to the Krawl honeypot dashboard, allowing administrators to view, export, and manage IPs currently serving an automatic time-ban. It also adds the ability to exempt specific IPs from the automatic timeout system. Several backend, API, metrics, database, and UI changes support these features.

**Timed Out IPs Management and UI:**

- Added backend support to track, paginate, and export IPs currently serving an automatic time-ban, including new methods in `ip_stats.py` and new routes for the dashboard and API. [[1]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR1045-R1198) [[2]](diffhunk://#diff-dcb19fd70af1248af1457362412f377c6a93e172765e3436ab6920de73f7125dR879-R960) [[3]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667L612-R648) [[4]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667L632-R680) [[5]](diffhunk://#diff-b35c77417a95b8cae03279f3d83f499516ffa0cc11534b4ddeb5670ae37e8f0cR58) [[6]](diffhunk://#diff-b35c77417a95b8cae03279f3d83f499516ffa0cc11534b4ddeb5670ae37e8f0cR248-R252) [[7]](diffhunk://#diff-8fdde812766d4f010859b5b088a4d69d1a46761000ad249a6c53c58e49ca58edR53-R59)
- Exposed "Timed Out IPs" as a new tab and export category in the dashboard UI, with paginated views and export options. [[1]](diffhunk://#diff-b35c77417a95b8cae03279f3d83f499516ffa0cc11534b4ddeb5670ae37e8f0cR58) [[2]](diffhunk://#diff-b35c77417a95b8cae03279f3d83f499516ffa0cc11534b4ddeb5670ae37e8f0cR248-R252) [[3]](diffhunk://#diff-8fdde812766d4f010859b5b088a4d69d1a46761000ad249a6c53c58e49ca58edR53-R59)

**Timeout Exemption Controls:**

- Added a `timeout_exempt` column to the `ip_stats` table, with migration support, and implemented backend logic and API endpoints to exempt or re-enable automatic time-ban for specific IPs. [[1]](diffhunk://#diff-f4ca477841bd3ad5c0b292cbfff7c3ae403a65fb6c97deb15ad996f85dc87bd8R223-R229) [[2]](diffhunk://#diff-0119995de1c509b0400d02c94a1ffd2f7699f56aec6ad9c1646a40803746f7a9R160-R170) [[3]](diffhunk://#diff-0119995de1c509b0400d02c94a1ffd2f7699f56aec6ad9c1646a40803746f7a9R217-R220) [[4]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR113) [[5]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aL124-R135) [[6]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR161-R170) [[7]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR263-R290) [[8]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667R190-R219) [[9]](diffhunk://#diff-dcb19fd70af1248af1457362412f377c6a93e172765e3436ab6920de73f7125dR879-R960)
- Added paginated dashboard views for timeout-exempt IPs.

**Metrics and Monitoring:**

- Introduced a new Prometheus metric `krawl_timed_out_ips` to report the number of IPs currently serving an automatic time-ban, and documented it. [[1]](diffhunk://#diff-595e88de1f402f9e039ff56a467520ba15c29cdd5ca8f328091369c1440bae28R109-R123) [[2]](diffhunk://#diff-5451393354374ef994bc816d1c0a86459be726bd231dc37b4385707be6b56921R58)

**Database and Internal Improvements:**

- Improved efficiency of timed-out IP queries by bounding scans and handling large ban windows. [[1]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR22-R25) [[2]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR1045-R1198)
- Updated Helm chart version to reflect new features (`2.2.1`).

These changes collectively provide more granular control and visibility over IP bans, improving the dashboard’s usability for administrators.

Closes #234 