### PR TITLE
feat: change runners to self-hosted for Helm chart and Docker build v…

### DIFF
--- a/.github/workflows/kubernetes-validation.yml
+++ b/.github/workflows/kubernetes-validation.yml
@@ -43,7 +43,7 @@ jobs:
 
   validate-helm:
     name: Validate Helm Chart
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -164,7 +164,7 @@ jobs:
 
   build-docker:
     name: Build Docker
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use self-hosted runners instead of the default `ubuntu-latest` runners for certain jobs. This change is aimed at improving control over the build environment or optimizing CI resource usage.

**Workflow runner configuration:**

* [`.github/workflows/kubernetes-validation.yml`](diffhunk://#diff-96e0ea70295078e10b7c701c0ac140b7c16d87c2cc613e9171ffd48477087253L46-R46): Changed the `validate-helm` job to run on a self-hosted runner instead of `ubuntu-latest`.
* [`.github/workflows/pr-checks.yml`](diffhunk://#diff-1da7a27709d11ac16eef3de8e46ed10672b7b1d63a790ffbcbd23a94b19efdcbL167-R167): Changed the `build-docker` job to run on a self-hosted runner instead of `ubuntu-latest`.…alidation