### PR TITLE
fix: update PR checks to handle forked pull requests correctly

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,6 +35,10 @@ jobs:
           pip install black pip-check-reqs ruff
 
       - name: Apply auto-fixes (ruff --fix & black)
+        # Only auto-fix on same-repo PRs, where we can push the result back.
+        # On fork PRs we skip this so the checks below validate the *submitted*
+        # code rather than a locally-fixed tree (which would give a false pass).
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           ruff check --fix src/ || true
           black src/
@@ -67,7 +71,9 @@ jobs:
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Comment Ruff findings on PR
-        if: github.event_name == 'pull_request'
+        # GITHUB_TOKEN is read-only for fork PRs, so commenting would 403.
+        # Skip on forks; the Ruff/Black/deps checks below still gate the PR.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         env:
           RUFF_REPORT_PATH: ${{ runner.temp }}/ruff-report.txt


### PR DESCRIPTION
This pull request updates the `.github/workflows/pr-checks.yml` workflow to improve security and accuracy when handling pull requests from forks versus same-repo branches. The key changes ensure that auto-fix steps and PR comments are only performed when the PR originates from the same repository, avoiding issues with permissions and ensuring checks reflect the submitted code.

Workflow behavior changes:

* Restricted the auto-fix step (`ruff --fix` and `black`) to only run on same-repo pull requests, preventing auto-fixes on forked PRs so that checks validate the submitted code as-is.
* Updated the PR comment step for Ruff findings to only execute on same-repo pull requests, avoiding permission errors on forked PRs where the `GITHUB_TOKEN` is read-only.