### PR TITLE
Feat: add cloudflare cdn exclusion

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.2.11
-appVersion: 2.2.11
+version: 2.2.12
+appVersion: 2.2.12
 keywords:
   - honeypot
   - security

--- a/src/ip_utils.py
+++ b/src/ip_utils.py
@@ -74,3 +74,80 @@ def is_valid_public_ip(ip: str, server_ip: str | None = None) -> bool:
         True if the IP is a valid public IP to track, False otherwise.
     """
     return not is_ignored_ip(ip) and (server_ip is None or ip != server_ip)
+
+
+# Published CDN ranges per provider, fetched at export time (never stored).
+CDN_PROVIDER_URLS = {
+    "cloudflare": (
+        "https://www.cloudflare.com/ips-v4",
+        "https://www.cloudflare.com/ips-v6",
+    ),
+    "fastly": ("https://api.fastly.com/public-ip-list",),
+    "cloudfront": (
+        "https://d7uri8nf7uskq.cloudfront.net/tools/list-cloudfront-ips",
+    ),
+    "google": ("https://www.gstatic.com/ipranges/goog.json",),
+    "bunny": ("https://bunnycdn.com/api/system/edgeserverlist",),
+}
+
+
+def _cidrs_in(payload):
+    """Yield every CIDR-looking string in a text or JSON response body."""
+    if isinstance(payload, str):
+        yield from payload.split()
+    elif isinstance(payload, dict):
+        for v in payload.values():
+            yield from _cidrs_in(v)
+    elif isinstance(payload, list):
+        for v in payload:
+            yield from _cidrs_in(v)
+
+
+@lru_cache(maxsize=8)
+def _cdn_networks(provider: str, _hour_bucket: int) -> tuple:
+    """Fetch a provider's published ranges. Cached in memory for an hour.
+
+    Never persisted to disk; a fetch failure yields no networks for that URL
+    so export still works (just without that provider filtered out).
+    """
+    import requests
+
+    networks = []
+    for url in CDN_PROVIDER_URLS.get(provider, ()):
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            try:
+                body = resp.json()
+            except ValueError:
+                body = resp.text
+            for entry in _cidrs_in(body):
+                try:
+                    networks.append(ipaddress.ip_network(entry.strip(), strict=False))
+                except ValueError:
+                    continue
+        except Exception as e:
+            get_app_logger().warning(f"Could not fetch CDN ranges from {url}: {e}")
+    return tuple(networks)
+
+
+def get_cdn_networks(providers) -> tuple:
+    """Published ranges for the given providers, refreshed at most once per hour."""
+    import time
+
+    bucket = int(time.time() // 3600)
+    return tuple(
+        net
+        for p in providers
+        if p in CDN_PROVIDER_URLS
+        for net in _cdn_networks(p, bucket)
+    )
+
+
+def is_cdn_ip(ip_str: str, networks: tuple) -> bool:
+    """True if the IP falls inside one of the given CDN ranges."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    return any(ip.version == net.version and ip in net for net in networks)

--- a/src/ip_utils.py
+++ b/src/ip_utils.py
@@ -83,9 +83,7 @@ CDN_PROVIDER_URLS = {
         "https://www.cloudflare.com/ips-v6",
     ),
     "fastly": ("https://api.fastly.com/public-ip-list",),
-    "cloudfront": (
-        "https://d7uri8nf7uskq.cloudfront.net/tools/list-cloudfront-ips",
-    ),
+    "cloudfront": ("https://d7uri8nf7uskq.cloudfront.net/tools/list-cloudfront-ips",),
     "google": ("https://www.gstatic.com/ipranges/goog.json",),
     "bunny": ("https://bunnycdn.com/api/system/edgeserverlist",),
 }

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -871,6 +871,7 @@ async def export_ips(
     categories: str = Query(...),
     fwtype: str = Query("raw"),
     merge_banlists: bool = Query(False),
+    exclude_cdn: str = Query(""),
 ):
     valid_categories = {
         "attacker",
@@ -922,9 +923,19 @@ async def export_ips(
 
         ips = list(ip_set)
 
-        from ip_utils import is_valid_public_ip
+        from ip_utils import get_cdn_networks, is_cdn_ip, is_valid_public_ip
 
         public_ips = [ip for ip in ips if is_valid_public_ip(ip, server_ip)]
+
+        providers = [p.strip() for p in exclude_cdn.split(",") if p.strip()]
+        if providers:
+            cdn_nets = await asyncio.to_thread(get_cdn_networks, providers)
+            before = len(public_ips)
+            public_ips = [ip for ip in public_ips if not is_cdn_ip(ip, cdn_nets)]
+            get_app_logger().debug(
+                f"[ExportIPs] Excluded {before - len(public_ips)} CDN IPs"
+            )
+
         content = fw.getBanlist(public_ips)
 
         cat_label = "_".join(sorted(cat_list))

--- a/src/templates/jinja2/dashboard/partials/export_modal.html
+++ b/src/templates/jinja2/dashboard/partials/export_modal.html
@@ -16,56 +16,74 @@
             <span class="auth-modal-close" @click="exportModal.show = false">&times;</span>
         </div>
         <div class="auth-modal-body">
-            <p class="auth-modal-description">Select which IP categories to include and the export format.</p>
+            <p class="auth-modal-description">Choose what goes in the list and how it is formatted.</p>
+
+            {# Exclude published CDN ranges #}
+            <div class="auth-modal-input-group">
+                <label class="export-group-label">Skip CDN providers</label>
+                <div class="export-grid">
+                    <label class="export-check">
+                        <input type="checkbox" value="cloudflare" x-model="exportModal.excludeCdn" />
+                        <span>Cloudflare</span>
+                    </label>
+                    <label class="export-check">
+                        <input type="checkbox" value="fastly" x-model="exportModal.excludeCdn" />
+                        <span>Fastly</span>
+                    </label>
+                    <label class="export-check">
+                        <input type="checkbox" value="cloudfront" x-model="exportModal.excludeCdn" />
+                        <span>AWS CloudFront</span>
+                    </label>
+                    <label class="export-check">
+                        <input type="checkbox" value="google" x-model="exportModal.excludeCdn" />
+                        <span>Google</span>
+                    </label>
+                    <label class="export-check">
+                        <input type="checkbox" value="bunny" x-model="exportModal.excludeCdn" />
+                        <span>Bunny.net</span>
+                    </label>
+                </div>
+                <p class="export-hint">Drops IPs inside these providers' published ranges, fetched at export time.</p>
+            </div>
 
             {# Category checkboxes #}
             <div class="auth-modal-input-group">
-                <label style="display: block; color: #8b949e; font-size: 12px; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px;">Categories</label>
-                <div style="display: flex; flex-direction: column; gap: 8px;">
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+                <label class="export-group-label">Categories</label>
+                <div class="export-grid">
+                    <label class="export-check">
                         <input type="checkbox" value="attacker" x-model="exportModal.categories" style="accent-color: #f85149;" />
-                        <span style="display: inline-flex; align-items: center; gap: 6px;">
-                            <span style="width: 8px; height: 8px; border-radius: 50%; background: #f85149; display: inline-block;"></span>
-                            Attackers
-                        </span>
+                        <span class="dot" style="background: #f85149;"></span>
+                        <span>Attackers</span>
                     </label>
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+                    <label class="export-check">
                         <input type="checkbox" value="bad_crawler" x-model="exportModal.categories" style="accent-color: #d29922;" />
-                        <span style="display: inline-flex; align-items: center; gap: 6px;">
-                            <span style="width: 8px; height: 8px; border-radius: 50%; background: #d29922; display: inline-block;"></span>
-                            Bad Crawlers
-                        </span>
+                        <span class="dot" style="background: #d29922;"></span>
+                        <span>Bad Crawlers</span>
                     </label>
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+                    <label class="export-check">
                         <input type="checkbox" value="regular_user" x-model="exportModal.categories" style="accent-color: #58a6ff;" />
-                        <span style="display: inline-flex; align-items: center; gap: 6px;">
-                            <span style="width: 8px; height: 8px; border-radius: 50%; background: #58a6ff; display: inline-block;"></span>
-                            Regular Users
-                        </span>
+                        <span class="dot" style="background: #58a6ff;"></span>
+                        <span>Regular Users</span>
                     </label>
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+                    <label class="export-check">
                         <input type="checkbox" value="good_crawler" x-model="exportModal.categories" style="accent-color: #3fb950;" />
-                        <span style="display: inline-flex; align-items: center; gap: 6px;">
-                            <span style="width: 8px; height: 8px; border-radius: 50%; background: #3fb950; display: inline-block;"></span>
-                            Good Crawlers
-                        </span>
+                        <span class="dot" style="background: #3fb950;"></span>
+                        <span>Good Crawlers</span>
                     </label>
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+                    <label class="export-check">
                         <input type="checkbox" value="timed_out" x-model="exportModal.categories" style="accent-color: #db61a2;" />
-                        <span style="display: inline-flex; align-items: center; gap: 6px;">
-                            <span style="width: 8px; height: 8px; border-radius: 50%; background: #db61a2; display: inline-block;"></span>
-                            Timed Out IPs
-                        </span>
+                        <span class="dot" style="background: #db61a2;"></span>
+                        <span>Timed Out IPs</span>
                     </label>
                 </div>
             </div>
 
             {# Merge external banlists checkbox #}
-            <div class="auth-modal-input-group" style="margin-bottom: 0;">
-                <label style="display: block; color: #8b949e; font-size: 12px; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px;">External Banlists</label>
+            <div class="auth-modal-input-group">
+                <label class="export-group-label">External banlists</label>
                 <div style="position: relative;">
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
-                        <input type="checkbox" x-model="exportModal.mergeBanlists" style="accent-color: #58a6ff;" />
+                    <label class="export-check">
+                        <input type="checkbox" x-model="exportModal.mergeBanlists" />
                         <span>Merge banlists</span>
                         <span class="banlist-sources-hint"
                               x-show="banlistSources.length > 0"
@@ -109,28 +127,28 @@
             </div>
 
             {# Format radio buttons #}
-            <div class="auth-modal-input-group" style="margin-bottom: 0;">
-                <label style="display: block; color: #8b949e; font-size: 12px; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px;">Format</label>
-                <div style="display: flex; flex-direction: column; gap: 8px;">
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+            <div class="auth-modal-input-group">
+                <label class="export-group-label">Format</label>
+                <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+                    <label class="export-check">
                         <input type="radio" name="export-format" value="raw" x-model="exportModal.fwtype" />
-                        RAW IPs List
+                        <span>RAW list</span>
                     </label>
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+                    <label class="export-check">
                         <input type="radio" name="export-format" value="iptables" x-model="exportModal.fwtype" />
-                        IPTables Rules
+                        <span>IPTables</span>
                     </label>
-                    <label style="display: flex; align-items: center; gap: 8px; color: #c9d1d9; font-size: 14px; cursor: pointer;">
+                    <label class="export-check">
                         <input type="radio" name="export-format" value="nftables" x-model="exportModal.fwtype" />
-                        NFTables Rules
+                        <span>NFTables</span>
                     </label>
                 </div>
             </div>
 
             {# Direct download URL (for OPNsense and other external systems) #}
-            <div class="auth-modal-input-group" style="margin-top: 16px; margin-bottom: 0;" x-show="exportModal.categories.length > 0" x-cloak>
-                <label style="display: block; color: #8b949e; font-size: 12px; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px;">Direct URL</label>
-                <p style="color: #8b949e; font-size: 12px; margin: 0 0 8px;">Use this URL to fetch the list directly from OPNsense or other external systems.</p>
+            <div class="auth-modal-input-group" style="margin-bottom: 0;" x-show="exportModal.categories.length > 0" x-cloak>
+                <label class="export-group-label">Direct URL</label>
+                <p class="export-hint" style="margin: 0 0 8px;">Fetch the list directly from OPNsense or other external systems.</p>
                 <div style="display: flex; gap: 8px; align-items: stretch;">
                     <input type="text" readonly :value="exportUrl()"
                            @click="$event.target.select()"

--- a/src/templates/static/css/dashboard.css
+++ b/src/templates/static/css/dashboard.css
@@ -1330,6 +1330,9 @@ tbody {
     max-width: 90vw;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
     animation: authModalIn 0.2s ease-out;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
 }
 @keyframes authModalIn {
     from { opacity: 0; transform: scale(0.95) translateY(-10px); }
@@ -1367,6 +1370,45 @@ tbody {
 }
 .auth-modal-body {
     padding: 24px;
+    overflow-y: auto;
+}
+
+/* Export modal: compact checkbox sections */
+.export-group-label {
+    display: block;
+    color: #8b949e;
+    font-size: 12px;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.export-check {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #c9d1d9;
+    font-size: 14px;
+    cursor: pointer;
+}
+.export-check input {
+    accent-color: #58a6ff;
+    flex-shrink: 0;
+}
+.export-check .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+}
+.export-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 16px;
+}
+.export-hint {
+    color: #8b949e;
+    font-size: 12px;
+    margin: 8px 0 0;
 }
 .auth-modal-description {
     margin: 0 0 20px;
@@ -2611,6 +2653,9 @@ tbody {
     flex-direction: column;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
     animation: authModalIn 0.2s ease-out;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
 }
 .expand-overlay-header {
     padding: 16px 24px;

--- a/src/templates/static/js/dashboard.js
+++ b/src/templates/static/js/dashboard.js
@@ -268,7 +268,7 @@ document.addEventListener('alpine:init', () => {
         dashboardPath: window.__DASHBOARD_PATH__ || '',
 
         // Export IPs modal
-        exportModal: { show: false, categories: ['attacker'], fwtype: 'raw', error: '', loading: false, mergeBanlists: false },
+        exportModal: { show: false, categories: ['attacker'], fwtype: 'raw', error: '', loading: false, mergeBanlists: false, excludeCdn: ['cloudflare', 'fastly', 'cloudfront', 'google', 'bunny'] },
         banlistSources: [],
         showBanlistSources: false,
 
@@ -509,6 +509,9 @@ document.addEventListener('alpine:init', () => {
             if (this.exportModal.mergeBanlists) {
                 params.set('merge_banlists', 'true');
             }
+            if (this.exportModal.excludeCdn.length > 0) {
+                params.set('exclude_cdn', this.exportModal.excludeCdn.slice().sort().join(','));
+            }
             return `${window.location.origin}${this.dashboardPath}/api/export-ips?${params}`;
         },
 
@@ -539,6 +542,9 @@ document.addEventListener('alpine:init', () => {
                 });
                 if (this.exportModal.mergeBanlists) {
                     params.set('merge_banlists', 'true');
+                }
+                if (this.exportModal.excludeCdn.length > 0) {
+                    params.set('exclude_cdn', this.exportModal.excludeCdn.join(','));
                 }
                 const resp = await fetch(`${this.dashboardPath}/api/export-ips?${params}`, {
                     credentials: 'same-origin',


### PR DESCRIPTION

<img width="515" height="690" alt="2026-08-15_15-39-02" src="https://github.com/user-attachments/assets/04aece98-bca6-4bf6-b78e-41c14799731d" />


This pull request introduces a new feature that allows users to exclude IP addresses belonging to major CDN providers from exported IP lists, improving the utility of export functionality for firewall and banlist management. It also refines the export modal UI for better usability and consistency, and adds related backend logic for dynamic CDN range filtering.

The most important changes are:

**Feature: Exclude CDN IPs from Exported Lists**
- Added a new option in the export modal UI to skip IPs from known CDN providers (Cloudflare, Fastly, CloudFront, Google, Bunny.net). Users can select which providers to exclude, and the system fetches the latest published IP ranges at export time. [[1]](diffhunk://#diff-8fdde812766d4f010859b5b088a4d69d1a46761000ad249a6c53c58e49ca58edL19-R86) [[2]](diffhunk://#diff-8a5740e39328fb952ad7f0cd14723cc6a1c8e3ffcd1b9eb2b5a4279e08dd914cL271-R271)
- Implemented backend logic in `ip_utils.py` to fetch, cache, and check if IPs are within published CDN ranges. The API now supports an `exclude_cdn` query parameter to filter these IPs during export. [[1]](diffhunk://#diff-7551086f0ce90304604e35a64eb976409eaf148bf22dfdf798a28ecc866a2e0dR77-R153) [[2]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667R874) [[3]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667L925-R938)

**UI/UX Improvements**
- Refactored the export modal for a more compact, accessible, and consistent layout, including grouped and styled checkboxes, improved labels, and hints. [[1]](diffhunk://#diff-8fdde812766d4f010859b5b088a4d69d1a46761000ad249a6c53c58e49ca58edL19-R86) [[2]](diffhunk://#diff-8fdde812766d4f010859b5b088a4d69d1a46761000ad249a6c53c58e49ca58edL112-R151)
- Made the export modal body scrollable and improved modal sizing for better usability on smaller screens. [[1]](diffhunk://#diff-a745f1d4dc0ab92f45b3c0f1985bcbe71a60287efd534c1b03594a4ec732c500R1333-R1335) [[2]](diffhunk://#diff-a745f1d4dc0ab92f45b3c0f1985bcbe71a60287efd534c1b03594a4ec732c500R2656-R2658) [[3]](diffhunk://#diff-a745f1d4dc0ab92f45b3c0f1985bcbe71a60287efd534c1b03594a4ec732c500R1373-R1411)

**Frontend Integration**
- Updated JavaScript to support the new CDN exclusion feature, ensuring selected providers are reflected in both direct export URLs and export actions. The default is to exclude all supported CDNs. [[1]](diffhunk://#diff-8a5740e39328fb952ad7f0cd14723cc6a1c8e3ffcd1b9eb2b5a4279e08dd914cL271-R271) [[2]](diffhunk://#diff-8a5740e39328fb952ad7f0cd14723cc6a1c8e3ffcd1b9eb2b5a4279e08dd914cR512-R514) [[3]](diffhunk://#diff-8a5740e39328fb952ad7f0cd14723cc6a1c8e3ffcd1b9eb2b5a4279e08dd914cR546-R548)

These changes together provide more control over exported IP lists, especially for environments where CDN IPs should not be blocked, and significantly improve the export modal's usability.