### PR TITLE
Feat: improved timedout ips insight and ignored ips

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -110,6 +110,23 @@ crawl:
   max_pages_limit: 250
   ban_duration_seconds: 600
 
+# IPs / CIDR ranges to ignore everywhere: never tracked, banned, exported, and
+# purged from the database on startup. Accepts single IPs (e.g. 203.0.113.5) or
+# CIDR ranges (IPv4 and IPv6). Defaults cover loopback, RFC1918 private,
+# link-local and CGNAT ranges; add your own trusted networks (monitoring,
+# health checks, office egress, etc.) here.
+ignored_ips:
+  - 127.0.0.0/8      # loopback
+  - 10.0.0.0/8       # RFC1918 private
+  - 172.16.0.0/12    # RFC1918 private
+  - 192.168.0.0/16   # RFC1918 private
+  - 169.254.0.0/16   # link-local
+  - 0.0.0.0/8        # "this network"
+  - 100.64.0.0/10    # CGNAT
+  - ::1/128          # IPv6 loopback
+  - fc00::/7         # IPv6 unique local
+  - fe80::/10        # IPv6 link-local
+
 tarpit:
   enabled: false  # Opt-in: trap AI agents with slow responses and random text
   delay_seconds: 5  # Extra delay (seconds) added to each response when tarpit is active

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.2.1
-appVersion: 2.2.1
+version: 2.2.2
+appVersion: 2.2.2
 keywords:
   - honeypot
   - security

--- a/helm/README.md
+++ b/helm/README.md
@@ -357,6 +357,12 @@ A one-shot Kubernetes Job that copies data from an existing SQLite PVC into Post
 | `config.crawl.max_pages_limit` | Maximum pages limit for legitimate crawlers | `250` |
 | `config.crawl.ban_duration_seconds` | IP ban duration in seconds | `600` |
 
+### Ignored IPs
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `config.ignored_ips` | List of IPs / CIDR ranges (IPv4/IPv6) never tracked, banned, exported, or persisted — and purged from the database on startup | loopback, RFC1918, link-local, CGNAT ranges |
+
 ### Resource Limits
 
 | Parameter | Description | Default |

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -53,6 +53,10 @@ data:
       infinite_pages_for_malicious: {{ .Values.config.crawl.infinite_pages_for_malicious }}
       max_pages_limit: {{ .Values.config.crawl.max_pages_limit }}
       ban_duration_seconds: {{ .Values.config.crawl.ban_duration_seconds }}
+    {{- with .Values.config.ignored_ips }}
+    ignored_ips:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     ai:
       enabled: {{ .Values.config.ai.enabled }}
       provider: {{ .Values.config.ai.provider | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -133,6 +133,21 @@ config:
     infinite_pages_for_malicious: true
     max_pages_limit: 250
     ban_duration_seconds: 600
+  # IPs / CIDR ranges to ignore everywhere: never tracked, banned, exported, or
+  # persisted, and purged from the database on startup. Single IPs or CIDRs
+  # (IPv4/IPv6). Defaults cover loopback, RFC1918, link-local and CGNAT ranges;
+  # add trusted networks (monitoring, health checks, office egress) as needed.
+  ignored_ips:
+    - 127.0.0.0/8      # loopback
+    - 10.0.0.0/8       # RFC1918 private
+    - 172.16.0.0/12    # RFC1918 private
+    - 192.168.0.0/16   # RFC1918 private
+    - 169.254.0.0/16   # link-local
+    - 0.0.0.0/8        # "this network"
+    - 100.64.0.0/10    # CGNAT
+    - ::1/128          # IPv6 loopback
+    - fc00::/7         # IPv6 unique local
+    - fe80::/10        # IPv6 link-local
   ai:
     enabled: false
     provider: "openrouter"  # "openrouter" or "openai". Use "openai" for OpenAI-compatible endpoints such as Ollama or llama.cpp.

--- a/kubernetes/krawl-all-in-one-deploy.yaml
+++ b/kubernetes/krawl-all-in-one-deploy.yaml
@@ -236,6 +236,20 @@ data:
       infinite_pages_for_malicious: true
       max_pages_limit: 250
       ban_duration_seconds: 600
+    # IPs / CIDR ranges to ignore everywhere: never tracked, banned, exported,
+    # or persisted, and purged from the database on startup. Single IPs or CIDRs
+    # (IPv4/IPv6). Add trusted networks (monitoring, health checks, egress) here.
+    ignored_ips:
+      - 127.0.0.0/8      # loopback
+      - 10.0.0.0/8       # RFC1918 private
+      - 172.16.0.0/12    # RFC1918 private
+      - 192.168.0.0/16   # RFC1918 private
+      - 169.254.0.0/16   # link-local
+      - 0.0.0.0/8        # "this network"
+      - 100.64.0.0/10    # CGNAT
+      - ::1/128          # IPv6 loopback
+      - fc00::/7         # IPv6 unique local
+      - fe80::/10        # IPv6 link-local
     ai:
       enabled: false
       provider: "openrouter"  # "openrouter" or "openai". Use "openai" for OpenAI-compatible endpoints such as Ollama or llama.cpp.

--- a/src/app.py
+++ b/src/app.py
@@ -16,7 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from config import get_config
 from dashboard_cache import flush_all as flush_cache
 from dashboard_cache import initialize_cache
-from database import initialize_database
+from database import get_database, initialize_database
 from generators import random_server_header
 from logger import get_access_logger, get_app_logger, initialize_logging
 from routes.dashboard import KRAWL_VERSION
@@ -68,6 +68,17 @@ async def lifespan(app: FastAPI):
                 f"Database initialization failed: {e}. Continuing with in-memory only."
             )
 
+    # One-time startup cleanup: purge configured ignored IPs that predate the
+    # tracking guard and clear stale (fully expired) ban state.
+    try:
+        from database.startup import run_startup_cleanup
+
+        run_startup_cleanup(
+            get_database(), config.ban_duration_seconds, config.ignored_ips
+        )
+    except Exception as e:
+        app_logger.warning(f"Startup cleanup skipped: {e}")
+
     # Initialize cache backend (in-memory dict for standalone, Redis for scalable)
     try:
         if config.mode == "scalable":
@@ -108,7 +119,6 @@ async def lifespan(app: FastAPI):
     # recompute). In scalable mode only the first pod actually seeds.
     try:
         import metrics_counters
-        from database import get_database
 
         metrics_counters.bootstrap(get_database())
         app_logger.info("Metric counters seeded")

--- a/src/config.py
+++ b/src/config.py
@@ -3,12 +3,30 @@
 import os
 import sys
 from dataclasses import dataclass
+from dataclasses import field as dc_field
 from pathlib import Path
 
 import requests
 import yaml
 
 from logger import get_app_logger
+
+# IPs/CIDRs ignored everywhere (never tracked, banned, exported, and purged on
+# startup). Defaults reproduce the previous hardcoded private/loopback/
+# link-local/CGNAT behaviour; operators can override via the `ignored_ips`
+# config section.
+DEFAULT_IGNORED_IPS = [
+    "127.0.0.0/8",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "169.254.0.0/16",
+    "0.0.0.0/8",
+    "100.64.0.0/10",
+    "::1/128",
+    "fc00::/7",
+    "fe80::/10",
+]
 
 
 @dataclass
@@ -61,6 +79,12 @@ class Config:
     )
     infinite_pages_for_malicious: bool = True  # Infinite pages for malicious crawlers
     ban_duration_seconds: int = 600  # Ban duration in seconds for IPs exceeding limits
+
+    # IPs/CIDRs to ignore everywhere (never tracked, banned, exported, purged
+    # on startup). See DEFAULT_IGNORED_IPS.
+    ignored_ips: list[str] = dc_field(
+        default_factory=lambda: list(DEFAULT_IGNORED_IPS)
+    )
 
     # backup job settings
     backups_path: str = "backups"
@@ -295,6 +319,7 @@ class Config:
             ),
             max_pages_limit=crawl.get("max_pages_limit", 250),
             ban_duration_seconds=crawl.get("ban_duration_seconds", 600),
+            ignored_ips=data.get("ignored_ips") or list(DEFAULT_IGNORED_IPS),
             tarpit_enabled=tarpit.get("enabled", False),
             tarpit_delay_seconds=tarpit.get("delay_seconds", 5),
             log_level=os.getenv(
@@ -366,6 +391,12 @@ def override_config_from_env(config: Config = None):
                     parts = env_value.split(",")
                     if len(parts) == 2:
                         setattr(config, field, (int(parts[0]), int(parts[1])))
+                elif field_type == list[str]:
+                    setattr(
+                        config,
+                        field,
+                        [p.strip() for p in env_value.split(",") if p.strip()],
+                    )
                 else:
                     # Treat empty strings as None for Optional fields (e.g. passwords)
                     setattr(config, field, env_value if env_value else None)

--- a/src/config.py
+++ b/src/config.py
@@ -74,17 +74,13 @@ class Config:
     metrics_enabled: bool = True
 
     # Crawl limiting settings - for legitimate vs malicious crawlers
-    max_pages_limit: int = (
-        100  # Max pages limit for good crawlers and regular users (and bad crawlers/attackers if infinite_pages_for_malicious is False)
-    )
+    max_pages_limit: int = 100  # Max pages limit for good crawlers and regular users (and bad crawlers/attackers if infinite_pages_for_malicious is False)
     infinite_pages_for_malicious: bool = True  # Infinite pages for malicious crawlers
     ban_duration_seconds: int = 600  # Ban duration in seconds for IPs exceeding limits
 
     # IPs/CIDRs to ignore everywhere (never tracked, banned, exported, purged
     # on startup). See DEFAULT_IGNORED_IPS.
-    ignored_ips: list[str] = dc_field(
-        default_factory=lambda: list(DEFAULT_IGNORED_IPS)
-    )
+    ignored_ips: list[str] = dc_field(default_factory=lambda: list(DEFAULT_IGNORED_IPS))
 
     # backup job settings
     backups_path: str = "backups"
@@ -367,10 +363,8 @@ def override_config_from_env(config: Config = None):
     """Initialize configuration from environment variables"""
 
     for field in config.__dataclass_fields__:
-
         env_var = __get_env_from_config(field)
         if env_var in os.environ:
-
             get_app_logger().info(
                 f"Overriding config '{field}' from environment variable '{env_var}'"
             )

--- a/src/config.py
+++ b/src/config.py
@@ -74,7 +74,9 @@ class Config:
     metrics_enabled: bool = True
 
     # Crawl limiting settings - for legitimate vs malicious crawlers
-    max_pages_limit: int = 100  # Max pages limit for good crawlers and regular users (and bad crawlers/attackers if infinite_pages_for_malicious is False)
+    max_pages_limit: int = (
+        100  # Max pages limit for good crawlers and regular users (and bad crawlers/attackers if infinite_pages_for_malicious is False)
+    )
     infinite_pages_for_malicious: bool = True  # Infinite pages for malicious crawlers
     ban_duration_seconds: int = 600  # Ban duration in seconds for IPs exceeding limits
 

--- a/src/database/startup.py
+++ b/src/database/startup.py
@@ -1,0 +1,115 @@
+"""One-time startup maintenance for the Krawl database.
+
+Runs at boot (idempotent, safe every time). Keeps the database consistent with
+rules that were introduced after some data had already been persisted:
+
+- Private/local/reserved IPs should never be tracked, so purge any that
+  predate the tracking guard from every IP-bearing table.
+- Fully expired bans should not linger, so clear stale ban state.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from ip_utils import is_ignored_ip
+from logger import get_app_logger
+from models import (
+    AccessLog,
+    AttackDetection,
+    CategoryHistory,
+    CredentialAttempt,
+    IpStats,
+    TrackedIp,
+)
+
+if TYPE_CHECKING:
+    from database.core import DatabaseManager
+
+applogger = get_app_logger()
+
+# Chunk size for IN() clauses so we stay under SQLite's ~999-variable limit.
+_CHUNK = 500
+
+
+def run_startup_cleanup(
+    db: "DatabaseManager", ban_duration_seconds: int, ignored_ips: list[str]
+) -> dict[str, int]:
+    """Purge ignored IPs and clear expired bans. Returns a summary of counts.
+
+    ``ignored_ips`` is the configured list of IPs/CIDRs to purge (see
+    config.Config.ignored_ips).
+    """
+    session = db.session
+    summary = {"ignored_ips": 0, "expired_bans_cleared": 0}
+    try:
+        # 1. Collect distinct ignored IPs (per the configured list) across
+        #    all IP-bearing tables.
+        matched_ips: set[str] = set()
+        for col in (
+            IpStats.ip,
+            AccessLog.ip,
+            CredentialAttempt.ip,
+            CategoryHistory.ip,
+            TrackedIp.ip,
+        ):
+            for (ip,) in session.query(col).distinct():
+                if ip and is_ignored_ip(ip, ignored_ips):
+                    matched_ips.add(ip)
+
+        # 2. Delete rows for those IPs. attack_detections has an FK to
+        #    access_logs with ON DELETE CASCADE, but SQLite does not enforce
+        #    that unless PRAGMA foreign_keys is on, so delete it explicitly
+        #    first. Chunk the IN() lists to stay under SQLite's variable cap.
+        if matched_ips:
+            ip_list = list(matched_ips)
+            for start in range(0, len(ip_list), _CHUNK):
+                chunk = ip_list[start : start + _CHUNK]
+                log_ids = [
+                    r[0]
+                    for r in session.query(AccessLog.id)
+                    .filter(AccessLog.ip.in_(chunk))
+                    .all()
+                ]
+                for lstart in range(0, len(log_ids), _CHUNK):
+                    lchunk = log_ids[lstart : lstart + _CHUNK]
+                    session.query(AttackDetection).filter(
+                        AttackDetection.access_log_id.in_(lchunk)
+                    ).delete(synchronize_session=False)
+                for model, column in (
+                    (AccessLog, AccessLog.ip),
+                    (CredentialAttempt, CredentialAttempt.ip),
+                    (CategoryHistory, CategoryHistory.ip),
+                    (TrackedIp, TrackedIp.ip),
+                    (IpStats, IpStats.ip),
+                ):
+                    session.query(model).filter(column.in_(chunk)).delete(
+                        synchronize_session=False
+                    )
+            summary["ignored_ips"] = len(matched_ips)
+
+        # 3. Clear expired bans for the remaining (public) IPs. The ban window
+        #    is per-row (ban_multiplier varies), so compute it in Python.
+        now = datetime.now()
+        banned = session.query(IpStats).filter(IpStats.ban_timestamp.isnot(None)).all()
+        for row in banned:
+            multiplier = row.ban_multiplier or 1
+            effective = ban_duration_seconds * multiplier
+            elapsed = (now - row.ban_timestamp).total_seconds()
+            if elapsed > effective:
+                row.ban_timestamp = None
+                row.page_visit_count = 0
+                summary["expired_bans_cleared"] += 1
+
+        session.commit()
+        if summary["ignored_ips"] or summary["expired_bans_cleared"]:
+            applogger.info(
+                f"Startup cleanup: removed {summary['ignored_ips']} ignored IP(s), "
+                f"cleared {summary['expired_bans_cleared']} expired ban(s)"
+            )
+        return summary
+    except Exception as e:
+        session.rollback()
+        applogger.error(f"Startup cleanup failed: {e}")
+        return summary
+    finally:
+        db.close_session()

--- a/src/ip_utils.py
+++ b/src/ip_utils.py
@@ -3,58 +3,74 @@
 """
 IP utility functions for filtering and validating IP addresses.
 Provides common IP filtering logic used across the Krawl honeypot.
+
+The set of IPs to ignore (never track, ban, export, or persist) is
+configurable via the `ignored_ips` config section — a list of single IPs or
+CIDR ranges. See config.DEFAULT_IGNORED_IPS for the built-in defaults.
 """
 
 import ipaddress
+from functools import lru_cache
+
+from logger import get_app_logger
 
 
-def is_local_or_private_ip(ip_str: str) -> bool:
+@lru_cache(maxsize=8)
+def _parse_ignored_networks(entries: tuple[str, ...]) -> tuple:
+    """Parse ignored_ips entries into ip_network objects (cached per entry set).
+
+    Invalid entries are skipped with a warning so one bad line can't break
+    filtering for the rest.
     """
-    Check if an IP address is local, private, or reserved.
+    networks = []
+    for entry in entries:
+        try:
+            networks.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            get_app_logger().warning(f"Ignoring invalid ignored_ips entry: {entry!r}")
+    return tuple(networks)
 
-    Filters out:
-    - 127.0.0.1 (localhost)
-    - 127.0.0.0/8 (loopback)
-    - 10.0.0.0/8 (private network)
-    - 172.16.0.0/12 (private network)
-    - 192.168.0.0/16 (private network)
-    - 0.0.0.0/8 (this network)
-    - ::1 (IPv6 localhost)
-    - ::ffff:127.0.0.0/104 (IPv6-mapped IPv4 loopback)
+
+def is_ignored_ip(ip_str: str, ignored_entries: list[str] | None = None) -> bool:
+    """
+    Check whether an IP should be ignored (never tracked, banned, exported,
+    or persisted), based on the configurable ignored_ips list.
 
     Args:
-        ip_str: IP address string
+        ip_str: IP address string.
+        ignored_entries: Optional explicit list of IP/CIDR strings. When None,
+            the current config's `ignored_ips` is used.
 
     Returns:
-        True if IP is local/private/reserved, False if it's public
+        True if the IP matches the ignore list, or is not a valid IP address
+        (malformed input is treated as ignorable, mirroring the previous guard).
     """
+    if ignored_entries is None:
+        from config import get_config
+
+        ignored_entries = get_config().ignored_ips
+
     try:
         ip = ipaddress.ip_address(ip_str)
-        return (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_reserved
-            or ip.is_link_local
-            or str(ip) in ("0.0.0.0", "::1")  # noqa: S104 — IP comparison, not a bind
-        )
     except ValueError:
-        # Invalid IP address
         return True
+
+    for net in _parse_ignored_networks(tuple(ignored_entries)):
+        if ip.version == net.version and ip in net:
+            return True
+    return False
 
 
 def is_valid_public_ip(ip: str, server_ip: str | None = None) -> bool:
     """
-    Check if an IP is public and not the server's own IP.
-
-    Returns True only if:
-    - IP is not in local/private ranges AND
-    - IP is not the server's own public IP (if server_ip provided)
+    Check if an IP is trackable: not in the ignore list and not the server's
+    own IP.
 
     Args:
-        ip: IP address string to check
-        server_ip: Server's public IP (optional). If provided, filters out this IP too.
+        ip: IP address string to check.
+        server_ip: Server's public IP (optional). If provided, filters it out.
 
     Returns:
-        True if IP is a valid public IP to track, False otherwise
+        True if the IP is a valid public IP to track, False otherwise.
     """
-    return not is_local_or_private_ip(ip) and (server_ip is None or ip != server_ip)
+    return not is_ignored_ip(ip) and (server_ip is None or ip != server_ip)

--- a/src/middleware/ban_check.py
+++ b/src/middleware/ban_check.py
@@ -12,7 +12,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from dependencies import get_client_ip
-from ip_utils import is_local_or_private_ip
+from ip_utils import is_ignored_ip
 
 
 class BanCheckMiddleware(BaseHTTPMiddleware):
@@ -27,7 +27,7 @@ class BanCheckMiddleware(BaseHTTPMiddleware):
 
         # Private/local/reserved IPs (e.g. k8s health-check sources) are never
         # banned, so skip the ban check entirely for them.
-        if is_local_or_private_ip(client_ip):
+        if is_ignored_ip(client_ip):
             return await call_next(request)
 
         tracker = request.app.state.tracker

--- a/src/templates/jinja2/dashboard/partials/timedout_ips_table.html
+++ b/src/templates/jinja2/dashboard/partials/timedout_ips_table.html
@@ -59,7 +59,7 @@
             <td>{{ ip.last_seen | format_ts }}</td>
             <td>
                 <button class="ban-icon-btn ban-icon-unban" onclick="timeoutExemptAction('{{ ip.ip | e }}', 'exempt')" title="Exempt from timeout">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M2.344 2.343h-.001a8 8 0 0 1 11.314 11.314A8.002 8.002 0 0 1 .234 10.089a8 8 0 0 1 2.11-7.746Zm1.06 1.06a6.5 6.5 0 1 0 9.193 9.193L3.404 3.404Zm9.193-1.06a6.5 6.5 0 0 0-9.193 0l9.193 9.193a6.5 6.5 0 0 0 0-9.193Z"/></svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="6.25"/><line x1="3.75" y1="3.75" x2="12.25" y2="12.25"/></svg>
                     <span class="ban-icon-tooltip">Exempt</span>
                 </button>
             </td>

--- a/src/templates/jinja2/dashboard/partials/timedout_ips_table.html
+++ b/src/templates/jinja2/dashboard/partials/timedout_ips_table.html
@@ -42,9 +42,15 @@
     </thead>
     <tbody>
         {% for ip in items %}
-        <tr>
+        <tr class="ip-row" data-ip="{{ ip.ip | e }}">
             <td class="rank">{{ loop.index + (pagination.page - 1) * pagination.page_size }}</td>
-            <td>{{ ip.ip | e }}</td>
+            <td class="ip-clickable"
+                hx-get="{{ dashboard_path }}/htmx/ip-detail/{{ ip.ip | e }}"
+                hx-target="next .ip-stats-row .ip-stats-dropdown"
+                hx-swap="innerHTML"
+                @click="toggleIpDetail($event)">
+                {{ ip.ip | e }}
+            </td>
             <td class="timeout-countdown" data-remaining="{{ ip.remaining_ban_seconds }}" data-ip="{{ ip.ip | e }}">&mdash;</td>
             <td>{{ ip.total_violations }}</td>
             <td>&times;{{ ip.ban_multiplier }}</td>
@@ -56,6 +62,13 @@
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M2.344 2.343h-.001a8 8 0 0 1 11.314 11.314A8.002 8.002 0 0 1 .234 10.089a8 8 0 0 1 2.11-7.746Zm1.06 1.06a6.5 6.5 0 1 0 9.193 9.193L3.404 3.404Zm9.193-1.06a6.5 6.5 0 0 0-9.193 0l9.193 9.193a6.5 6.5 0 0 0 0-9.193Z"/></svg>
                     <span class="ban-icon-tooltip">Exempt</span>
                 </button>
+            </td>
+        </tr>
+        <tr class="ip-stats-row" style="display: none;">
+            <td colspan="9" class="ip-stats-cell">
+                <div class="ip-stats-dropdown">
+                    <div class="loading">Loading stats...</div>
+                </div>
             </td>
         </tr>
         {% else %}

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -5,7 +5,7 @@ import re
 import urllib.parse
 
 from database import DatabaseManager, get_database
-from ip_utils import is_local_or_private_ip
+from ip_utils import is_ignored_ip
 from wordlists import get_wordlists
 
 logger = logging.getLogger("krawl")
@@ -242,7 +242,7 @@ class AccessTracker:
         """
         # Private/local/reserved IPs (e.g. k8s health-check sources) are never
         # tracked, categorized, or banned.
-        if is_local_or_private_ip(ip):
+        if is_ignored_ip(ip):
             return 0
 
         # Skip if this is the server's own IP
@@ -403,7 +403,7 @@ class AccessTracker:
             The updated page visit count for this IP
         """
         # Private/local/reserved IPs are never tracked or banned.
-        if is_local_or_private_ip(client_ip):
+        if is_ignored_ip(client_ip):
             return 0
 
         from config import get_config


### PR DESCRIPTION
This pull request introduces a configurable and extensible system for ignoring specific IP addresses and CIDR ranges across the application. Previously, the logic for ignoring local, private, and reserved IPs was hardcoded; now, it is driven by a new `ignored_ips` config section, allowing operators to customize which IPs are never tracked, banned, exported, or persisted. The changes also include a startup database cleanup to retroactively purge any ignored IPs and expired bans, and refactor all relevant code to use the new system. Additionally, there are improvements to the dashboard's timed-out IPs table for better interactivity.

**Configurable IP Ignore System**

* Added an `ignored_ips` section to `config.yaml` and the `Config` class, with sensible defaults covering loopback, private, link-local, and CGNAT ranges; operators can extend or override this list. [[1]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034R113-R129) [[2]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R6-R30) [[3]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592L59-R84) [[4]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R318)
* Updated environment variable and YAML config parsing to support `ignored_ips` as a comma-separated list.

**Core Logic and Refactoring**

* Replaced the old `is_local_or_private_ip` function with a new `is_ignored_ip` utility, which checks against the configurable ignore list (with caching and robust error handling), and updated all code paths (middleware, tracker, etc.) to use it. [[1]](diffhunk://#diff-7551086f0ce90304604e35a64eb976409eaf148bf22dfdf798a28ecc866a2e0dR6-R76) [[2]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7L15-R15) [[3]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7L30-R30) [[4]](diffhunk://#diff-229deb342c5697840c90530aa1cd46644b4ccacda0439f830d30cf93fd1301f5L8-R8) [[5]](diffhunk://#diff-229deb342c5697840c90530aa1cd46644b4ccacda0439f830d30cf93fd1301f5L245-R245) [[6]](diffhunk://#diff-229deb342c5697840c90530aa1cd46644b4ccacda0439f830d30cf93fd1301f5L406-R406)

**Database Maintenance**

* Added a one-time startup cleanup routine (`run_startup_cleanup`) that purges any ignored IPs from all relevant tables and clears fully expired bans, ensuring the database remains consistent with the new ignore rules. [[1]](diffhunk://#diff-14cf2443a4472192b633ccec115d67e7456b3180ab30fb915a7b76d77740efabR1-R115) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R71-R81)
* Integrated the startup cleanup into the FastAPI app’s lifespan event. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L19-R19) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L111)

**Dashboard Improvements**

* Enhanced the timed-out IPs table with clickable IP rows that dynamically load detailed stats, and updated the exempt icon for improved clarity. [[1]](diffhunk://#diff-2e59272dc230454f7fc15000f42df8210b108a651c1a43ddc40ef08ad91b5c6aL45-R53) [[2]](diffhunk://#diff-2e59272dc230454f7fc15000f42df8210b108a651c1a43ddc40ef08ad91b5c6aL56-R73)

These changes make the IP ignore logic more flexible and robust, improve operational control, and ensure the database and UI stay in sync with operator intent.