### PR TITLE
Feat: ram usage and disk cleanup optimization

### DIFF
--- a/src/auth_store.py
+++ b/src/auth_store.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+"""
+Dashboard session tokens and bruteforce counters.
+
+Redis in scalable mode, so every replica sees the same sessions and the same
+lockout; a process-local dict in standalone. Holding these per-process meant a
+cookie issued by one pod was unknown to the next, and the 5-attempt lockout
+applied per pod rather than per attacker.
+
+Both kinds of entry expire, which also keeps the standalone dicts from growing
+for the lifetime of the process.
+"""
+
+import json
+import threading
+import time
+
+from dashboard_cache import get_backend, get_redis_client
+
+_SESSION_PREFIX = "krawl:auth:session:"
+_ATTEMPT_PREFIX = "krawl:auth:attempts:"
+
+SESSION_TTL = 12 * 3600
+ATTEMPT_TTL = 3600
+
+_lock = threading.Lock()
+_sessions: dict[str, float] = {}  # token -> expires_at
+_attempts: dict[str, tuple[dict, float]] = {}  # ip -> (record, expires_at)
+
+
+def _redis():
+    """Return the Redis client when scalable mode is active, else None."""
+    return get_redis_client() if get_backend() == "scalable" else None
+
+
+def create_session(token: str) -> None:
+    """Register a new authenticated session."""
+    r = _redis()
+    if r is not None:
+        r.setex(f"{_SESSION_PREFIX}{token}", SESSION_TTL, "1")
+        return
+    with _lock:
+        _sessions[token] = time.time() + SESSION_TTL
+
+
+def is_valid_session(token: str | None) -> bool:
+    """True if the token identifies a live session."""
+    if not token:
+        return False
+    r = _redis()
+    if r is not None:
+        return bool(r.exists(f"{_SESSION_PREFIX}{token}"))
+    with _lock:
+        expires = _sessions.get(token)
+        if expires is None:
+            return False
+        if expires < time.time():
+            del _sessions[token]
+            return False
+        return True
+
+
+def destroy_session(token: str | None) -> None:
+    """Invalidate a session (logout)."""
+    if not token:
+        return
+    r = _redis()
+    if r is not None:
+        r.delete(f"{_SESSION_PREFIX}{token}")
+        return
+    with _lock:
+        _sessions.pop(token, None)
+
+
+def get_attempts(ip: str) -> dict | None:
+    """Return the failed-attempt record for an IP, if any."""
+    r = _redis()
+    if r is not None:
+        raw = r.get(f"{_ATTEMPT_PREFIX}{ip}")
+        return json.loads(raw) if raw else None
+    with _lock:
+        entry = _attempts.get(ip)
+        if entry is None:
+            return None
+        record, expires = entry
+        if expires < time.time():
+            del _attempts[ip]
+            return None
+        return record
+
+
+def save_attempts(ip: str, record: dict) -> None:
+    """Persist the failed-attempt record for an IP."""
+    ttl = max(ATTEMPT_TTL, int(record.get("locked_until", 0) - time.time()) + 60)
+    r = _redis()
+    if r is not None:
+        r.setex(f"{_ATTEMPT_PREFIX}{ip}", ttl, json.dumps(record))
+        return
+    with _lock:
+        _attempts[ip] = (record, time.time() + ttl)
+
+
+def clear_attempts(ip: str) -> None:
+    """Drop an IP's failed-attempt record (successful login)."""
+    r = _redis()
+    if r is not None:
+        r.delete(f"{_ATTEMPT_PREFIX}{ip}")
+        return
+    with _lock:
+        _attempts.pop(ip, None)
+
+
+def count_locked() -> int:
+    """IPs currently serving a bruteforce lockout (for metrics)."""
+    now = time.time()
+    r = _redis()
+    if r is not None:
+        locked = 0
+        for key in r.scan_iter(match=f"{_ATTEMPT_PREFIX}*", count=200):
+            raw = r.get(key)
+            if raw and json.loads(raw).get("locked_until", 0) > now:
+                locked += 1
+        return locked
+    with _lock:
+        return sum(
+            1
+            for record, expires in _attempts.values()
+            if expires > now and record.get("locked_until", 0) > now
+        )

--- a/src/banlist_sync.py
+++ b/src/banlist_sync.py
@@ -5,16 +5,25 @@ import requests
 
 from logger import get_app_logger
 
-_global_banlist: set[str] = set()
+# Frozen and swapped wholesale: the ban-check middleware reads this on every
+# request, and copying a 100k-entry set per request cost ~4 MiB each time.
+_global_banlist: frozenset[str] = frozenset()
 _banlist_sources: list[dict] = []
 _last_refresh: float = 0.0
 _lock = threading.Lock()
 
 
-def get_global_banlist() -> set[str]:
-    """Return the current in-memory global banlist (IPs from all sources)."""
-    with _lock:
-        return _global_banlist.copy()
+def get_global_banlist() -> frozenset[str]:
+    """Return the current in-memory global banlist (IPs from all sources).
+
+    The returned set is immutable and shared — do not copy it on hot paths.
+    """
+    return _global_banlist
+
+
+def is_globally_banned(ip: str) -> bool:
+    """Membership test against the global banlist, without copying it."""
+    return ip in _global_banlist
 
 
 def get_banlist_sources() -> list[dict]:
@@ -28,6 +37,8 @@ def refresh_banlist_sources(*, source_urls: list[str] | None = None) -> None:
 
     Called on startup and periodically by the refresh_banlist task.
     """
+    global _global_banlist, _last_refresh
+
     from config import get_config
 
     config = get_config()
@@ -35,7 +46,7 @@ def refresh_banlist_sources(*, source_urls: list[str] | None = None) -> None:
 
     if not urls:
         with _lock:
-            _global_banlist.clear()
+            _global_banlist = frozenset()
             _banlist_sources.clear()
             _last_refresh = time.time()
         return
@@ -67,8 +78,8 @@ def refresh_banlist_sources(*, source_urls: list[str] | None = None) -> None:
         sources_info.append(entry)
 
     with _lock:
-        _global_banlist.clear()
-        _global_banlist.update(combined)
+        # Rebind, not clear()+update(): readers saw an empty banlist mid-update.
+        _global_banlist = frozenset(combined)
         _banlist_sources.clear()
         _banlist_sources.extend(sources_info)
         _last_refresh = time.time()

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -8,6 +8,7 @@ exposed as attributes on DatabaseManager (db.access_logs, db.ip_stats, ...).
 from database.core import (
     DatabaseManager,
     get_database,
+    get_dropped_rows,
     get_write_buffer_size,
     initialize_database,
 )
@@ -15,6 +16,7 @@ from database.core import (
 __all__ = [
     "DatabaseManager",
     "get_database",
+    "get_dropped_rows",
     "get_write_buffer_size",
     "initialize_database",
 ]

--- a/src/database/core.py
+++ b/src/database/core.py
@@ -396,9 +396,7 @@ class DatabaseManager:
             # sort_by_parameter_order: without it RETURNING order is undefined
             # and detections attach to the wrong rows.
             log_ids = session.scalars(
-                insert(AccessLog).returning(
-                    AccessLog.id, sort_by_parameter_order=True
-                ),
+                insert(AccessLog).returning(AccessLog.id, sort_by_parameter_order=True),
                 logs,
             ).all()
 

--- a/src/database/core.py
+++ b/src/database/core.py
@@ -12,7 +12,7 @@ import threading
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, insert
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from database.access_logs import AccessLogRepo
@@ -56,21 +56,35 @@ def _ban_multiplier_for(total_violations: int) -> int:
 # buffered in memory and flushed in bulk every few seconds by a background task.
 # IP stats counters are still updated synchronously (needed for ban checks).
 
-_write_buffer: collections.deque = collections.deque()
-_write_lock = threading.Lock()
+# Statement size, not a per-flush ceiling: the flush loops until drained.
 _FLUSH_BATCH_SIZE = 200
+# ~60 MiB at 1.2 KB/entry. Hitting it means the flush task is behind; the
+# oldest rows are dropped and counted rather than growing until OOM.
+_MAX_BUFFER_ROWS = 50_000
+
+_write_buffer: collections.deque = collections.deque(maxlen=_MAX_BUFFER_ROWS)
+_write_lock = threading.Lock()
+_dropped_rows = 0
 
 
 def _buffer_access_log_entry(**kwargs) -> None:
     """Append an access-log entry to the in-memory write buffer."""
+    global _dropped_rows
     kwargs["_buffered_at"] = datetime.now()
     with _write_lock:
+        if len(_write_buffer) == _MAX_BUFFER_ROWS:
+            _dropped_rows += 1  # maxlen evicts from the left on append
         _write_buffer.append(kwargs)
 
 
 def get_write_buffer_size() -> int:
     """Return current buffer depth (for monitoring)."""
     return len(_write_buffer)
+
+
+def get_dropped_rows() -> int:
+    """Access-log rows dropped because the buffer was full (for monitoring)."""
+    return _dropped_rows
 
 
 class DatabaseManager:
@@ -328,54 +342,85 @@ class DatabaseManager:
         finally:
             self.close_session()
 
-    def flush_access_log_buffer(self) -> int:
+    def _pop_batch(self, n: int) -> list[dict]:
+        """Remove up to n entries from the front of the write buffer."""
+        with _write_lock:
+            return [_write_buffer.popleft() for _ in range(min(len(_write_buffer), n))]
+
+    def flush_access_log_buffer(self, max_rows: int = 50_000) -> int:
         """
         Bulk-insert buffered access log entries into the database.
 
-        Called periodically by a background task in scalable mode.
+        Drains in _FLUSH_BATCH_SIZE statements until empty, so the flush rate
+        follows arrival rate. max_rows caps the work one run may do.
+
         Returns the number of entries flushed.
         """
-        entries = []
-        with _write_lock:
-            for _ in range(min(len(_write_buffer), _FLUSH_BATCH_SIZE)):
-                entries.append(_write_buffer.popleft())
+        total = 0
+        while total < max_rows:
+            entries = self._pop_batch(_FLUSH_BATCH_SIZE)
+            if not entries:
+                break
+            inserted = self._insert_access_log_batch(entries)
+            if inserted == 0:
+                break  # batch failed and was re-queued; stop to avoid spinning
+            total += inserted
+        return total
 
-        if not entries:
-            return 0
-
+    def _insert_access_log_batch(self, entries: list[dict]) -> int:
+        """Insert one batch of buffered entries: two statements, not two per row."""
         session = self.session
         try:
+            logs, attacks_per_entry = [], []
             for entry in entries:
                 ts = entry.pop("_buffered_at", datetime.now())
-                attack_types = entry.pop("attack_types", None)
-                matched_patterns = entry.pop("matched_patterns", None) or {}
-
-                access_log = AccessLog(
-                    ip=sanitize_ip(entry["ip"]),
-                    path=sanitize_path(entry["path"]),
-                    user_agent=sanitize_user_agent(entry.get("user_agent", "")),
-                    method=(entry.get("method", "GET"))[:10],
-                    is_suspicious=entry.get("is_suspicious", False),
-                    is_honeypot_trigger=entry.get("is_honeypot_trigger", False),
-                    timestamp=ts,
-                    raw_request=entry.get("raw_request"),
+                attacks_per_entry.append(
+                    (
+                        entry.pop("attack_types", None),
+                        entry.pop("matched_patterns", None) or {},
+                    )
                 )
-                session.add(access_log)
+                logs.append(
+                    {
+                        "ip": sanitize_ip(entry["ip"]),
+                        "path": sanitize_path(entry["path"]),
+                        "user_agent": sanitize_user_agent(entry.get("user_agent", "")),
+                        "method": (entry.get("method", "GET"))[:10],
+                        "is_suspicious": entry.get("is_suspicious", False),
+                        "is_honeypot_trigger": entry.get("is_honeypot_trigger", False),
+                        "timestamp": ts,
+                        "raw_request": entry.get("raw_request"),
+                    }
+                )
 
-                if attack_types:
-                    session.flush()
-                    for attack_type in attack_types:
-                        detection = AttackDetection(
-                            access_log_id=access_log.id,
-                            attack_type=attack_type[:50],
-                            matched_pattern=sanitize_attack_pattern(
-                                matched_patterns.get(attack_type, "")
-                            ),
-                        )
-                        session.add(detection)
+            # sort_by_parameter_order: without it RETURNING order is undefined
+            # and detections attach to the wrong rows.
+            log_ids = session.scalars(
+                insert(AccessLog).returning(
+                    AccessLog.id, sort_by_parameter_order=True
+                ),
+                logs,
+            ).all()
+
+            detections = [
+                {
+                    "access_log_id": log_id,
+                    "attack_type": attack_type[:50],
+                    "matched_pattern": sanitize_attack_pattern(
+                        patterns.get(attack_type, "")
+                    ),
+                }
+                for log_id, (types, patterns) in zip(
+                    log_ids, attacks_per_entry, strict=True
+                )
+                if types
+                for attack_type in types
+            ]
+            if detections:
+                session.execute(insert(AttackDetection), detections)
 
             session.commit()
-            return len(entries)
+            return len(logs)
 
         except Exception as e:
             session.rollback()

--- a/src/database/ip_stats.py
+++ b/src/database/ip_stats.py
@@ -393,6 +393,26 @@ class IpStatsRepo:
         finally:
             self._db.close_session()
 
+    def mark_analysed(self, ip: str, when: datetime) -> None:
+        """Clear the reevaluation flag without changing the category.
+
+        For IPs with no access logs left in the analysis window: there is
+        nothing to score, but the flag has to clear or the IP is re-read on
+        every run forever.
+        """
+        session = self._db.session
+        try:
+            session.query(IpStats).filter(IpStats.ip == sanitize_ip(ip)).update(
+                {IpStats.last_analysis: when, IpStats.need_reevaluation: False},
+                synchronize_session=False,
+            )
+            session.commit()
+        except Exception as e:
+            session.rollback()
+            applogger.error(f"Error marking {ip} analysed: {e}")
+        finally:
+            self._db.close_session()
+
     def manual_update_category(self, ip: str, category: str) -> None:
         """
         Update IP category as a result of a manual intervention by an admin
@@ -660,8 +680,10 @@ class IpStatsRepo:
                 .filter(
                     IpStats.last_seen >= last_seen_cutoff,
                     IpStats.last_analysis <= last_analysis_cutoff,
-                    not IpStats.need_reevaluation,
-                    not IpStats.manual_category,
+                    # `not <column>` is Python truthiness: it collapsed to False,
+                    # so this update matched nothing and never flagged an IP.
+                    IpStats.need_reevaluation.isnot(True),
+                    IpStats.manual_category.isnot(True),
                 )
                 .update(
                     {IpStats.need_reevaluation: True},
@@ -689,8 +711,8 @@ class IpStatsRepo:
             count = (
                 session.query(IpStats)
                 .filter(
-                    not IpStats.need_reevaluation,
-                    not IpStats.manual_category,
+                    IpStats.need_reevaluation.isnot(True),
+                    IpStats.manual_category.isnot(True),
                 )
                 .update(
                     {IpStats.need_reevaluation: True},

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -83,8 +83,24 @@ def get_client_ip(request: Request) -> str:
     return "0.0.0.0"  # noqa: S104 — sentinel for unknown client, not a socket bind
 
 
+# Keep the request line, headers and start of body; never a whole upload.
+MAX_RAW_REQUEST = 16 * 1024
+
+# Starlette caches request.body() for the middleware and the route to share;
+# refusing early on content-length keeps that shared copy small.
+MAX_BODY_BYTES = 64 * 1024
+
+
+def body_too_large(request: Request) -> bool:
+    """True when the declared body exceeds what we are willing to buffer."""
+    try:
+        return int(request.headers.get("content-length") or 0) > MAX_BODY_BYTES
+    except ValueError:
+        return False
+
+
 def build_raw_request(request: Request, body: str = "") -> str:
-    """Build raw HTTP request string for forensic analysis."""
+    """Build raw HTTP request string for forensic analysis (capped)."""
     try:
         raw = f"{request.method} {request.url.path}"
         if request.url.query:
@@ -99,6 +115,6 @@ def build_raw_request(request: Request, body: str = "") -> str:
         if body:
             raw += body
 
-        return raw
+        return raw[:MAX_RAW_REQUEST]
     except Exception as e:
         return f"{request.method} {request.url.path} (error building full request: {str(e)})"

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -19,7 +19,6 @@ Two families of metrics:
 """
 
 import re
-import time
 
 from prometheus_client import REGISTRY, Gauge
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
@@ -105,6 +104,24 @@ class KrawlMetricsCollector:
         except Exception as e:
             app_logger.error(f"collect clients_total failed: {e}")
         yield clients
+
+        # Rising depth means the flush task is behind — visible as RSS growth
+        # long before anything else. Alert on krawl_write_buffer_rows > 10000.
+        try:
+            from database import get_dropped_rows, get_write_buffer_size
+
+            yield GaugeMetricFamily(
+                "krawl_write_buffer_rows",
+                "Access-log rows waiting to be flushed to the database",
+                value=get_write_buffer_size(),
+            )
+            yield CounterMetricFamily(
+                "krawl_write_buffer_dropped",
+                "Access-log rows dropped because the write buffer was full",
+                value=get_dropped_rows(),
+            )
+        except Exception as e:
+            app_logger.error(f"collect write buffer metrics failed: {e}")
 
         timed_out = GaugeMetricFamily(
             "krawl_timed_out_ips",
@@ -194,15 +211,9 @@ def refresh_system(db) -> None:
         app_logger.error(f"refresh_system: unenriched_ips failed: {e}")
 
     try:
-        from routes.api import _auth_attempts
+        from auth_store import count_locked
 
-        now = time.time()
-        locked = sum(
-            1
-            for record in _auth_attempts.values()
-            if record.get("locked_until", 0) > now
-        )
-        auth_locked_ips.set(locked)
+        auth_locked_ips.set(count_locked())
     except Exception as e:
         app_logger.error(f"refresh_system: auth_locked_ips failed: {e}")
 

--- a/src/middleware/ban_check.py
+++ b/src/middleware/ban_check.py
@@ -53,10 +53,9 @@ class BanCheckMiddleware(BaseHTTPMiddleware):
 
         # Check global banlist (external maintainer sources)
         if config.banlist_export_path or config.banlist_sources:
-            from banlist_sync import get_global_banlist
+            from banlist_sync import is_globally_banned
 
-            global_bans = get_global_banlist()
-            if client_ip in global_bans:
+            if is_globally_banned(client_ip):
                 get_access_logger().info(
                     f"[GLOBAL-BANNED] [{request.method}] {client_ip} - {request.url.path}"
                 )

--- a/src/middleware/deception.py
+++ b/src/middleware/deception.py
@@ -10,7 +10,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from deception_responses import detect_and_respond_deception
-from dependencies import build_raw_request, get_client_ip
+from dependencies import body_too_large, build_raw_request, get_client_ip
 from logger import get_access_logger, get_app_logger
 
 
@@ -32,8 +32,11 @@ class DeceptionMiddleware(BaseHTTPMiddleware):
         body = ""
         if method == "POST":
             try:
-                body_bytes = await request.body()
-                body = body_bytes.decode("utf-8", errors="replace")
+                if body_too_large(request):
+                    body = ""
+                else:
+                    body_bytes = await request.body()
+                    body = body_bytes.decode("utf-8", errors="replace")
             except Exception:
                 # Client disconnected before body was fully sent
                 body = ""

--- a/src/models.py
+++ b/src/models.py
@@ -64,7 +64,9 @@ class AccessLog(Base):
         DateTime, nullable=False, default=datetime.utcnow, index=True
     )
     # Raw HTTP request for forensic analysis (nullable for backward compatibility)
-    raw_request: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Deferred: largest column on the busiest table, read only by the
+    # raw-request modal (by id). Eager loading dragged it into every query.
+    raw_request: Mapped[str | None] = mapped_column(Text, nullable=True, deferred=True)
 
     # Relationship to attack detections
     attack_detections: Mapped[list["AttackDetection"]] = relationship(

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -23,6 +23,14 @@ from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyCookie
 from pydantic import BaseModel, validator
 
+from auth_store import (
+    clear_attempts,
+    create_session,
+    destroy_session,
+    get_attempts,
+    is_valid_session,
+    save_attempts,
+)
 from config import get_config
 from dashboard_cache import (
     get_cached,
@@ -35,12 +43,8 @@ from dashboard_cache import (
 from dependencies import get_client_ip, get_db
 from logger import get_app_logger
 
-# Server-side session token store (valid tokens for authenticated sessions)
-_auth_tokens: set = set()
-
-# Bruteforce protection: tracks failed attempts per IP
-# { ip: { "attempts": int, "locked_until": float } }
-_auth_attempts: dict = {}
+# Sessions and bruteforce counters live in auth_store: Redis in scalable mode
+# so they are shared by every replica, a local dict in standalone.
 _AUTH_MAX_ATTEMPTS = 5
 _AUTH_BASE_LOCKOUT = 30  # seconds, doubles on each lockout
 
@@ -62,8 +66,7 @@ class AuthRequest(BaseModel):
 
 def verify_auth(request: Request) -> bool:
     """Check if the request has a valid auth session cookie."""
-    token = request.cookies.get("krawl_auth")
-    return token is not None and token in _auth_tokens
+    return is_valid_session(request.cookies.get("krawl_auth"))
 
 
 class Unauthorized(Exception):
@@ -81,7 +84,7 @@ _cookie_scheme = APIKeyCookie(
 
 def require_auth(token: str | None = Depends(_cookie_scheme)) -> None:
     """Route dependency: 401 JSON unless the session cookie is valid."""
-    if token is None or token not in _auth_tokens:
+    if not is_valid_session(token):
         raise Unauthorized()
 
 
@@ -90,7 +93,7 @@ async def authenticate(request: Request, body: AuthRequest):
     ip = get_client_ip(request)
 
     # Check if IP is currently locked out
-    record = _auth_attempts.get(ip)
+    record = get_attempts(ip)
     if record and record["locked_until"] > time.time():
         remaining = int(record["locked_until"] - time.time())
         return JSONResponse(
@@ -107,10 +110,10 @@ async def authenticate(request: Request, body: AuthRequest):
     expected = config.dashboard_password.strip()
     if hmac.compare_digest(body.password, expected):
         # Success — clear failed attempts
-        _auth_attempts.pop(ip, None)
+        clear_attempts(ip)
         get_app_logger().info(f"[AUTH] Successful login from {ip}")
         token = secrets.token_hex(32)
-        _auth_tokens.add(token)
+        create_session(token)
         response = JSONResponse(content={"authenticated": True})
         response.set_cookie(
             key="krawl_auth",
@@ -124,7 +127,6 @@ async def authenticate(request: Request, body: AuthRequest):
     get_app_logger().warning(f"[AUTH] Failed login attempt from {ip}")
     if not record:
         record = {"attempts": 0, "locked_until": 0, "lockouts": 0}
-        _auth_attempts[ip] = record
     record["attempts"] += 1
 
     if record["attempts"] >= _AUTH_MAX_ATTEMPTS:
@@ -132,6 +134,7 @@ async def authenticate(request: Request, body: AuthRequest):
         record["locked_until"] = time.time() + lockout
         record["lockouts"] += 1
         record["attempts"] = 0
+        save_attempts(ip, record)
         get_app_logger().warning(
             f"Auth bruteforce: IP {ip} locked out for {lockout}s "
             f"(lockout #{record['lockouts']})"
@@ -146,6 +149,7 @@ async def authenticate(request: Request, body: AuthRequest):
             status_code=429,
         )
 
+    save_attempts(ip, record)
     remaining_attempts = _AUTH_MAX_ATTEMPTS - record["attempts"]
     return JSONResponse(
         content={
@@ -158,9 +162,7 @@ async def authenticate(request: Request, body: AuthRequest):
 
 @router.post("/api/auth/logout")
 async def logout(request: Request):
-    token = request.cookies.get("krawl_auth")
-    if token and token in _auth_tokens:
-        _auth_tokens.discard(token)
+    destroy_session(request.cookies.get("krawl_auth"))
     response = JSONResponse(content={"authenticated": False})
     response.delete_cookie(key="krawl_auth")
     return response

--- a/src/routes/honeypot.py
+++ b/src/routes/honeypot.py
@@ -22,6 +22,7 @@ from deception_responses import (
     get_sql_response_with_data,
 )
 from dependencies import (
+    body_too_large,
     build_raw_request,
     get_client_ip,
 )
@@ -45,8 +46,10 @@ from wordlists import get_wordlists
 
 
 async def _safe_body(request: Request) -> str:
-    """Read request body, returning empty string on client disconnect."""
+    """Read the request body, bounded, empty on client disconnect."""
     try:
+        if body_too_large(request):
+            return ""
         body_bytes = await request.body()
         return body_bytes.decode("utf-8", errors="replace")
     except Exception:

--- a/src/tasks/analyze_ips.py
+++ b/src/tasks/analyze_ips.py
@@ -21,6 +21,12 @@ TASK_CONFIG = {
     "run_when_loaded": True,
 }
 
+# Upper bound on IPs analysed per run; the remainder is picked up next minute.
+# Sized from the real workload: the vast majority of flagged IPs have under 100
+# rows to read, so 2000 fits comfortably inside the one-minute window while
+# still capping the worst case at 2000 x 10,000 rows.
+MAX_IPS_PER_RUN = 2000
+
 
 def main():
     config = get_config()
@@ -123,6 +129,16 @@ def main():
         )
         return
 
+    # flag-stale-ips flags every stale IP at once (daily), and each IP costs a
+    # 10,000-row read. Take a slice per run; the task fires every minute.
+    pending = len(ips_to_analyze)
+    if pending > MAX_IPS_PER_RUN:
+        ips_to_analyze = set(sorted(ips_to_analyze)[:MAX_IPS_PER_RUN])
+        app_logger.info(
+            f"[Background Task] analyze-ips: {pending} IPs pending, "
+            f"analysing {MAX_IPS_PER_RUN} this run"
+        )
+
     for ip in ips_to_analyze:
         # Get full history for this IP to perform accurate analysis
         ip_accesses = db_manager.access_logs.get_list(
@@ -130,6 +146,9 @@ def main():
         )  # look back up to 30 days of history for better accuracy
         total_accesses_count = len(ip_accesses)
         if total_accesses_count <= 0:
+            # No history left in the window (logs aged out or were purged).
+            # Clear the flag anyway, or this IP is re-read on every run forever.
+            db_manager.ip_stats.mark_analysed(ip, datetime.now())
             continue
 
         # --------------------- HTTP Methods ---------------------

--- a/src/tasks/db_retention.py
+++ b/src/tasks/db_retention.py
@@ -18,6 +18,10 @@ from logger import get_app_logger
 # TASK CONFIG
 # ----------------------
 
+# Rows per delete transaction; the first run after the is_(False) fix has a
+# large backlog to clear.
+DELETE_BATCH_SIZE = 10_000
+
 TASK_CONFIG = {
     "name": "db-retention",
     "cron": "0 3 * * *",  # Run daily at 3 AM
@@ -52,28 +56,42 @@ def main():
 
         cutoff = datetime.now() - timedelta(days=retention_days)
 
-        # Delete attack detections linked to old NON-suspicious access logs (FK constraint)
-        old_nonsuspicious_log_ids = session.query(AccessLog.id).filter(
+        # `not <column>` is Python truthiness, not SQL NOT: it collapses to the
+        # literal False and the whole predicate becomes "AND false", so these
+        # two deletes matched nothing. Use is_(False) — NULL-safe and explicit.
+        purgeable = (
             AccessLog.timestamp < cutoff,
-            not AccessLog.is_suspicious,
-            not AccessLog.is_honeypot_trigger,
-        )
-        detections_deleted = (
-            session.query(AttackDetection)
-            .filter(AttackDetection.access_log_id.in_(old_nonsuspicious_log_ids))
-            .delete(synchronize_session=False)
+            AccessLog.is_suspicious.is_(False),
+            AccessLog.is_honeypot_trigger.is_(False),
         )
 
-        # Delete old non-suspicious access logs (keep suspicious ones)
-        logs_deleted = (
-            session.query(AccessLog)
-            .filter(
-                AccessLog.timestamp < cutoff,
-                not AccessLog.is_suspicious,
-                not AccessLog.is_honeypot_trigger,
+        # Delete in batches: the first run after this fix has a large backlog to
+        # clear, and one statement over millions of rows is a long lock and a
+        # large WAL write.
+        detections_deleted = 0
+        logs_deleted = 0
+        while True:
+            batch_ids = [
+                row[0]
+                for row in session.query(AccessLog.id)
+                .filter(*purgeable)
+                .limit(DELETE_BATCH_SIZE)
+                .all()
+            ]
+            if not batch_ids:
+                break
+
+            detections_deleted += (
+                session.query(AttackDetection)
+                .filter(AttackDetection.access_log_id.in_(batch_ids))
+                .delete(synchronize_session=False)
             )
-            .delete(synchronize_session=False)
-        )
+            logs_deleted += (
+                session.query(AccessLog)
+                .filter(AccessLog.id.in_(batch_ids))
+                .delete(synchronize_session=False)
+            )
+            session.commit()
 
         # IPs to preserve: those with any suspicious access logs
         preserved_ips = (

--- a/src/tasks/pre_retention_cleanup.py
+++ b/src/tasks/pre_retention_cleanup.py
@@ -163,7 +163,9 @@ def main():
                 .filter(
                     AccessLog.timestamp < cutoff,
                     AccessLog.is_suspicious,
-                    not AccessLog.is_honeypot_trigger,
+                    # `not <column>` is Python truthiness: it collapsed to False
+                    # and this query matched nothing.
+                    AccessLog.is_honeypot_trigger.is_(False),
                 )
                 .limit(BATCH_SIZE)
                 .all()


### PR DESCRIPTION
This pull request introduces several improvements to session/token storage, banlist management, access log buffering, and metrics reporting for the Krawl honeypot system. The changes aim to improve scalability, efficiency, and observability, particularly in high-load or multi-instance deployments. The most significant updates include switching to Redis-backed session and bruteforce tracking, optimizing global banlist handling, making access log buffering more robust, and enhancing metrics for operational monitoring.

**Authentication/session storage and brute-force protection:**
- Added a new `auth_store.py` module to centralize session token and bruteforce attempt storage, using Redis in scalable mode for cross-instance consistency and a process-local dictionary in standalone mode. This ensures session tokens and lockouts are shared across all pods, fixing issues with per-pod isolation. Also includes expiration and cleanup logic to prevent unbounded growth.
- Updated metrics to use the new `count_locked()` function from `auth_store.py` to accurately report the number of IPs currently locked out due to bruteforce protection.

**Banlist management:**
- Changed the global banlist to use an immutable `frozenset` that is swapped atomically, preventing expensive copies on every request and eliminating race conditions where the banlist could appear empty during updates. Added a new `is_globally_banned()` function for efficient membership testing. [[1]](diffhunk://#diff-b5d1afbbeb6738799c797f5da1d4110d0496e352a10d05394f79fac49fc4cbc2L8-R26) [[2]](diffhunk://#diff-b5d1afbbeb6738799c797f5da1d4110d0496e352a10d05394f79fac49fc4cbc2R40-R49) [[3]](diffhunk://#diff-b5d1afbbeb6738799c797f5da1d4110d0496e352a10d05394f79fac49fc4cbc2L70-R82) [[4]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7L56-R58)

**Access log buffering and database writes:**
- Made the access log write buffer size-bounded (max 50,000 rows), dropping the oldest entries if the buffer is full and tracking the number of dropped rows. This prevents unbounded memory growth under heavy load. [[1]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64L59-R76) [[2]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64R85-R89)
- Refactored access log flush logic to process batches efficiently and added metrics to expose buffer depth and dropped row counts for monitoring. [[1]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64L331-R423) [[2]](diffhunk://#diff-595e88de1f402f9e039ff56a467520ba15c29cdd5ca8f328091369c1440bae28R108-R125) [[3]](diffhunk://#diff-b3ffde3cc523682e08f3ab79dbb700978cdc75d6db7d9c3daf1b5ce39309d713R11-R19)

**IP stats analysis and reevaluation:**
- Fixed SQLAlchemy filter logic for flagging stale IPs for reevaluation, using `.isnot(True)` instead of Python `not` to ensure correct query semantics. [[1]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aL663-R686) [[2]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aL692-R715)
- Added a `mark_analysed()` method to clear the reevaluation flag for IPs with no access logs left in the analysis window, preventing unnecessary repeated reevaluations.

**Request body handling and middleware:**
- Added logic to cap the size of raw HTTP request data stored for forensic analysis and to skip buffering large request bodies, preventing excessive memory usage when handling large uploads. [[1]](diffhunk://#diff-ef173fd45ba5b889bc97b5fbb29bfe8cf38497c066568375f9d82d92ccb17df9R86-R103) [[2]](diffhunk://#diff-ef173fd45ba5b889bc97b5fbb29bfe8cf38497c066568375f9d82d92ccb17df9L102-R118) [[3]](diffhunk://#diff-06a8a8e57259f5b9689a9bcab037778718311805689c9421c14cdd6e8a1106dcL13-R13) [[4]](diffhunk://#diff-06a8a8e57259f5b9689a9bcab037778718311805689c9421c14cdd6e8a1106dcR35-R37)

These changes collectively improve the system's resilience, performance, and observability in both standalone and scalable deployments.