### PR TITLE
fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,4 +509,4 @@ Contributions welcome! Please:
 > This is a deception/honeypot system. Deploy in isolated environments and monitor carefully for security events. Use responsibly and in compliance with applicable laws and regulations.
 
 ## Star History
-<img src="https://api.star-history.com/svg?repos=BlessedRebuS/Krawl&type=Date" width="600" alt="Star History Chart" />
+<img src="https://star-history.dera.page/svg?repos=BlessedRebuS/Krawl&type=Date" width="600" alt="Star History Chart" />


### PR DESCRIPTION
The star history chart displayed in the README was broken because of the GitHub stargazer API restrictions. This change points it to a working alternative so the chart renders correctly again.