### PR TITLE
Feat: improved expanded tabs and externally-managed secrets

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.2.9
-appVersion: 2.2.9
+version: 2.2.10
+appVersion: 2.2.10
 keywords:
   - honeypot
   - security

--- a/helm/README.md
+++ b/helm/README.md
@@ -255,6 +255,10 @@ The Krawl service already includes `externalTrafficPolicy: Local` by default to 
 |-----------|-------------|---------|
 | `config.dashboard.secret_path` | Secret dashboard path (auto-generated if null) | `null` |
 | `dashboardPassword` | Password for protected panels (injected via Secret as `KRAWL_DASHBOARD_PASSWORD` env, auto-generated if empty) | `""` |
+| `dashboardExistingSecret` | Use an externally-managed Secret for the dashboard password (key `dashboardExistingSecretKey`, default `dashboard-password`). When set, the chart-managed Secret is not created. | `""` |
+| `dashboardExistingSecretKey` | Key in `dashboardExistingSecret` holding the dashboard password | `dashboard-password` |
+| `dashboardPathExistingSecret` | Use an externally-managed Secret for the dashboard secret path (key `dashboardPathExistingSecretKey`, default `dashboard-path`). When set, `KRAWL_DASHBOARD_SECRET_PATH` is injected from this Secret and overrides `config.dashboard.secret_path` at runtime. | `""` |
+| `dashboardPathExistingSecretKey` | Key in `dashboardPathExistingSecret` holding the dashboard path | `dashboard-path` |
 
 ### API Configuration
 
@@ -286,8 +290,8 @@ The Krawl service already includes `externalTrafficPolicy: Local` by default to 
 | `postgres.user` | PostgreSQL username | `krawl` |
 | `postgres.password` | PostgreSQL password | `krawl` |
 | `postgres.database` | PostgreSQL database name | `krawl` |
-| `postgres.existingSecret` | Use an existing Secret for the password | `` |
-| `postgres.existingSecretKey` | Key in the existing Secret | `postgres-password` |
+| `postgres.existingSecret` | Use an externally-managed Secret for the PostgreSQL password (skips chart-managed Secret for Postgres, used by Krawl Deployment, bundled StatefulSet, and the migration Job) | `` |
+| `postgres.existingSecretKey` | Key in `postgres.existingSecret` holding the password | `postgres-password` |
 | `postgres.image.repository` | PostgreSQL image repository (bundled only) | `postgres` |
 
 | `postgres.image.tag` | PostgreSQL image tag | `16-alpine` |
@@ -307,8 +311,8 @@ The Krawl service already includes `externalTrafficPolicy: Local` by default to 
 | `redis.port` | Redis port | `6379` |
 | `redis.db` | Redis database number | `0` |
 | `redis.password` | Redis password | `` |
-| `redis.existingSecret` | Use an existing Secret for the password | `` |
-| `redis.existingSecretKey` | Key in the existing Secret | `redis-password` |
+| `redis.existingSecret` | Use an externally-managed Secret for the Redis password (skips chart-managed Secret for Redis, used by Krawl Deployment and bundled StatefulSet) | `` |
+| `redis.existingSecretKey` | Key in `redis.existingSecret` holding the password | `redis-password` |
 | `redis.image.repository` | Redis image repository (bundled only) | `redis` |
 | `redis.image.tag` | Redis image tag | `7-alpine` |
 | `redis.image.pullPolicy` | Image pull policy | `IfNotPresent` |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -58,3 +58,43 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve the PostgreSQL Secret name to reference for credentials.
+Prefers an operator-supplied existing Secret; falls back to the chart-managed
+Secret. Returns the Secret name and key as a pair via a dict so templates can
+share the same resolution logic.
+*/}}
+{{- define "krawl.postgres.secret" -}}
+{{- $name := .Values.postgres.existingSecret | default (printf "%s-postgres" (include "krawl.fullname" .)) }}
+{{- $key := .Values.postgres.existingSecretKey | default "postgres-password" }}
+{{- dict "name" $name "key" $key | toJson }}
+{{- end }}
+
+{{/*
+Resolve the Redis Secret name/key to reference for credentials.
+*/}}
+{{- define "krawl.redis.secret" -}}
+{{- $name := .Values.redis.existingSecret | default (printf "%s-redis" (include "krawl.fullname" .)) }}
+{{- $key := .Values.redis.existingSecretKey | default "redis-password" }}
+{{- dict "name" $name "key" $key | toJson }}
+{{- end }}
+
+{{/*
+Resolve the Dashboard password Secret name/key to reference.
+*/}}
+{{- define "krawl.dashboard.secret" -}}
+{{- $name := .Values.dashboardExistingSecret | default (printf "%s-dashboard" (include "krawl.fullname" .)) }}
+{{- $key := .Values.dashboardExistingSecretKey | default "dashboard-password" }}
+{{- dict "name" $name "key" $key | toJson }}
+{{- end }}
+
+{{/*
+Resolve the Dashboard secret path Secret name/key to reference.
+Empty when no external Secret is configured (path auto-generates from config).
+*/}}
+{{- define "krawl.dashboardPath.secret" -}}
+{{- $name := .Values.dashboardPathExistingSecret | default "" }}
+{{- $key := .Values.dashboardPathExistingSecretKey | default "dashboard-path" }}
+{{- dict "name" $name "key" $key | toJson }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -66,12 +66,19 @@ spec:
         - name: TZ
           value: {{ .Values.timezone | quote }}
         {{- end }}
-        {{- if .Values.dashboardPassword }}
+        {{- if or .Values.dashboardPassword .Values.dashboardExistingSecret }}
         - name: KRAWL_DASHBOARD_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "krawl.fullname" . }}-dashboard
-              key: dashboard-password
+              name: {{ (include "krawl.dashboard.secret" . | fromJson).name }}
+              key: {{ (include "krawl.dashboard.secret" . | fromJson).key }}
+        {{- end }}
+        {{- if .Values.dashboardPathExistingSecret }}
+        - name: KRAWL_DASHBOARD_SECRET_PATH
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.dashboardPathExistingSecret }}
+              key: {{ .Values.dashboardPathExistingSecretKey | default "dashboard-path" }}
         {{- end }}
         {{- if .Values.config.ai.api_key }}
         - name: KRAWL_AI_API_KEY
@@ -96,8 +103,8 @@ spec:
         - name: KRAWL_POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "krawl.fullname" . }}-postgres
-              key: postgres-password
+              name: {{ (include "krawl.postgres.secret" . | fromJson).name }}
+              key: {{ (include "krawl.postgres.secret" . | fromJson).key }}
         - name: KRAWL_POSTGRES_DATABASE
           value: {{ .Values.postgres.database | quote }}
         - name: KRAWL_REDIS_HOST
@@ -106,12 +113,12 @@ spec:
           value: {{ .Values.redis.port | quote }}
         - name: KRAWL_REDIS_DB
           value: {{ .Values.redis.db | quote }}
-        {{- if .Values.redis.password }}
+        {{- if or .Values.redis.password .Values.redis.existingSecret }}
         - name: KRAWL_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "krawl.fullname" . }}-redis
-              key: redis-password
+              name: {{ (include "krawl.redis.secret" . | fromJson).name }}
+              key: {{ (include "krawl.redis.secret" . | fromJson).key }}
         {{- end }}
         - name: KRAWL_REDIS_CACHE_TTL
           value: {{ .Values.redis.cache_ttl | default 600 | quote }}

--- a/helm/templates/migration-job.yaml
+++ b/helm/templates/migration-job.yaml
@@ -65,8 +65,8 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "krawl.fullname" . }}-postgres
-              key: postgres-password
+              name: {{ (include "krawl.postgres.secret" . | fromJson).name }}
+              key: {{ (include "krawl.postgres.secret" . | fromJson).key }}
         volumeMounts:
         - name: database
           mountPath: /app/data

--- a/helm/templates/postgres.yaml
+++ b/helm/templates/postgres.yaml
@@ -73,8 +73,8 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "krawl.fullname" . }}-postgres
-              key: postgres-password
+              name: {{ (include "krawl.postgres.secret" . | fromJson).name }}
+              key: {{ (include "krawl.postgres.secret" . | fromJson).key }}
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
         {{- if .Values.postgres.persistence.enabled }}

--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -74,8 +74,8 @@ spec:
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "krawl.fullname" . }}-redis
-              key: redis-password
+              name: {{ (include "krawl.redis.secret" . | fromJson).name }}
+              key: {{ (include "krawl.redis.secret" . | fromJson).key }}
         {{- end }}
         {{- if .Values.redis.persistence.enabled }}
         volumeMounts:

--- a/helm/templates/secret-scalable.yaml
+++ b/helm/templates/secret-scalable.yaml
@@ -1,4 +1,5 @@
 {{- if or (eq .Values.mode "scalable") .Values.migration.enabled }}
+{{- if not .Values.postgres.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +10,8 @@ type: Opaque
 stringData:
   postgres-password: {{ .Values.postgres.password | quote }}
 ---
-{{- if .Values.redis.password }}
+{{- end }}
+{{- if and .Values.redis.password (not .Values.redis.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dashboardPassword }}
+{{- if and .Values.dashboardPassword (not .Values.dashboardExistingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -84,6 +84,21 @@ affinity: {}
 # Dashboard password for protected panels
 # If empty, a random password will be auto-generated and printed in the logs
 dashboardPassword: ""
+# Reference an externally-managed Secret for the dashboard password instead of
+# the chart-managed Secret created from `dashboardPassword`. The Secret must
+# contain the password under the key set by `dashboardExistingSecretKey`
+# (default "dashboard-password").
+dashboardExistingSecret: ""
+dashboardExistingSecretKey: "dashboard-password"
+
+# Reference an externally-managed Secret for the dashboard secret path
+# (config.dashboard.secret_path). Set this when the secret path is provisioned
+# out-of-band, e.g. by ExternalSecrets / SealedSecrets / Vault. The Secret must
+# contain the path under `dashboardPathExistingSecretKey` (default
+# "dashboard-path"). When set, the env var KRAWL_DASHBOARD_SECRET_PATH is
+# injected from this Secret, overriding whatever is in config.dashboard.secret_path.
+dashboardPathExistingSecret: ""
+dashboardPathExistingSecretKey: "dashboard-path"
 
 # Application configuration (config.yaml structure)
 config:
@@ -220,9 +235,15 @@ postgres:
   user: "krawl"
   password: "krawl"
   database: "krawl"
-  # Use an existing secret for the PostgreSQL password instead of plaintext
-  # existingSecret: ""
-  # existingSecretKey: "postgres-password"
+  # Use an externally-managed Secret for the PostgreSQL password instead of the
+  # plaintext `password` field. The Secret must contain the password under the
+  # key set by `existingSecretKey` (default "postgres-password"). When set, the
+  # chart-managed Secret for postgres is not created and the PostgreSQL
+  # StatefulSet + Krawl Deployment + migration Job all read the password from
+  # this Secret. Combine with `postgres.enabled: false` to point at a fully
+  # external instance.
+  existingSecret: ""
+  existingSecretKey: "postgres-password"
   image:
     repository: postgres
     tag: "16-alpine"
@@ -252,9 +273,14 @@ redis:
   cache_ttl: 600    # Dashboard warmup data (default: 10 minutes)
   hot_ttl: 30       # Hot-path data like ban info (default: 30 seconds)
   table_ttl: 120    # Paginated dashboard tables (default: 2 minutes)
-  # Use an existing secret for the Redis password instead of plaintext
-  # existingSecret: ""
-  # existingSecretKey: "redis-password"
+  # Use an externally-managed Secret for the Redis password instead of the
+  # plaintext `password` field. The Secret must contain the password under the
+  # key set by `existingSecretKey` (default "redis-password"). When set, the
+  # chart-managed Secret for redis is not created and the Redis StatefulSet +
+  # Krawl Deployment both read the password from this Secret. Set
+  # `redis.enabled: false` to use a fully external Redis instance.
+  existingSecret: ""
+  existingSecretKey: "redis-password"
   image:
     repository: redis
     tag: "7-alpine"

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -31,7 +31,56 @@ kubectl get secret krawl-server -n krawl-system \
 
 ### Setting Dashboard Password
 
-To set a custom password for protected dashboard panels, create the `secret.yaml` manifest (see `kubernetes/manifests/secret.yaml`) and uncomment the `KRAWL_DASHBOARD_PASSWORD` env var in the deployment. If not set, a random password is auto-generated and printed in the pod logs.
+To set a custom password for protected dashboard panels, create a Secret and uncomment the `KRAWL_DASHBOARD_PASSWORD` env var in the deployment. If not set, a random password is auto-generated and printed in the pod logs.
+
+```bash
+kubectl create secret generic krawl-dashboard \
+  --namespace krawl-system \
+  --from-literal=dashboard-password='your-strong-password'
+```
+
+### Externally-Managed Secrets (Postgres / Redis / Dashboard / Dashboard Path)
+
+The all-in-one manifest ships with a built-in `krawl-postgres` Secret holding the
+default `krawl` password. To use credentials managed out-of-band (ExternalSecrets,
+SealedSecrets, Vault, cloud secret stores, etc.), supply your own Secret and edit
+the `secretKeyRef` entries in the manifest to point at it. The relevant locations
+are the `KRAWL_POSTGRES_PASSWORD` env on both the Krawl Deployment and the
+`krawl-postgres` StatefulSet, and (for the optional extras) the commented-out
+`KRAWL_DASHBOARD_PASSWORD`, `KRAWL_DASHBOARD_SECRET_PATH`, and `KRAWL_REDIS_PASSWORD`
+env vars on the Krawl Deployment.
+
+Example: bring your own Postgres Secret.
+
+```bash
+kubectl create secret generic my-pg-creds \
+  --namespace krawl-system \
+  --from-literal=postgres-password='supersecret'
+```
+
+Then in `kubernetes/krawl-all-in-one-deploy.yaml` replace every occurrence of
+
+```yaml
+secretKeyRef:
+  name: krawl-postgres
+  key: postgres-password
+```
+
+with
+
+```yaml
+secretKeyRef:
+  name: my-pg-creds
+  key: postgres-password
+```
+
+For dashboard password / dashboard path / Redis password, create a Secret (using
+keys `dashboard-password`, `dashboard-path`, and `redis-password` respectively)
+and uncomment the corresponding env-var blocks already present in the deployment.
+
+The Helm chart exposes the same flexibility via `postgres.existingSecret`,
+`redis.existingSecret`, `dashboardExistingSecret`, and `dashboardPathExistingSecret`
+— see the [Helm chart documentation](../helm/README.md) for the full reference.
 
 ### From Source (Python 3.13+)
 

--- a/kubernetes/krawl-all-in-one-deploy.yaml
+++ b/kubernetes/krawl-all-in-one-deploy.yaml
@@ -489,6 +489,29 @@ spec:
         env:
         - name: CONFIG_LOCATION
           value: "config.yaml"
+        # Optional: pull dashboard password from an externally-managed Secret
+        # (e.g. via ExternalSecrets / SealedSecrets / Vault). Uncomment and
+        # create the Secret under key `dashboard-password` to enable.
+        # - name: KRAWL_DASHBOARD_PASSWORD
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: krawl-dashboard
+        #       key: dashboard-password
+        # Optional: pull the dashboard secret path from an externally-managed
+        # Secret. When set, this overrides config.dashboard.secret_path at
+        # runtime, so the path no longer has to live in plaintext config.
+        # - name: KRAWL_DASHBOARD_SECRET_PATH
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: krawl-dashboard
+        #       key: dashboard-path
+        # Optional: pull Redis password from an externally-managed Secret. The
+        # bundled Redis ships with no password; uncomment to require one.
+        # - name: KRAWL_REDIS_PASSWORD
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: krawl-redis
+        #       key: redis-password
         - name: KRAWL_MODE
           value: "scalable"
         - name: KRAWL_POSTGRES_HOST

--- a/src/database/access_logs.py
+++ b/src/database/access_logs.py
@@ -7,7 +7,7 @@ as hot paths.
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import distinct, func
+from sqlalchemy import distinct, func, or_
 from sqlalchemy.orm import joinedload
 
 from logger import get_app_logger
@@ -235,6 +235,88 @@ class AccessLogRepo:
                 }
                 for log in logs
             ]
+        finally:
+            self._db.close_session()
+
+    def get_recent_suspicious_paginated(
+        self,
+        page: int = 1,
+        page_size: int = 25,
+        search: str | None = None,
+        sort_order: str = "desc",
+    ) -> dict[str, Any]:
+        """
+        Paginated recent suspicious access attempts (excludes local/private IPs and server IP).
+
+        Args:
+            page: Page number (1-indexed)
+            page_size: Number of results per page
+            search: Optional case-insensitive substring filter on IP/path/user-agent
+            sort_order: 'asc' or 'desc' (by timestamp)
+
+        Returns:
+            Dictionary with `items` list and `pagination` info.
+        """
+        session = self._db.session
+        try:
+            from config import get_config
+
+            config = get_config()
+            server_ip = config.get_server_ip()
+
+            sort_order = sort_order.lower()
+            if sort_order not in {"asc", "desc"}:
+                sort_order = "desc"
+            order = (
+                AccessLog.timestamp.asc()
+                if sort_order == "asc"
+                else AccessLog.timestamp.desc()
+            )
+
+            query = (
+                session.query(AccessLog)
+                .options(joinedload(AccessLog.attack_detections))
+                .filter(AccessLog.is_suspicious)
+                .order_by(order)
+            )
+            query = self._db._public_ip_filter(query, AccessLog.ip, server_ip)
+
+            if search:
+                like = f"%{search}%"
+                query = query.filter(
+                    or_(
+                        AccessLog.ip.ilike(like),
+                        AccessLog.path.ilike(like),
+                        AccessLog.user_agent.ilike(like),
+                    )
+                )
+
+            total = query.count()
+            offset = (page - 1) * page_size
+            logs = query.offset(offset).limit(page_size).all()
+            total_pages = (total + page_size - 1) // page_size
+
+            items = [
+                {
+                    "ip": log.ip,
+                    "path": log.path,
+                    "user_agent": log.user_agent,
+                    "method": log.method,
+                    "timestamp": log.timestamp.isoformat() if log.timestamp else None,
+                    "log_id": log.id,
+                    "attack_types": [d.attack_type for d in log.attack_detections],
+                }
+                for log in logs
+            ]
+            return {
+                "items": items,
+                "pagination": {
+                    "page": page,
+                    "page_size": page_size,
+                    "total": total,
+                    "total_pages": max(1, total_pages),
+                },
+            }
         finally:
             self._db.close_session()
 

--- a/src/database/analytics.py
+++ b/src/database/analytics.py
@@ -373,6 +373,8 @@ class AnalyticsRepo:
         sort_order: str = "desc",
         ip_filter: str | None = None,
         attack_type_filter: str | None = None,
+        search: str | None = None,
+        method_filter: str | None = None,
     ) -> dict[str, Any]:
         """
         Retrieve paginated list of detected attack types with access logs.
@@ -384,6 +386,8 @@ class AnalyticsRepo:
             sort_order: Sort order (asc or desc)
             ip_filter: Optional IP address to filter results
             attack_type_filter: Optional attack type to filter results
+            search: Optional case-insensitive substring filter across IP/path/user-agent
+            method_filter: Optional HTTP method filter (e.g. GET, POST)
 
         Returns:
             Dictionary with attacks list and pagination info
@@ -424,6 +428,19 @@ class AnalyticsRepo:
             match_filters = [detection_exists.exists()]
             if ip_filter:
                 match_filters.append(AccessLog.ip == ip_filter)
+            if method_filter:
+                match_filters.append(
+                    func.upper(AccessLog.method) == method_filter.upper()
+                )
+            if search:
+                like = f"%{search}%"
+                match_filters.append(
+                    or_(
+                        AccessLog.ip.ilike(like),
+                        AccessLog.path.ilike(like),
+                        AccessLog.user_agent.ilike(like),
+                    )
+                )
 
             # Count total matching access logs.
             total_attacks = (

--- a/src/routes/htmx.py
+++ b/src/routes/htmx.py
@@ -531,14 +531,27 @@ async def htmx_credentials(
 async def htmx_attacks(
     request: Request,
     page: int = Query(1),
+    page_size: int = Query(15),
     sort_by: str = Query("timestamp"),
     sort_order: str = Query("desc"),
     ip_filter: str = Query(None),
     attack_type_filter: str = Query(None),
+    search: str = Query(""),
+    method_filter: str = Query(None),
 ):
     page = max(1, page)
-    cache_key = f"attacks:{page}:{sort_by}:{sort_order}:{ip_filter or ''}:{attack_type_filter or ''}"
-    cached = get_cached_table(cache_key)
+    page_size = max(1, min(int(page_size), 200))
+    search = search.strip() or None
+    method_filter = (method_filter or "").strip().upper() or None
+    # Validate page_size for the inline dashboard (must match the cached size to
+    # use cached results). When the expand overlay requests a different page
+    # size (e.g. 25), skip the cache so cached pages don't bleed across sizes.
+    use_cache = page_size == 15
+    cache_key = (
+        f"attacks:{page}:{sort_by}:{sort_order}:{ip_filter or ''}:"
+        f"{attack_type_filter or ''}:{search or ''}:{method_filter or ''}"
+    )
+    cached = get_cached_table(cache_key) if use_cache else None
     if cached:
         result = cached
     else:
@@ -546,13 +559,16 @@ async def htmx_attacks(
         result = await asyncio.to_thread(
             db.analytics.get_attack_types_paginated,
             page=page,
-            page_size=15,
+            page_size=page_size,
             sort_by=sort_by,
             sort_order=sort_order,
             ip_filter=ip_filter,
             attack_type_filter=attack_type_filter,
+            search=search,
+            method_filter=method_filter,
         )
-        set_cached_table(cache_key, result)
+        if use_cache:
+            set_cached_table(cache_key, result)
 
     # Transform attack data for template (join attack_types list, map id to log_id)
     items = []
@@ -582,8 +598,69 @@ async def htmx_attacks(
             "sort_order": sort_order,
             "ip_filter": ip_filter or "",
             "attack_type_filter": attack_type_filter or "",
+            "search": search or "",
+            "method_filter": method_filter or "",
         },
     )
+
+
+# ── Recent Suspicious Activity (paginated for expand overlay) ────────
+
+
+@router.get("/htmx/suspicious")
+async def htmx_suspicious(
+    request: Request,
+    page: int = Query(1),
+    page_size: int = Query(25),
+    search: str = Query(""),
+    sort_order: str = Query("desc"),
+):
+    page = max(1, page)
+    page_size = max(1, min(int(page_size), 200))
+    search = search.strip() or None
+
+    cache_key = f"suspicious:{page}:{page_size}:{sort_order}:{search or ''}"
+    cached = get_cached_table(cache_key)
+    if cached:
+        result = cached
+    else:
+        db = get_db()
+        result = await asyncio.to_thread(
+            db.access_logs.get_recent_suspicious_paginated,
+            page=page,
+            page_size=page_size,
+            search=search,
+            sort_order=sort_order,
+        )
+        set_cached_table(cache_key, result)
+
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/suspicious_expand_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "items": result["items"],
+            "pagination": result["pagination"],
+            "sort_order": sort_order,
+            "search": search or "",
+        },
+    )
+
+
+# ── Attack types list (for filter dropdown in expand overlay) ────────
+
+
+@router.get("/htmx/attack-types-list")
+async def htmx_attack_types_list(request: Request):
+    """Return the list of distinct attack types for the expand overlay filter.
+    Rendered as a JSON response for client-side consumption."""
+    db = get_db()
+    stats = await asyncio.to_thread(db.analytics.get_attack_types_stats, limit=100)
+    types = [item["type"] for item in stats.get("attack_types", []) if item.get("type")]
+    from fastapi.responses import JSONResponse
+
+    return JSONResponse({"attack_types": types})
 
 
 # ── Attack Patterns ──────────────────────────────────────────────────

--- a/src/templates/jinja2/dashboard/index.html
+++ b/src/templates/jinja2/dashboard/index.html
@@ -178,7 +178,12 @@
 
         {# Attack Types table #}
         <div class="table-container alert-section">
-            <h2>Detected Attack Types</h2>
+            <div style="display: flex; justify-content: space-between; align-items: flex-start;">
+                <h2>Detected Attack Types</h2>
+                <button class="expand-btn" onclick="openExpandOverlay('Detected Attack Types', 'attacks', 25)" title="Expand">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5H4.56l2.72 2.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L3.5 4.56v2.69a.75.75 0 0 1-1.5 0v-3.5A1.75 1.75 0 0 1 3.75 2Zm8.5 12h-3.5a.75.75 0 0 1 0-1.5h2.69l-2.72-2.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.72 2.72v-2.69a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14Z"/></svg>
+                </button>
+            </div>
             <div id="attacks-htmx-container" class="htmx-container"
                  hx-get="{{ dashboard_path }}/htmx/attacks?page=1"
                  hx-trigger="revealed"

--- a/src/templates/jinja2/dashboard/partials/attack_types_table.html
+++ b/src/templates/jinja2/dashboard/partials/attack_types_table.html
@@ -1,27 +1,41 @@
 {# HTMX fragment: Detected Attack Types table #}
-{% set filter_qs %}{% if ip_filter %}&ip_filter={{ ip_filter }}{% endif %}{% if attack_type_filter %}&attack_type_filter={{ attack_type_filter }}{% endif %}{% endset %}
+{% set filter_qs %}{% if ip_filter %}&ip_filter={{ ip_filter }}{% endif %}{% if attack_type_filter %}&attack_type_filter={{ attack_type_filter | e }}{% endif %}{% if search %}&search={{ search | e }}{% endif %}{% if method_filter %}&method_filter={{ method_filter | e }}{% endif %}{% endset %}
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-    <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
         <span class="pagination-info">Page {{ pagination.page }}/{{ pagination.total_pages }} &mdash; {{ pagination.total }} total</span>
         {% if attack_type_filter %}
-        <span style="display: inline-flex; align-items: center; gap: 6px; background: rgba(88, 166, 255, 0.1); color: #58a6ff; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 500;">
-            {{ attack_type_filter }}
+        <span class="filter-pill" style="display: inline-flex; align-items: center; gap: 6px; background: rgba(88, 166, 255, 0.1); color: #58a6ff; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 500;">
+            {{ attack_type_filter | e }}
             <span style="cursor: pointer; opacity: 0.7; font-size: 1.1em;"
-                  hx-get="{{ dashboard_path }}/htmx/attacks?page=1&sort_by={{ sort_by }}&sort_order={{ sort_order }}{% if ip_filter %}&ip_filter={{ ip_filter }}{% endif %}"
-                  hx-target="closest .htmx-container"
-                  hx-swap="innerHTML"
+                  onclick="clearExpandFilter('attackType')"
                   title="Clear filter">&times;</span>
+        </span>
+        {% endif %}
+        {% if method_filter %}
+        <span class="filter-pill" style="display: inline-flex; align-items: center; gap: 6px; background: rgba(63, 185, 80, 0.12); color: #3fb950; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 500;">
+            {{ method_filter | e }}
+            <span style="cursor: pointer; opacity: 0.7; font-size: 1.1em;"
+                  onclick="clearExpandFilter('method')"
+                  title="Clear method">&times;</span>
+        </span>
+        {% endif %}
+        {% if search %}
+        <span class="filter-pill" style="display: inline-flex; align-items: center; gap: 6px; background: rgba(248, 81, 73, 0.12); color: #f85149; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 500;">
+            &ldquo;{{ search | e }}&rdquo;
+            <span style="cursor: pointer; opacity: 0.7; font-size: 1.1em;"
+                  onclick="clearExpandFilter('search')"
+                  title="Clear search">&times;</span>
         </span>
         {% endif %}
     </div>
     <div style="display: flex; gap: 8px;">
         <button class="pagination-btn"
-                hx-get="{{ dashboard_path }}/htmx/attacks?page={{ pagination.page - 1 }}&sort_by={{ sort_by }}&sort_order={{ sort_order }}{{ filter_qs }}"
+                hx-get="{{ dashboard_path }}/htmx/attacks?page={{ pagination.page - 1 }}&page_size={{ pagination.page_size }}&sort_by={{ sort_by }}&sort_order={{ sort_order }}{{ filter_qs }}"
                 hx-target="closest .htmx-container"
                 hx-swap="innerHTML"
                 {% if pagination.page <= 1 %}disabled{% endif %}>Prev</button>
         <button class="pagination-btn"
-                hx-get="{{ dashboard_path }}/htmx/attacks?page={{ pagination.page + 1 }}&sort_by={{ sort_by }}&sort_order={{ sort_order }}{{ filter_qs }}"
+                hx-get="{{ dashboard_path }}/htmx/attacks?page={{ pagination.page + 1 }}&page_size={{ pagination.page_size }}&sort_by={{ sort_by }}&sort_order={{ sort_order }}{{ filter_qs }}"
                 hx-target="closest .htmx-container"
                 hx-swap="innerHTML"
                 {% if pagination.page >= pagination.total_pages %}disabled{% endif %}>Next</button>
@@ -33,13 +47,13 @@
             <th>#</th>
             <th>IP Address</th>
             <th class="sortable {% if sort_by == 'method' %}{{ sort_order }}{% endif %}"
-                hx-get="{{ dashboard_path }}/htmx/attacks?page=1&sort_by=method&sort_order={% if sort_by == 'method' and sort_order == 'desc' %}asc{% else %}desc{% endif %}{{ filter_qs }}"
+                hx-get="{{ dashboard_path }}/htmx/attacks?page=1&page_size={{ pagination.page_size }}&sort_by=method&sort_order={% if sort_by == 'method' and sort_order == 'desc' %}asc{% else %}desc{% endif %}{{ filter_qs }}"
                 hx-target="closest .htmx-container"
                 hx-swap="innerHTML">
                 Method
             </th>
             <th class="sortable {% if sort_by == 'request_size' %}{{ sort_order }}{% endif %}"
-                hx-get="{{ dashboard_path }}/htmx/attacks?page=1&sort_by=request_size&sort_order={% if sort_by == 'request_size' and sort_order == 'desc' %}asc{% else %}desc{% endif %}{{ filter_qs }}"
+                hx-get="{{ dashboard_path }}/htmx/attacks?page=1&page_size={{ pagination.page_size }}&sort_by=request_size&sort_order={% if sort_by == 'request_size' and sort_order == 'desc' %}asc{% else %}desc{% endif %}{{ filter_qs }}"
                 hx-target="closest .htmx-container"
                 hx-swap="innerHTML">
                 Size
@@ -48,7 +62,7 @@
             <th>Attack Types</th>
             <th>User-Agent</th>
             <th class="sortable {% if sort_by == 'timestamp' %}{{ sort_order }}{% endif %}"
-                hx-get="{{ dashboard_path }}/htmx/attacks?page=1&sort_by=timestamp&sort_order={% if sort_by == 'timestamp' and sort_order == 'desc' %}asc{% else %}desc{% endif %}{{ filter_qs }}"
+                hx-get="{{ dashboard_path }}/htmx/attacks?page=1&page_size={{ pagination.page_size }}&sort_by=timestamp&sort_order={% if sort_by == 'timestamp' and sort_order == 'desc' %}asc{% else %}desc{% endif %}{{ filter_qs }}"
                 hx-target="closest .htmx-container"
                 hx-swap="innerHTML">
                 Time

--- a/src/templates/jinja2/dashboard/partials/expand_overlay.html
+++ b/src/templates/jinja2/dashboard/partials/expand_overlay.html
@@ -20,7 +20,7 @@
         </div>
 
         {# Contextual filter bar - shown based on endpoint #}
-        <div x-show="expandOverlay.endpoint === 'top-ips' || expandOverlay.endpoint === 'top-paths'"
+        <div x-show="['top-ips', 'top-paths', 'attacks'].includes(expandOverlay.endpoint)"
              x-cloak
              style="padding: 8px 24px; border-bottom: 1px solid #30363d; display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
 
@@ -71,6 +71,31 @@
                         <span class="map-legend-dot" style="background: #f85149;"></span>
                         <span class="map-legend-label">Honeypot Only</span>
                     </div>
+                </div>
+            </template>
+
+            {# Filters for Attacks #}
+            <template x-if="expandOverlay.endpoint === 'attacks'">
+                <div style="display: flex; align-items: center; gap: 10px; flex-wrap: wrap; width: 100%;">
+                    <span style="color: #8b949e; font-size: 0.8em;">Method</span>
+                    <div style="display: flex; gap: 4px; flex-wrap: wrap;">
+                        <template x-for="m in ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']" :key="m">
+                            <button class="map-limit-btn"
+                                    :class="{ active: expandOverlay.method === m }"
+                                    @click="toggleExpandMethod(m)"
+                                    x-text="m"
+                                    style="padding: 2px 8px; font-size: 0.8em;"></button>
+                        </template>
+                    </div>
+                    <span style="color: #8b949e; font-size: 0.8em; margin-left: 8px;">Attack type</span>
+                    <select x-model="expandOverlay.attackType"
+                            @change="triggerExpandSearch()"
+                            style="background: #0d1117; color: #c9d1d9; border: 1px solid #30363d; border-radius: 6px; padding: 3px 8px; font-size: 0.85em; min-width: 160px; max-width: 280px;">
+                        <option value="">All attack types</option>
+                        <template x-for="t in expandOverlay.attackTypes" :key="t">
+                            <option :value="t" x-text="t"></option>
+                        </template>
+                    </select>
                 </div>
             </template>
         </div>

--- a/src/templates/jinja2/dashboard/partials/suspicious_expand_table.html
+++ b/src/templates/jinja2/dashboard/partials/suspicious_expand_table.html
@@ -1,0 +1,88 @@
+{# HTMX fragment: paginated recent suspicious activity (used in expand overlay) #}
+{% set filter_qs %}{% if search %}&search={{ search | e }}{% endif %}&sort_order={{ sort_order }}{% endset %}
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+    <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+        <span class="pagination-info">Page {{ pagination.page }}/{{ pagination.total_pages }} &mdash; {{ pagination.total }} suspicious</span>
+        {% if search %}
+        <span class="filter-pill" style="display: inline-flex; align-items: center; gap: 6px; background: rgba(248, 81, 73, 0.12); color: #f85149; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 500;">
+            &ldquo;{{ search | e }}&rdquo;
+            <span style="cursor: pointer; opacity: 0.7; font-size: 1.1em;"
+                  onclick="clearExpandFilter('search')"
+                  title="Clear search">&times;</span>
+        </span>
+        {% endif %}
+    </div>
+    <div style="display: flex; gap: 8px;">
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/suspicious?page={{ pagination.page - 1 }}{{ filter_qs }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page <= 1 %}disabled{% endif %}>Prev</button>
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/suspicious?page={{ pagination.page + 1 }}{{ filter_qs }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page >= pagination.total_pages %}disabled{% endif %}>Next</button>
+    </div>
+</div>
+<table>
+    <thead>
+        <tr>
+            <th>IP Address</th>
+            <th>Method</th>
+            <th>Path</th>
+            <th>User-Agent</th>
+            <th>Time</th>
+            <th style="width: 80px;"></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for activity in items %}
+        <tr class="ip-row" data-ip="{{ activity.ip | e }}">
+            <td class="ip-clickable"
+                hx-get="{{ dashboard_path }}/htmx/ip-detail/{{ activity.ip | e }}"
+                hx-target="next .ip-stats-row .ip-stats-dropdown"
+                hx-swap="innerHTML"
+                @click="toggleIpDetail($event)">
+                {{ activity.ip | e }}
+            </td>
+            <td>
+                {% set method = activity.method | default('GET') | upper %}
+                <span class="method-badge method-{{ method | lower | e }}">{{ method | e }}</span>
+            </td>
+            <td>
+                <div class="path-cell-container">
+                    <span class="path-truncated">{{ activity.path | e }}</span>
+                    {% if activity.path | length > 30 %}
+                    <div class="path-tooltip">{{ activity.path | e }}</div>
+                    {% endif %}
+                </div>
+            </td>
+            <td style="word-break: break-all;">{{ (activity.user_agent | default(''))[:80] | e }}</td>
+            <td>{{ activity.timestamp | format_ts }}</td>
+            <td>
+                <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+                {% if activity.log_id %}
+                <button class="view-btn" @click="viewRawRequest({{ activity.log_id }})" title="View Request">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6z"/></svg>
+                    <span class="view-btn-tooltip">View Request</span>
+                </button>
+                {% endif %}
+                <button class="inspect-btn" @click="openIpInsight('{{ activity.ip | e }}')" title="Inspect IP">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+                </button>
+                </div>
+            </td>
+        </tr>
+        <tr class="ip-stats-row" style="display: none;">
+            <td colspan="6" class="ip-stats-cell">
+                <div class="ip-stats-dropdown">
+                    <div class="loading">Loading stats...</div>
+                </div>
+            </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="6" class="empty-state">No suspicious activity detected</td></tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/src/templates/static/js/dashboard.js
+++ b/src/templates/static/js/dashboard.js
@@ -125,7 +125,7 @@ document.addEventListener('alpine:init', () => {
         uploadModal: { show: false, path: '', fileName: '', fileContent: '', error: '', success: '', loading: false, dragging: false },
 
         // Expand overlay state
-        expandOverlay: { show: false, title: '', endpoint: '', pageSize: 25, search: '', categories: [], honeypotOnly: false },
+        expandOverlay: { show: false, title: '', endpoint: '', pageSize: 25, search: '', categories: [], honeypotOnly: false, method: '', attackType: '', attackTypes: [], ipFilter: '' },
 
         // Flag to prevent double-triggering during init
         _initializingHash: false,
@@ -1150,8 +1150,15 @@ window.openExpandOverlay = function(title, endpoint, pageSize) {
         show: true, title: title, endpoint: endpoint,
         pageSize: pageSize || 25, search: '',
         categories: [], honeypotOnly: false,
+        method: '', attackType: '', attackTypes: [],
+        ipFilter: '',
     });
     _reloadExpandOverlay();
+    // For attacks, lazily load the list of distinct attack types for the
+    // dropdown filter.
+    if (endpoint === 'attacks') {
+        _loadExpandAttackTypes();
+    }
 };
 
 window.triggerExpandSearch = function() {
@@ -1175,6 +1182,39 @@ window.toggleExpandHoneypot = function() {
     _reloadExpandOverlay();
 };
 
+window.toggleExpandMethod = function(method) {
+    const app = _getAlpineData();
+    if (!app) return;
+    app.expandOverlay.method = (app.expandOverlay.method === method) ? '' : method;
+    _reloadExpandOverlay();
+};
+
+window.clearExpandFilter = function(name) {
+    const app = _getAlpineData();
+    if (!app) return;
+    const ov = app.expandOverlay;
+    if (name === 'attackType') ov.attackType = '';
+    else if (name === 'method') ov.method = '';
+    else if (name === 'search') { ov.search = ''; const el = document.querySelector('.expand-overlay-search'); if (el) el.value = ''; }
+    else if (name === 'ipFilter') ov.ipFilter = '';
+    _reloadExpandOverlay();
+};
+
+function _loadExpandAttackTypes() {
+    const dashboardPath = window.__DASHBOARD_PATH__ || '';
+    fetch(`${dashboardPath}/htmx/attack-types-list`)
+        .then(r => r.ok ? r.json() : { attack_types: [] })
+        .then(data => {
+            const app = _getAlpineData();
+            if (!app) return;
+            app.expandOverlay.attackTypes = Array.isArray(data.attack_types) ? data.attack_types : [];
+        })
+        .catch(() => {
+            const app = _getAlpineData();
+            if (app) app.expandOverlay.attackTypes = [];
+        });
+}
+
 function _reloadExpandOverlay() {
     const app = _getAlpineData();
     if (!app) return;
@@ -1195,6 +1235,14 @@ function _reloadExpandOverlay() {
     }
     if (ov.endpoint === 'top-paths' && ov.honeypotOnly) {
         params.set('honeypot_only', '1');
+    }
+    if (ov.endpoint === 'attacks') {
+        if (ov.method) params.set('method_filter', ov.method);
+        if (ov.attackType) params.set('attack_type_filter', ov.attackType);
+        // Pull sort defaults from the currently displayed partial if present,
+        // otherwise default to timestamp desc.
+        if (!params.has('sort_by')) params.set('sort_by', 'timestamp');
+        if (!params.has('sort_order')) params.set('sort_order', 'desc');
     }
 
     const url = `${dashboardPath}/htmx/${ov.endpoint}?${params}`;


### PR DESCRIPTION
This pull request introduces support for externally-managed Kubernetes Secrets for dashboard, Postgres, and Redis credentials in the Krawl Helm chart and deployment manifests. It adds new values and template helpers to allow operators to supply their own Secrets (e.g., via ExternalSecrets, SealedSecrets, or Vault), disables chart-managed Secret creation when an external Secret is configured, and updates documentation to reflect these options. Additionally, a new paginated and searchable suspicious access log query is added to the backend.

**Helm Chart Improvements (External Secret Support):**
- Added new values in `values.yaml` and `README.md` for `dashboardExistingSecret`, `dashboardPathExistingSecret`, `postgres.existingSecret`, and `redis.existingSecret` to allow referencing externally-managed Secrets for dashboard password, dashboard path, Postgres, and Redis credentials. Chart-managed Secret creation is skipped when these are set. [[1]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R87-R101) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L223-R246) [[3]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L255-R283) [[4]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16R258-R261) [[5]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L289-R294) [[6]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L310-R315)
- Added template helpers (`_helpers.tpl`) for resolving Secret names/keys, and updated all Secret references in deployments, jobs, and statefulsets to use these helpers. [[1]](diffhunk://#diff-f1a6324c375e55f92a8e4e1e5cc78ba3cc846c4869deb2d1659841257a325bceR61-R100) [[2]](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435L69-R81) [[3]](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435L99-R107) [[4]](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435L109-R121) [[5]](diffhunk://#diff-8ca3a41e7a4b15ce9234729131fab0787a1f74bec355ba6f0cd8223d73d33581L68-R69) [[6]](diffhunk://#diff-17442822dcbf7f8f38fbd0675c02a144c05de8e0b3d62ab97623ee7c0ff6aa8eL76-R77) [[7]](diffhunk://#diff-d6b9e928d722755c58f567be61c2ce8232cd92a02486fa3250d3b9947eec3175L77-R78)
- Chart-managed Secret manifests (`secret.yaml`, `secret-scalable.yaml`) now only create Secrets when an external Secret is not configured. [[1]](diffhunk://#diff-488441c4b047082e5a49e881768927eac438f782a2c96cc1c536c8e29cef8956L1-R1) [[2]](diffhunk://#diff-88709c9194a792909f106b8a7cc6980718eb71834376b4a921ebf8dc02f6a53cR2) [[3]](diffhunk://#diff-88709c9194a792909f106b8a7cc6980718eb71834376b4a921ebf8dc02f6a53cL12-R14)

**Kubernetes Manifest and Documentation Updates:**
- Updated the all-in-one manifest and `kubernetes/README.md` with instructions and commented-out examples for using externally-managed Secrets for dashboard, dashboard path, Postgres, and Redis credentials. [[1]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L34-R83) [[2]](diffhunk://#diff-c8362d0534a8761eaa19fbfc011a08a710b46d2a8932f3555bc74ec18b571759R492-R514)
- Bumped Helm chart version to `2.2.10`.

**Backend API Enhancements:**
- Added a new `get_recent_suspicious_paginated` method to `AccessLogDB` for paginated, searchable, and sortable suspicious access log queries. [[1]](diffhunk://#diff-2ab7dd145822a31e8aacf0ba9ea6b2cb5c78bca39ec858b9828f45ce7d91a953R241-R322) [[2]](diffhunk://#diff-2ab7dd145822a31e8aacf0ba9ea6b2cb5c78bca39ec858b9828f45ce7d91a953L10-R10)

These changes make it much easier to integrate Krawl with external secret management solutions and improve operational security and flexibility.

Closes #240 
Closes #243 