### PR TITLE
Feat: enhance PR linting workflow with auto-fix capabilities

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,7 @@ on:
       - dev
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 
@@ -16,6 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Check out the PR head branch itself (not the detached merge commit)
+          # so we can commit auto-fixes back to it. Using the head repo/ref means
+          # this also works for PRs opened from forks (read-only in that case).
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: actions/setup-python@v5
         with:
@@ -27,6 +33,29 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install black pip-check-reqs ruff
+
+      - name: Apply auto-fixes (ruff --fix & black)
+        run: |
+          ruff check --fix src/ || true
+          black src/
+
+      - name: Commit & push auto-fixes
+        id: autofix
+        # GITHUB_TOKEN is read-only for PRs from forks, so we can only push back
+        # to branches that live in this repository.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No formatting/lint changes to commit."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: apply ruff --fix and black auto-fixes"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Ruff lint & security check
         id: ruff
@@ -41,6 +70,7 @@ jobs:
         env:
           RUFF_REPORT_PATH: ${{ runner.temp }}/ruff-report.txt
           EXIT_CODE: ${{ steps.ruff.outputs.exit_code }}
+          PUSHED: ${{ steps.autofix.outputs.pushed }}
         with:
           script: |
             const fs = require('fs');
@@ -48,6 +78,12 @@ jobs:
             const reportPath = process.env.RUFF_REPORT_PATH;
             const exitCode = process.env.EXIT_CODE;
             const hasFailed = exitCode !== '0';
+            // 'pushed' is 'true' only when CI committed fixes back to this repo's
+            // branch; it's empty for fork PRs (where CI can't push).
+            const canPush = process.env.PUSHED === 'true' || process.env.PUSHED === 'false';
+            const autofixNote = canPush
+              ? 'Auto-fixable issues have already been fixed and pushed to this branch by CI (\`ruff --fix\` + \`black\`). The issues below **could not be fixed automatically** and must be addressed manually'
+              : 'This PR appears to come from a fork, so CI could not push auto-fixes. Run \`ruff check --fix src/\` and \`black src/\` locally and push. The issues below also include ones that **cannot be fixed automatically**';
 
             let body;
             if (hasFailed) {
@@ -55,7 +91,7 @@ jobs:
               body = `${marker}
             ### Ruff — lint & security issues
 
-            The following issues were found by Ruff (includes linting rules and security checks via \`S\` / Bandit rules).
+            ${autofixNote} (includes linting rules and security checks via \`S\` / Bandit rules).
 
             <details>
             <summary>View full report</summary>
@@ -66,11 +102,11 @@ jobs:
 
             </details>
 
-            **To fix auto-fixable issues locally:**
+            **Tip:** pull the latest changes first (\`git pull\`), then try:
             \`\`\`sh
             ruff check --fix --unsafe-fixes src/
             \`\`\`
-            Then address any remaining \`S\` (security) findings manually.`;
+            and address any remaining \`S\` (security) findings manually.`;
             } else {
               body = `${marker}
             ### Ruff — lint & security issues


### PR DESCRIPTION
This pull request updates the `pr-checks.yml` GitHub Actions workflow to automatically apply formatting and lint fixes using `ruff --fix` and `black`, and to push those fixes directly to pull request branches when possible. It also improves the PR feedback comment to clarify when auto-fixes have been applied or when manual intervention is needed, especially for PRs from forks.

**Automated code formatting and linting:**

* The workflow now checks out the PR head branch directly, allowing CI to commit and push auto-fixes back to the branch, including support for PRs from forks (read-only in that case). (`.github/workflows/pr-checks.yml`)
* After installing dependencies, the workflow runs `ruff check --fix` and `black` on the `src/` directory to apply automatic formatting and lint fixes. (`.github/workflows/pr-checks.yml`)
* If any changes are made, CI commits and pushes them back to the branch automatically, but only if the PR is from the same repository (not a fork). (`.github/workflows/pr-checks.yml`)

**Permissions and workflow configuration:**

* Increases the `contents` permission from `read` to `write` to allow CI to push commits back to PR branches. (`.github/workflows/pr-checks.yml`)

**Improved PR feedback and instructions:**

* The comment left on the PR now clearly explains whether auto-fixes were applied by CI or if manual action is needed (e.g., for PRs from forks), and updates the instructions for running auto-fixes locally. (`.github/workflows/pr-checks.yml`) [[1]](diffhunk://#diff-1da7a27709d11ac16eef3de8e46ed10672b7b1d63a790ffbcbd23a94b19efdcbR73-R94) [[2]](diffhunk://#diff-1da7a27709d11ac16eef3de8e46ed10672b7b1d63a790ffbcbd23a94b19efdcbL69-R109)