### PR TITLE
fix: change workflow runners to self-hosted insted of ubuntu-latest

### DIFF
--- a/.github/workflows/kubernetes-validation.yml
+++ b/.github/workflows/kubernetes-validation.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   validate-manifests:
     name: Validate Kubernetes Manifests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,10 +23,14 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-          cache: 'pip'
+      # Self-hosted Debian runner: actions/setup-python can't fetch a prebuilt
+      # Python for this distro, so use the interpreter already installed and
+      # isolate installs in a venv (avoids PEP 668 / polluting the runner).
+      # Prereq on the runner: python3 + python3-venv (matching 3.13).
+      - name: Set up Python venv
+        run: |
+          python3 -m venv "$RUNNER_TEMP/venv"
+          echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   lint-and-test:
     name: Lint & Dependency Checks
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   security-checks:
     name: Security & Dependencies
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,10 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-          cache: 'pip'
+      # Self-hosted Debian runner: actions/setup-python can't fetch a prebuilt
+      # Python for this distro, so use the interpreter already installed and
+      # isolate installs in a venv (avoids PEP 668 / polluting the runner).
+      # Prereq on the runner: python3 + python3-venv (matching 3.13).
+      - name: Set up Python venv
+        run: |
+          python3 -m venv "$RUNNER_TEMP/venv"
+          echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update_banlist.yml
+++ b/.github/workflows/update_banlist.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   fetch-and-pr:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use self-hosted runners instead of the default GitHub-hosted runners. This change affects several workflows related to linting, security scanning, Kubernetes manifest validation, and the banlist update process.

**Workflow runner changes:**

* Updated the `runs-on` parameter from `ubuntu-latest` to `self-hosted` in the following workflow jobs:
  - `lint-and-test` job in `.github/workflows/pr-checks.yml`
  - `security-checks` job in `.github/workflows/security-scan.yml`
  - `validate-manifests` job in `.github/workflows/kubernetes-validation.yml`
  - `fetch-and-pr` job in `.github/workflows/update_banlist.yml`