### PR TITLE
feat: enhance timed-out IPs table with inspect button

### DIFF
--- a/src/templates/jinja2/dashboard/partials/timedout_ips_table.html
+++ b/src/templates/jinja2/dashboard/partials/timedout_ips_table.html
@@ -37,7 +37,7 @@
             <th>Category</th>
             <th>Location</th>
             <th>Last Seen</th>
-            <th style="width: 40px;"></th>
+            <th style="width: 72px;"></th>
         </tr>
     </thead>
     <tbody>
@@ -58,10 +58,15 @@
             <td>{{ ip.city | default('') | e }}{% if ip.city and ip.country_code %}, {% endif %}{{ ip.country_code | default('N/A') | e }}</td>
             <td>{{ ip.last_seen | format_ts }}</td>
             <td>
-                <button class="ban-icon-btn ban-icon-unban" onclick="timeoutExemptAction('{{ ip.ip | e }}', 'exempt')" title="Exempt from timeout">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="6.25"/><line x1="3.75" y1="3.75" x2="12.25" y2="12.25"/></svg>
-                    <span class="ban-icon-tooltip">Exempt</span>
-                </button>
+                <div style="display: flex; align-items: center; gap: 6px;">
+                    <button class="inspect-btn" @click="openIpInsight('{{ ip.ip | e }}')" title="Inspect IP">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+                    </button>
+                    <button class="ban-icon-btn ban-icon-unban" onclick="timeoutExemptAction('{{ ip.ip | e }}', 'exempt')" title="Exempt from timeout">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="6.25"/><line x1="3.75" y1="3.75" x2="12.25" y2="12.25"/></svg>
+                        <span class="ban-icon-tooltip">Exempt</span>
+                    </button>
+                </div>
             </td>
         </tr>
         <tr class="ip-stats-row" style="display: none;">


### PR DESCRIPTION
This pull request updates the `timedout_ips_table.html` partial to improve the user interface for managing timed-out IP addresses. The main changes include adding a new "Inspect IP" button for each IP entry and adjusting the table layout to accommodate the new action.

**UI improvements for timed-out IP management:**

* Added an "Inspect IP" button (with an icon) next to each IP address, which triggers the `openIpInsight` function for easier inspection of IP details.
* Grouped action buttons in a flex container for better alignment and spacing, enhancing the visual clarity of the actions column.
* Increased the width of the actions column from 40px to 72px to fit the new button layout.