### PR TITLE
Fix: update commit message to include [skip ci] for auto-fixes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -53,7 +53,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "style: apply ruff --fix and black auto-fixes"
+          # "[skip ci]" stops this bot commit from re-triggering the PR workflow,
+          # which would otherwise spawn a second run that needs maintainer approval.
+          git commit -m "style: apply ruff --fix and black auto-fixes [skip ci]"
           git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
This pull request makes a minor update to the PR workflow to prevent unnecessary workflow runs when bot commits are pushed. The commit message for style auto-fixes now includes "[skip ci]" to avoid triggering another CI run.

* Updated the commit message in `.github/workflows/pr-checks.yml` for style auto-fix bot commits to include "[skip ci]", preventing these commits from re-triggering the workflow and requiring extra maintainer approval.