### PR TITLE
Feat improved secret management

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.2.12
-appVersion: 2.2.12
+version: 2.2.13
+appVersion: 2.2.13
 keywords:
   - honeypot
   - security

--- a/helm/README.md
+++ b/helm/README.md
@@ -255,10 +255,20 @@ The Krawl service already includes `externalTrafficPolicy: Local` by default to 
 |-----------|-------------|---------|
 | `config.dashboard.secret_path` | Secret dashboard path (auto-generated if null) | `null` |
 | `dashboardPassword` | Password for protected panels (injected via Secret as `KRAWL_DASHBOARD_PASSWORD` env, auto-generated if empty) | `""` |
-| `dashboardExistingSecret` | Use an externally-managed Secret for the dashboard password (key `dashboardExistingSecretKey`, default `dashboard-password`). When set, the chart-managed Secret is not created. | `""` |
-| `dashboardExistingSecretKey` | Key in `dashboardExistingSecret` holding the dashboard password | `dashboard-password` |
-| `dashboardPathExistingSecret` | Use an externally-managed Secret for the dashboard secret path (key `dashboardPathExistingSecretKey`, default `dashboard-path`). When set, `KRAWL_DASHBOARD_SECRET_PATH` is injected from this Secret and overrides `config.dashboard.secret_path` at runtime. | `""` |
-| `dashboardPathExistingSecretKey` | Key in `dashboardPathExistingSecret` holding the dashboard path | `dashboard-path` |
+| `dashboardExistingSecret.name` | Externally-managed Secret holding the dashboard password (and optionally the path). When set, the chart-managed Secret is not created. | `""` |
+| `dashboardExistingSecret.passwordKey` | Key holding the dashboard password | `dashboard-password` |
+| `dashboardExistingSecret.pathKey` | Key holding the dashboard secret path. When set, `KRAWL_DASHBOARD_SECRET_PATH` is injected from the Secret and overrides `config.dashboard.secret_path`. | `""` |
+| `aiExistingSecret.name` | Externally-managed Secret holding the AI/LLM API key. When set, the chart-managed AI Secret is not created. | `""` |
+| `aiExistingSecret.key` | Key holding the API key | `ai-api-key` |
+| `canaryTokenUrl` | Canary token URL. Stored in a chart-managed Secret and injected as `KRAWL_CANARY_TOKEN_URL`, keeping it out of the ConfigMap. | `""` |
+| `canaryExistingSecret.name` | Externally-managed Secret holding the canary token URL | `""` |
+| `canaryExistingSecret.key` | Key holding the URL | `canary-token-url` |
+| `cloudflare.enabled` | Enable CloudFlare WAF/banlist sync (`KRAWL_CLOUDFLARE_ENABLED`) | `false` |
+| `cloudflare.accountId` / `cloudflare.authToken` | CloudFlare credentials, stored in a chart-managed Secret. Injected as env, take precedence over `data/webhooks.json`, and are never written back to disk. | `""` |
+| `cloudflare.existingSecret.name` | Externally-managed Secret holding the CloudFlare credentials | `""` |
+| `cloudflare.existingSecret.accountIdKey` / `.authTokenKey` | Keys in that Secret | `cloudflare-account-id` / `cloudflare-auth-token` |
+| `extraEnv` | Extra env vars for the Krawl container (list of `name`/`value` or `valueFrom` entries) | `[]` |
+| `extraEnvFrom` | Extra `envFrom` sources (`secretRef` / `configMapRef`) — escape hatch for External Secrets Operator / Vault | `[]` |
 
 ### API Configuration
 
@@ -290,8 +300,12 @@ The Krawl service already includes `externalTrafficPolicy: Local` by default to 
 | `postgres.user` | PostgreSQL username | `krawl` |
 | `postgres.password` | PostgreSQL password | `krawl` |
 | `postgres.database` | PostgreSQL database name | `krawl` |
-| `postgres.existingSecret` | Use an externally-managed Secret for the PostgreSQL password (skips chart-managed Secret for Postgres, used by Krawl Deployment, bundled StatefulSet, and the migration Job) | `` |
-| `postgres.existingSecretKey` | Key in `postgres.existingSecret` holding the password | `postgres-password` |
+| `postgres.existingSecret.name` | Externally-managed Secret for the PostgreSQL credentials (skips the chart-managed Secret; used by the Krawl Deployment, bundled StatefulSet and migration Job) | `""` |
+| `postgres.existingSecret.passwordKey` | Key holding the password | `postgres-password` |
+| `postgres.existingSecret.userKey` | Key holding the username (empty = use `postgres.user`) | `""` |
+| `postgres.existingSecret.hostKey` | Key holding the host (empty = use `postgres.host`) | `""` |
+| `postgres.existingSecret.portKey` | Key holding the port (empty = use `postgres.port`) | `""` |
+| `postgres.existingSecret.databaseKey` | Key holding the database name (empty = use `postgres.database`) | `""` |
 | `postgres.image.repository` | PostgreSQL image repository (bundled only) | `postgres` |
 
 | `postgres.image.tag` | PostgreSQL image tag | `16-alpine` |
@@ -311,8 +325,10 @@ The Krawl service already includes `externalTrafficPolicy: Local` by default to 
 | `redis.port` | Redis port | `6379` |
 | `redis.db` | Redis database number | `0` |
 | `redis.password` | Redis password | `` |
-| `redis.existingSecret` | Use an externally-managed Secret for the Redis password (skips chart-managed Secret for Redis, used by Krawl Deployment and bundled StatefulSet) | `` |
-| `redis.existingSecretKey` | Key in `redis.existingSecret` holding the password | `redis-password` |
+| `redis.existingSecret.name` | Externally-managed Secret for the Redis credentials (skips the chart-managed Secret; used by the Krawl Deployment and bundled StatefulSet) | `""` |
+| `redis.existingSecret.passwordKey` | Key holding the password | `redis-password` |
+| `redis.existingSecret.hostKey` | Key holding the host (empty = use `redis.host`) | `""` |
+| `redis.existingSecret.portKey` | Key holding the port (empty = use `redis.port`) | `""` |
 | `redis.image.repository` | Redis image repository (bundled only) | `redis` |
 | `redis.image.tag` | Redis image tag | `7-alpine` |
 | `redis.image.pullPolicy` | Image pull policy | `IfNotPresent` |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -66,8 +66,8 @@ Secret. Returns the Secret name and key as a pair via a dict so templates can
 share the same resolution logic.
 */}}
 {{- define "krawl.postgres.secret" -}}
-{{- $name := .Values.postgres.existingSecret | default (printf "%s-postgres" (include "krawl.fullname" .)) }}
-{{- $key := .Values.postgres.existingSecretKey | default "postgres-password" }}
+{{- $name := .Values.postgres.existingSecret.name | default (printf "%s-postgres" (include "krawl.fullname" .)) }}
+{{- $key := .Values.postgres.existingSecret.passwordKey | default "postgres-password" }}
 {{- dict "name" $name "key" $key | toJson }}
 {{- end }}
 
@@ -75,8 +75,8 @@ share the same resolution logic.
 Resolve the Redis Secret name/key to reference for credentials.
 */}}
 {{- define "krawl.redis.secret" -}}
-{{- $name := .Values.redis.existingSecret | default (printf "%s-redis" (include "krawl.fullname" .)) }}
-{{- $key := .Values.redis.existingSecretKey | default "redis-password" }}
+{{- $name := .Values.redis.existingSecret.name | default (printf "%s-redis" (include "krawl.fullname" .)) }}
+{{- $key := .Values.redis.existingSecret.passwordKey | default "redis-password" }}
 {{- dict "name" $name "key" $key | toJson }}
 {{- end }}
 
@@ -84,8 +84,8 @@ Resolve the Redis Secret name/key to reference for credentials.
 Resolve the Dashboard password Secret name/key to reference.
 */}}
 {{- define "krawl.dashboard.secret" -}}
-{{- $name := .Values.dashboardExistingSecret | default (printf "%s-dashboard" (include "krawl.fullname" .)) }}
-{{- $key := .Values.dashboardExistingSecretKey | default "dashboard-password" }}
+{{- $name := .Values.dashboardExistingSecret.name | default (printf "%s-dashboard" (include "krawl.fullname" .)) }}
+{{- $key := .Values.dashboardExistingSecret.passwordKey | default "dashboard-password" }}
 {{- dict "name" $name "key" $key | toJson }}
 {{- end }}
 
@@ -94,7 +94,32 @@ Resolve the Dashboard secret path Secret name/key to reference.
 Empty when no external Secret is configured (path auto-generates from config).
 */}}
 {{- define "krawl.dashboardPath.secret" -}}
-{{- $name := .Values.dashboardPathExistingSecret | default "" }}
-{{- $key := .Values.dashboardPathExistingSecretKey | default "dashboard-path" }}
+{{- $name := ternary .Values.dashboardExistingSecret.name "" (not (empty .Values.dashboardExistingSecret.pathKey)) }}
+{{- $key := .Values.dashboardExistingSecret.pathKey | default "dashboard-path" }}
 {{- dict "name" $name "key" $key | toJson }}
+{{- end }}
+
+{{/*
+Resolve the AI API key Secret name/key to reference.
+*/}}
+{{- define "krawl.ai.secret" -}}
+{{- $name := .Values.aiExistingSecret.name | default (printf "%s-ai" (include "krawl.fullname" .)) }}
+{{- $key := .Values.aiExistingSecret.key | default "ai-api-key" }}
+{{- dict "name" $name "key" $key | toJson }}
+{{- end }}
+
+{{/*
+Resolve the canary token URL Secret name/key to reference.
+*/}}
+{{- define "krawl.canary.secret" -}}
+{{- $name := .Values.canaryExistingSecret.name | default (ternary (printf "%s-canary" (include "krawl.fullname" .)) "" (not (empty .Values.canaryTokenUrl))) }}
+{{- $key := .Values.canaryExistingSecret.key | default "canary-token-url" }}
+{{- dict "name" $name "key" $key | toJson }}
+{{- end }}
+
+{{/*
+Resolve the CloudFlare credentials Secret name to reference.
+*/}}
+{{- define "krawl.cloudflare.secret" -}}
+{{- .Values.cloudflare.existingSecret.name | default (printf "%s-cloudflare" (include "krawl.fullname" .)) }}
 {{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -66,54 +66,121 @@ spec:
         - name: TZ
           value: {{ .Values.timezone | quote }}
         {{- end }}
-        {{- if or .Values.dashboardPassword .Values.dashboardExistingSecret }}
+        {{- if or .Values.dashboardPassword .Values.dashboardExistingSecret.name }}
         - name: KRAWL_DASHBOARD_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ (include "krawl.dashboard.secret" . | fromJson).name }}
               key: {{ (include "krawl.dashboard.secret" . | fromJson).key }}
         {{- end }}
-        {{- if .Values.dashboardPathExistingSecret }}
+        {{- $dashPath := include "krawl.dashboardPath.secret" . | fromJson }}
+        {{- if $dashPath.name }}
         - name: KRAWL_DASHBOARD_SECRET_PATH
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.dashboardPathExistingSecret }}
-              key: {{ .Values.dashboardPathExistingSecretKey | default "dashboard-path" }}
+              name: {{ $dashPath.name }}
+              key: {{ $dashPath.key }}
         {{- end }}
-        {{- if .Values.config.ai.api_key }}
+        {{- if or .Values.config.ai.api_key .Values.aiExistingSecret.name }}
         - name: KRAWL_AI_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ include "krawl.fullname" . }}-ai
-              key: ai-api-key
+              name: {{ (include "krawl.ai.secret" . | fromJson).name }}
+              key: {{ (include "krawl.ai.secret" . | fromJson).key }}
+        {{- end }}
+        {{- $canary := include "krawl.canary.secret" . | fromJson }}
+        {{- if $canary.name }}
+        - name: KRAWL_CANARY_TOKEN_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ $canary.name }}
+              key: {{ $canary.key }}
+        {{- end }}
+        {{- if or .Values.cloudflare.existingSecret.name .Values.cloudflare.accountId .Values.cloudflare.authToken }}
+        - name: KRAWL_CLOUDFLARE_ACCOUNT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "krawl.cloudflare.secret" . }}
+              key: {{ .Values.cloudflare.existingSecret.accountIdKey | default "cloudflare-account-id" }}
+        - name: KRAWL_CLOUDFLARE_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "krawl.cloudflare.secret" . }}
+              key: {{ .Values.cloudflare.existingSecret.authTokenKey | default "cloudflare-auth-token" }}
+        - name: KRAWL_CLOUDFLARE_ENABLED
+          value: {{ .Values.cloudflare.enabled | quote }}
         {{- end }}
         {{- if .Values.customTemplate.enabled }}
         - name: KRAWL_CUSTOM_TEMPLATE_PATH
           value: "/etc/krawl/templates/custom_page.html"
         {{- end }}
         {{- if eq .Values.mode "scalable" }}
+        {{- $pg := include "krawl.postgres.secret" . | fromJson }}
+        {{- $rd := include "krawl.redis.secret" . | fromJson }}
         - name: KRAWL_MODE
           value: "scalable"
         - name: KRAWL_POSTGRES_HOST
+          {{- if .Values.postgres.existingSecret.hostKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $pg.name }}
+              key: {{ .Values.postgres.existingSecret.hostKey }}
+          {{- else }}
           value: {{ .Values.postgres.host | quote }}
+          {{- end }}
         - name: KRAWL_POSTGRES_PORT
+          {{- if .Values.postgres.existingSecret.portKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $pg.name }}
+              key: {{ .Values.postgres.existingSecret.portKey }}
+          {{- else }}
           value: {{ .Values.postgres.port | quote }}
+          {{- end }}
         - name: KRAWL_POSTGRES_USER
+          {{- if .Values.postgres.existingSecret.userKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $pg.name }}
+              key: {{ .Values.postgres.existingSecret.userKey }}
+          {{- else }}
           value: {{ .Values.postgres.user | quote }}
+          {{- end }}
         - name: KRAWL_POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ (include "krawl.postgres.secret" . | fromJson).name }}
               key: {{ (include "krawl.postgres.secret" . | fromJson).key }}
         - name: KRAWL_POSTGRES_DATABASE
+          {{- if .Values.postgres.existingSecret.databaseKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $pg.name }}
+              key: {{ .Values.postgres.existingSecret.databaseKey }}
+          {{- else }}
           value: {{ .Values.postgres.database | quote }}
+          {{- end }}
         - name: KRAWL_REDIS_HOST
+          {{- if .Values.redis.existingSecret.hostKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $rd.name }}
+              key: {{ .Values.redis.existingSecret.hostKey }}
+          {{- else }}
           value: {{ .Values.redis.host | quote }}
+          {{- end }}
         - name: KRAWL_REDIS_PORT
+          {{- if .Values.redis.existingSecret.portKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $rd.name }}
+              key: {{ .Values.redis.existingSecret.portKey }}
+          {{- else }}
           value: {{ .Values.redis.port | quote }}
+          {{- end }}
         - name: KRAWL_REDIS_DB
           value: {{ .Values.redis.db | quote }}
-        {{- if or .Values.redis.password .Values.redis.existingSecret }}
+        {{- if or .Values.redis.password .Values.redis.existingSecret.name }}
         - name: KRAWL_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -126,6 +193,13 @@ spec:
           value: {{ .Values.redis.hot_ttl | default 30 | quote }}
         - name: KRAWL_REDIS_TABLE_TTL
           value: {{ .Values.redis.table_ttl | default 120 | quote }}
+        {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.extraEnvFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
         - name: config

--- a/helm/templates/secret-ai.yaml
+++ b/helm/templates/secret-ai.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.ai.api_key }}
+{{- if and .Values.config.ai.api_key (not .Values.aiExistingSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/templates/secret-canary.yaml
+++ b/helm/templates/secret-canary.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.canaryTokenUrl (not .Values.canaryExistingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "krawl.fullname" . }}-canary
+  labels:
+    {{- include "krawl.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  canary-token-url: {{ .Values.canaryTokenUrl | quote }}
+{{- end }}

--- a/helm/templates/secret-cloudflare.yaml
+++ b/helm/templates/secret-cloudflare.yaml
@@ -1,0 +1,12 @@
+{{- if and (or .Values.cloudflare.accountId .Values.cloudflare.authToken) (not .Values.cloudflare.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "krawl.fullname" . }}-cloudflare
+  labels:
+    {{- include "krawl.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  cloudflare-account-id: {{ .Values.cloudflare.accountId | quote }}
+  cloudflare-auth-token: {{ .Values.cloudflare.authToken | quote }}
+{{- end }}

--- a/helm/templates/secret-scalable.yaml
+++ b/helm/templates/secret-scalable.yaml
@@ -1,5 +1,5 @@
 {{- if or (eq .Values.mode "scalable") .Values.migration.enabled }}
-{{- if not .Values.postgres.existingSecret }}
+{{- if not .Values.postgres.existingSecret.name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,7 +11,7 @@ stringData:
   postgres-password: {{ .Values.postgres.password | quote }}
 ---
 {{- end }}
-{{- if and .Values.redis.password (not .Values.redis.existingSecret) }}
+{{- if and .Values.redis.password (not .Values.redis.existingSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dashboardPassword (not .Values.dashboardExistingSecret) }}
+{{- if and .Values.dashboardPassword (not .Values.dashboardExistingSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -84,21 +84,53 @@ affinity: {}
 # Dashboard password for protected panels
 # If empty, a random password will be auto-generated and printed in the logs
 dashboardPassword: ""
-# Reference an externally-managed Secret for the dashboard password instead of
-# the chart-managed Secret created from `dashboardPassword`. The Secret must
-# contain the password under the key set by `dashboardExistingSecretKey`
-# (default "dashboard-password").
-dashboardExistingSecret: ""
-dashboardExistingSecretKey: "dashboard-password"
+# Read the dashboard password and/or secret path from an externally-managed
+# Secret (ExternalSecrets / SealedSecrets / Vault) instead of the chart-managed
+# one. `name` empty = use the chart-managed Secret built from `dashboardPassword`.
+# `pathKey` empty = the secret path comes from config.dashboard.secret_path;
+# when set, KRAWL_DASHBOARD_SECRET_PATH is injected from the Secret instead.
+dashboardExistingSecret:
+  name: ""
+  passwordKey: "dashboard-password"
+  pathKey: ""
 
-# Reference an externally-managed Secret for the dashboard secret path
-# (config.dashboard.secret_path). Set this when the secret path is provisioned
-# out-of-band, e.g. by ExternalSecrets / SealedSecrets / Vault. The Secret must
-# contain the path under `dashboardPathExistingSecretKey` (default
-# "dashboard-path"). When set, the env var KRAWL_DASHBOARD_SECRET_PATH is
-# injected from this Secret, overriding whatever is in config.dashboard.secret_path.
-dashboardPathExistingSecret: ""
-dashboardPathExistingSecretKey: "dashboard-path"
+# AI/LLM API key from an externally-managed Secret instead of the chart-managed
+# one built from `config.ai.api_key`. `name` empty = chart-managed.
+aiExistingSecret:
+  name: ""
+  key: "ai-api-key"
+
+# Canary token URL. Setting `canaryTokenUrl` creates a chart-managed Secret and
+# injects KRAWL_CANARY_TOKEN_URL from it, keeping the URL out of the ConfigMap.
+# Set `canaryExistingSecret.name` to read it from an external Secret instead.
+canaryTokenUrl: ""
+canaryExistingSecret:
+  name: ""
+  key: "canary-token-url"
+
+# CloudFlare WAF/banlist sync credentials. Set them inline (chart-managed
+# Secret) or point `existingSecret.name` at an externally-managed one. Either
+# way they are injected as KRAWL_CLOUDFLARE_ACCOUNT_ID / KRAWL_CLOUDFLARE_AUTH_TOKEN
+# and take precedence over data/webhooks.json, so the sync survives restarts
+# without a persistent volume and the token is never written back to disk.
+cloudflare:
+  enabled: false
+  accountId: ""
+  authToken: ""
+  existingSecret:
+    name: ""
+    accountIdKey: "cloudflare-account-id"
+    authTokenKey: "cloudflare-auth-token"
+
+# Extra environment variables for the Krawl container, e.g. any KRAWL_* setting
+# this chart does not model yet. `extraEnvFrom` accepts secretRef/configMapRef
+# entries, which is the escape hatch for External Secrets Operator / Vault.
+extraEnv: []
+#  - name: KRAWL_LOG_LEVEL
+#    value: "INFO"
+extraEnvFrom: []
+#  - secretRef:
+#      name: krawl-external-secrets
 
 # Application configuration (config.yaml structure)
 config:
@@ -235,15 +267,19 @@ postgres:
   user: "krawl"
   password: "krawl"
   database: "krawl"
-  # Use an externally-managed Secret for the PostgreSQL password instead of the
-  # plaintext `password` field. The Secret must contain the password under the
-  # key set by `existingSecretKey` (default "postgres-password"). When set, the
-  # chart-managed Secret for postgres is not created and the PostgreSQL
-  # StatefulSet + Krawl Deployment + migration Job all read the password from
-  # this Secret. Combine with `postgres.enabled: false` to point at a fully
-  # external instance.
-  existingSecret: ""
-  existingSecretKey: "postgres-password"
+  # Read credentials from an externally-managed Secret. `name` empty = use the
+  # chart-managed Secret built from `password` above. Any connection key left
+  # empty falls back to the plaintext value above.
+  # Setting `name` skips the chart-managed postgres Secret; the Krawl
+  # Deployment, the bundled StatefulSet and the migration Job all read from it.
+  # Combine with `postgres.enabled: false` for a fully external instance.
+  existingSecret:
+    name: ""
+    passwordKey: "postgres-password"
+    userKey: ""
+    hostKey: ""
+    portKey: ""
+    databaseKey: ""
   image:
     repository: postgres
     tag: "16-alpine"
@@ -273,14 +309,17 @@ redis:
   cache_ttl: 600    # Dashboard warmup data (default: 10 minutes)
   hot_ttl: 30       # Hot-path data like ban info (default: 30 seconds)
   table_ttl: 120    # Paginated dashboard tables (default: 2 minutes)
-  # Use an externally-managed Secret for the Redis password instead of the
-  # plaintext `password` field. The Secret must contain the password under the
-  # key set by `existingSecretKey` (default "redis-password"). When set, the
-  # chart-managed Secret for redis is not created and the Redis StatefulSet +
-  # Krawl Deployment both read the password from this Secret. Set
-  # `redis.enabled: false` to use a fully external Redis instance.
-  existingSecret: ""
-  existingSecretKey: "redis-password"
+  # Read credentials from an externally-managed Secret. `name` empty = use the
+  # chart-managed Secret built from `password` above. Any connection key left
+  # empty falls back to the plaintext value above.
+  # Setting `name` skips the chart-managed redis Secret; the Krawl Deployment
+  # and the bundled StatefulSet both read from it. Combine with
+  # `redis.enabled: false` for a fully external instance.
+  existingSecret:
+    name: ""
+    passwordKey: "redis-password"
+    hostKey: ""
+    portKey: ""
   image:
     repository: redis
     tag: "7-alpine"

--- a/src/webhooks.py
+++ b/src/webhooks.py
@@ -44,11 +44,31 @@ def _default_config() -> dict:
     }
 
 
+# CloudFlare credentials may come from the environment (k8s Secrets) instead of
+# webhooks.json. Env always wins and is never written back to disk.
+_CF_ENV = {
+    "account_id": "KRAWL_CLOUDFLARE_ACCOUNT_ID",
+    "auth_token": "KRAWL_CLOUDFLARE_AUTH_TOKEN",
+}
+
+
+def _apply_cf_env(data: dict) -> dict:
+    cf = data.setdefault("cloudflare", {})
+    for key, env_var in _CF_ENV.items():
+        value = os.environ.get(env_var)
+        if value:
+            cf[key] = value
+    enabled = os.environ.get("KRAWL_CLOUDFLARE_ENABLED")
+    if enabled is not None:
+        cf["enabled"] = enabled.lower() in ("true", "yes", "1")
+    return data
+
+
 def load_config() -> dict:
     path = _get_config_path()
     with _lock:
         if not os.path.exists(path):
-            return _default_config()
+            return _apply_cf_env(_default_config())
         try:
             with open(path) as f:
                 data = json.load(f)
@@ -60,18 +80,23 @@ def load_config() -> dict:
                     for k2, v2 in val.items():
                         if k2 not in data[key]:
                             data[key][k2] = v2
-            return data
+            return _apply_cf_env(data)
         except (json.JSONDecodeError, OSError) as e:
             get_app_logger().warning(f"[Webhooks] Failed to load config: {e}")
-            return _default_config()
+            return _apply_cf_env(_default_config())
 
 
 def save_config(data: dict) -> None:
     path = _get_config_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
+    # Drop env-provided credentials so they stay only in the environment.
+    to_write = json.loads(json.dumps(data))
+    for key, env_var in _CF_ENV.items():
+        if os.environ.get(env_var):
+            to_write.get("cloudflare", {})[key] = ""
     with _lock:
         with open(path, "w") as f:
-            json.dump(data, f, indent=2)
+            json.dump(to_write, f, indent=2)
 
 
 def get_cloudflare_config() -> dict:


### PR DESCRIPTION
This pull request makes significant improvements to the Helm chart for the Krawl honeypot server by unifying and expanding support for externally-managed Kubernetes Secrets across all major credentials and configuration options. It introduces new values for referencing external Secrets, enhances flexibility for secret key mapping, and adds support for additional secret-based configuration (such as CloudFlare credentials and canary tokens). The documentation and template logic are updated accordingly to reflect these changes.

**Key changes include:**

### Unified and Expanded External Secret Support

* Refactored values for referencing external Secrets for dashboard, AI API key, canary token, CloudFlare credentials, PostgreSQL, and Redis, replacing legacy flat fields with structured objects (e.g., `dashboardExistingSecret`, `aiExistingSecret`, `canaryExistingSecret`, `cloudflare.existingSecret`, `postgres.existingSecret`, `redis.existingSecret`). This allows specifying both the Secret name and the key for each credential, and supports optional overrides for host, port, user, and database where applicable. [[1]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L87-R133) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L238-R282) [[3]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L258-R271) [[4]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L293-R308) [[5]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L314-R331)

* Added support for new secret-backed configuration options:
  - AI/LLM API key (`aiExistingSecret`)
  - Canary token URL (`canaryTokenUrl` and `canaryExistingSecret`)
  - CloudFlare credentials (`cloudflare.existingSecret`) [[1]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L258-R271) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L87-R133) [[3]](diffhunk://#diff-c149ca69fc2c5ec39dfc99a2df8347780ca89e06b44f9f77bee45538c5584660R1-R11) [[4]](diffhunk://#diff-cc3de2dac02ddd6d39e7317ed9a8b1af6050926ae9cadf4ca1525b4b78987149R1-R12)

### Template and Logic Enhancements

* Updated all relevant templates (`_helpers.tpl`, `deployment.yaml`, `secret-ai.yaml`, `secret-canary.yaml`, `secret-cloudflare.yaml`, `secret-scalable.yaml`, `secret.yaml`) to use the new Secret reference structure, supporting both chart-managed and externally-managed secrets for all credentials. [[1]](diffhunk://#diff-f1a6324c375e55f92a8e4e1e5cc78ba3cc846c4869deb2d1659841257a325bceL69-R88) [[2]](diffhunk://#diff-f1a6324c375e55f92a8e4e1e5cc78ba3cc846c4869deb2d1659841257a325bceL97-R125) [[3]](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435L69-R183) [[4]](diffhunk://#diff-132430817ae74d6e3cde3d41eb82bbac41c7c24f76862776a454a7f3e2913065L1-R1) [[5]](diffhunk://#diff-c149ca69fc2c5ec39dfc99a2df8347780ca89e06b44f9f77bee45538c5584660R1-R11) [[6]](diffhunk://#diff-cc3de2dac02ddd6d39e7317ed9a8b1af6050926ae9cadf4ca1525b4b78987149R1-R12) [[7]](diffhunk://#diff-88709c9194a792909f106b8a7cc6980718eb71834376b4a921ebf8dc02f6a53cL2-R2) [[8]](diffhunk://#diff-88709c9194a792909f106b8a7cc6980718eb71834376b4a921ebf8dc02f6a53cL14-R14) [[9]](diffhunk://#diff-488441c4b047082e5a49e881768927eac438f782a2c96cc1c536c8e29cef8956L1-R1)

* Enhanced the deployment logic to allow reading host, port, user, and database from external Secrets for both PostgreSQL and Redis, not just passwords, increasing flexibility for externalized infrastructure.

* Added `extraEnv` and `extraEnvFrom` values to allow for arbitrary additional environment variables and environment sources (e.g., for use with External Secrets Operator or Vault). [[1]](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435R197-R203) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L87-R133)

### Documentation and Versioning

* Updated `README.md` to document all new and changed values, providing clear guidance on how to use external Secrets for each supported configuration. [[1]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L258-R271) [[2]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L293-R308) [[3]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L314-R331)

* Bumped chart and app version to `2.2.13` to reflect these breaking and feature changes.

Closes #243 