### PR TITLE
Feat: release 2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ For more details on both modes, see [Deployment Modes](docs/deployment-modes.md)
 The Helm chart **defaults to scalable mode** with bundled PostgreSQL and Redis:
 
 ```bash
-helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.0 \
+helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.1 \
   -n krawl-system --create-namespace \
   --set postgres.password=your-password \
   --set redis.password=your-redis-password \

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.3.0
-appVersion: 2.3.0
+version: 2.3.1
+appVersion: 2.3.1
 keywords:
   - honeypot
   - security

--- a/helm/README.md
+++ b/helm/README.md
@@ -15,7 +15,7 @@ A Helm chart for deploying the Krawl honeypot application on Kubernetes.
 
 ```bash
 helm install krawl oci://ghcr.io/blessedrebus/krawl-chart \
-  --version 2.3.0 \
+  --version 2.3.1 \
   --namespace krawl-system \
   --create-namespace \
   -f values.yaml  # optional
@@ -62,7 +62,7 @@ This deploys PostgreSQL and Redis StatefulSets with Services in the same namespa
 
 Minimal `values-minimal.yaml` for scalable mode:
 
-> **Tip**: For production deployments, pin the image tag to a specific version (e.g., `tag: "2.3.0"`) instead of `latest` to ensure reproducible deployments.
+> **Tip**: For production deployments, pin the image tag to a specific version (e.g., `tag: "2.3.1"`) instead of `latest` to ensure reproducible deployments.
 
 ```yaml
 mode: scalable
@@ -179,7 +179,7 @@ The following table lists the main configuration parameters of the Krawl chart a
 | `mode` | Deployment mode (`standalone` or `scalable`) | `scalable` |
 | `replicaCount` | Number of pod replicas (>1 only in scalable mode) | `1` |
 | `image.repository` | Image repository | `ghcr.io/blessedrebus/krawl` |
-| `image.tag` | Image tag | `2.3.0` |
+| `image.tag` | Image tag | `2.3.1` |
 | `image.pullPolicy` | Image pull policy | `Always` |
 
 ### Service Configuration
@@ -463,7 +463,7 @@ kubectl get secret krawl-server -n krawl-system \
 ### Scalable with bundled PostgreSQL and Redis (default)
 
 ```bash
-helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.0 \
+helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.1 \
   --set replicaCount=3 \
   --set postgres.password=your-password \
   --set redis.password=your-redis-password \
@@ -473,7 +473,7 @@ helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.0 \
 ### Scalable with external PostgreSQL and Redis
 
 ```bash
-helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.0 \
+helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.1 \
   --set replicaCount=3 \
   --set postgres.enabled=false \
   --set postgres.host=your-postgres-host \
@@ -487,7 +487,7 @@ helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.0 \
 ### Standalone with custom settings
 
 ```bash
-helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.0 \
+helm install krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.1 \
   --set mode=standalone \
   --set postgres.enabled=false \
   --set redis.enabled=false \
@@ -509,7 +509,7 @@ helm upgrade krawl ./helm \
 ## Upgrading
 
 ```bash
-helm upgrade krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.0 -f values.yaml
+helm upgrade krawl oci://ghcr.io/blessedrebus/krawl-chart --version 2.3.1 -f values.yaml
 ```
 
 ## Uninstalling

--- a/helm/values-minimal.yaml
+++ b/helm/values-minimal.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: ghcr.io/blessedrebus/krawl
-  tag: "2.3.0"
+  tag: "2.3.1"
   pullPolicy: Always
 
 ingress:

--- a/helm/values-standalone.yaml
+++ b/helm/values-standalone.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/blessedrebus/krawl
-  tag: "2.3.0"
+  tag: "2.3.1"
   pullPolicy: Always
 
 ingress:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/blessedrebus/krawl
   pullPolicy: Always
-  tag: "2.3.0"
+  tag: "2.3.1"
 
 imagePullSecrets: []
 nameOverride: "krawl"

--- a/src/database/core.py
+++ b/src/database/core.py
@@ -20,6 +20,7 @@ from database.analytics import AnalyticsRepo
 from database.credentials import CredentialRepo
 from database.generated_pages import GeneratedPageRepo
 from database.ip_stats import IpStatsRepo
+from ip_utils import defer_persist
 from logger import get_app_logger
 from models import (
     AccessLog,
@@ -506,6 +507,15 @@ class DatabaseManager:
 
         was_new_ip = False
         was_first_honeypot = False
+
+        # A never-before-seen IPv6 address gets no row until it comes back:
+        # rotating proxy pools mint one address per request and never reuse it,
+        # which was 42% of this table. Suspicious traffic is exempt, so nothing
+        # worth investigating is dropped. See ip_utils.defer_persist.
+        if ip_stats is None and defer_persist(
+            sanitized_ip, is_suspicious, is_honeypot_trigger
+        ):
+            return 0, False, False
 
         if ip_stats:
             ip_stats.total_requests += 1

--- a/src/database/ip_stats.py
+++ b/src/database/ip_stats.py
@@ -586,49 +586,38 @@ class IpStatsRepo:
 
     def get_unenriched_ips(self, limit: int = 100) -> list[str]:
         """
-        Get IPs that don't have complete reputation data yet.
-        Returns IPs without country_code, city, latitude, or longitude data.
-        Excludes RFC1918 private addresses and other non-routable IPs.
+        Get IPs that still have no geolocation, newest activity first.
+
+        Coordinates are the only completeness test: they are the one field the
+        provider always returns on success, and they are what the dashboard map
+        needs. City in particular is legitimately empty for many datacenter and
+        hosting ranges — including it here meant a successfully enriched row kept
+        matching this filter forever, and since the batch is capped, those rows
+        monopolised every run and newly seen IPs were never enriched at all.
+
+        Ordering by last_seen keeps the batch pointed at currently active IPs
+        rather than whatever the database happens to return first.
 
         Args:
             limit: Maximum number of IPs to return
 
         Returns:
-            List of IP addresses without complete reputation data
+            List of IP addresses without geolocation data
         """
-        from sqlalchemy.exc import OperationalError
-
         session = self._db.session
         try:
-            # Try to query including latitude/longitude (for backward compatibility)
-            try:
-                ips = (
-                    session.query(IpStats.ip)
-                    .filter(
-                        or_(
-                            IpStats.country_code.is_(None),
-                            IpStats.city.is_(None),
-                            IpStats.latitude.is_(None),
-                            IpStats.longitude.is_(None),
-                        ),
-                    )
-                    .limit(limit)
-                    .all()
+            ips = (
+                session.query(IpStats.ip)
+                .filter(
+                    or_(
+                        IpStats.latitude.is_(None),
+                        IpStats.longitude.is_(None),
+                    ),
                 )
-            except OperationalError as e:
-                # If latitude/longitude columns don't exist yet, fall back to old query
-                if "no such column" in str(e).lower():
-                    ips = (
-                        session.query(IpStats.ip)
-                        .filter(
-                            or_(IpStats.country_code.is_(None), IpStats.city.is_(None)),
-                        )
-                        .limit(limit)
-                        .all()
-                    )
-                else:
-                    raise
-
+                .order_by(IpStats.last_seen.desc())
+                .limit(limit)
+                .all()
+            )
             return [ip[0] for ip in ips]
         finally:
             self._db.close_session()

--- a/src/geo_utils.py
+++ b/src/geo_utils.py
@@ -89,6 +89,42 @@ def extract_geolocation_from_ip(ip_address: str) -> dict[str, Any] | None:
     }
 
 
+# Geolocation is a property of the network, not the address. One /32 in this
+# honeypot produced 24,500 IPv6 addresses that would otherwise have cost 24,500
+# identical API calls. Cache by /48 — the standard site allocation, so the answer
+# is the same for every address inside it.
+# ponytail: plain dict cleared wholesale at the cap. Swap for an LRU if the
+# clear-and-refill ever shows up in the API call count.
+_PREFIX_GEO: dict[str, dict[str, Any]] = {}
+_PREFIX_GEO_MAX = 4096
+
+
+def _geo_cache_key(ip_address: str) -> str | None:
+    """The /48 an IPv6 address belongs to, or None for IPv4 (no sharing)."""
+    if ":" not in ip_address:
+        return None
+    return ":".join(ip_address.split(":")[:3])
+
+
+def extract_geolocation_shared(ip_address: str) -> dict[str, Any] | None:
+    """extract_geolocation_from_ip, reusing the answer across an IPv6 /48."""
+    key = _geo_cache_key(ip_address)
+    if key is not None and key in _PREFIX_GEO:
+        app_logger.debug(f"Reusing geolocation from {key}::/48 for {ip_address}")
+        return dict(_PREFIX_GEO[key])
+
+    data = extract_geolocation_from_ip(ip_address)
+
+    # Only successful lookups are cached, so a failure never poisons a whole /48.
+    if data and key is not None:
+        if len(_PREFIX_GEO) >= _PREFIX_GEO_MAX:
+            _PREFIX_GEO.clear()
+        # Reverse DNS is per-address; everything else describes the network.
+        _PREFIX_GEO[key] = {**data, "reverse": None}
+
+    return data
+
+
 def fetch_blocklist_data(ip_address: str) -> dict[str, Any] | None:
     """
     Fetch blocklist data for an IP address using lcrawl API.

--- a/src/ip_utils.py
+++ b/src/ip_utils.py
@@ -10,6 +10,8 @@ CIDR ranges. See config.DEFAULT_IGNORED_IPS for the built-in defaults.
 """
 
 import ipaddress
+import threading
+import time
 from functools import lru_cache
 
 from logger import get_app_logger
@@ -149,3 +151,70 @@ def is_cdn_ip(ip_str: str, networks: tuple) -> bool:
     except ValueError:
         return False
     return any(ip.version == net.version and ip in net for net in networks)
+
+
+# ---------------------------------------------------------------------------
+# First-sighting ledger: keeping single-request IPv6 addresses out of the DB
+# ---------------------------------------------------------------------------
+# Rotating proxy pools burn a fresh IPv6 address on every request: one operator
+# produced ~24,500 addresses from a single /32, each with exactly one request,
+# and 42% of ip_stats was IPv6 rows that would never be seen again. Every one
+# cost a row, an analyzer pass and a geolocation lookup for a known network.
+#
+# So an IPv6 address earns its row on the *second* sighting. IPv4 is unaffected
+# (addresses are scarce there and reuse is the norm), and anything suspicious is
+# persisted immediately, so a one-shot attacker is never lost.
+
+_SEEN_PREFIX = "krawl:seen:"
+
+# ponytail: a fixed window, not a tuned one. Long enough that a real client
+# returning within the session gets its row, short enough that the ledger stays
+# small. Make it configurable if operators need to trade rows for fidelity.
+FIRST_SIGHT_TTL = 1800  # 30 minutes
+
+_seen_lock = threading.Lock()
+_seen: dict[str, float] = {}  # ip -> expires_at
+
+
+def _prune_seen(now: float) -> None:
+    """Drop expired entries. Cheap: the dict only holds one TTL window."""
+    for ip in [ip for ip, expires in _seen.items() if expires <= now]:
+        del _seen[ip]
+
+
+def seen_before(ip: str, ttl: int = FIRST_SIGHT_TTL) -> bool:
+    """Record a sighting of `ip`; return True if it was already sighted.
+
+    Redis in scalable mode so the two sightings can land on different pods, a
+    process-local dict in standalone. Same split as auth_store.
+
+    First call within the window returns False, every later one returns True.
+    """
+    from dashboard_cache import get_backend, get_redis_client
+
+    if get_backend() == "scalable":
+        r = get_redis_client()
+        if r is not None:
+            # SET NX returns truthy only when the key did not exist, so a
+            # falsey result means "already there" — one round-trip, no race.
+            return not r.set(f"{_SEEN_PREFIX}{ip}", "1", nx=True, ex=ttl)
+
+    now = time.time()
+    with _seen_lock:
+        _prune_seen(now)
+        if _seen.get(ip, 0) > now:
+            return True
+        _seen[ip] = now + ttl
+        return False
+
+
+def defer_persist(ip: str, is_suspicious: bool, is_honeypot_trigger: bool) -> bool:
+    """True when this request should not yet create an ip_stats row.
+
+    Only ever defers a first-sighting IPv6 address that did nothing suspicious.
+    """
+    if ":" not in ip:  # IPv4 — persist immediately, as before
+        return False
+    if is_suspicious or is_honeypot_trigger:
+        return False
+    return not seen_before(ip)

--- a/src/tasks/fetch_ip_rep.py
+++ b/src/tasks/fetch_ip_rep.py
@@ -1,7 +1,7 @@
 import requests
 
 from database import get_database
-from geo_utils import extract_geolocation_from_ip, fetch_blocklist_data
+from geo_utils import extract_geolocation_shared, fetch_blocklist_data
 from logger import get_app_logger
 from sanitizer import sanitize_dict, sanitize_for_storage
 
@@ -29,7 +29,7 @@ def main():
     for ip in unenriched_ips:
         try:
             # Fetch geolocation data using ip-api.com
-            geoloc_data = extract_geolocation_from_ip(ip)
+            geoloc_data = extract_geolocation_shared(ip)
 
             # Fetch blocklist data from lcrawl API
             blocklist_data = fetch_blocklist_data(ip)

--- a/tests/test_ipv6_flood.py
+++ b/tests/test_ipv6_flood.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+"""
+Checks for the two IPv6 flood defences.
+
+Background: a rotating proxy pool used one IPv6 address per request — 24,500
+addresses from a single /32, every one with total_requests = 1. That filled 42%
+of ip_stats with rows that would never be seen again, and queued a geolocation
+lookup for each.
+
+1. ip_utils.defer_persist: an IPv6 address earns its row on the second
+   sighting. IPv4 and suspicious traffic are never deferred.
+2. geo_utils.extract_geolocation_shared: one lookup answers for a whole /48.
+
+Usage: python tests/test_ipv6_flood.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import geo_utils
+import ip_utils
+
+V6 = "2a13:f41:90a8:10ba:3385:f289:6613:e84d"
+V6_SIBLING = "2a13:f41:90a8:ffff:1111:2222:3333:4444"  # same /48
+V6_OTHER = "2a13:f41:a171:fadb:673b:3781:bc1:4a74"  # different /48
+V4 = "203.0.113.7"
+
+
+def test_defer_persist():
+    ip_utils._seen.clear()
+
+    # The flood: first sighting of an ordinary IPv6 address is not persisted.
+    assert ip_utils.defer_persist(V6, False, False) is True
+    # It came back — now it earns a row.
+    assert ip_utils.defer_persist(V6, False, False) is False
+
+    # IPv4 is never deferred, not even on first sight.
+    assert ip_utils.defer_persist(V4, False, False) is False
+
+    # A one-shot attacker is persisted immediately despite being new IPv6.
+    ip_utils._seen.clear()
+    assert ip_utils.defer_persist(V6_OTHER, True, False) is False
+    ip_utils._seen.clear()
+    assert ip_utils.defer_persist(V6_OTHER, False, True) is False
+
+    # Expiry: a sighting older than the window does not count as a return visit.
+    ip_utils._seen.clear()
+    assert ip_utils.seen_before(V6, ttl=0) is False
+    assert ip_utils.seen_before(V6, ttl=0) is False, "expired entry must not count"
+
+    print("OK: IPv6 deferred until second sighting; IPv4 and suspicious exempt")
+
+
+def test_geo_shared():
+    geo_utils._PREFIX_GEO.clear()
+    calls = []
+
+    def fake_lookup(ip):
+        calls.append(ip)
+        return {"city": "Frankfurt", "latitude": 50.1, "longitude": 8.7, "reverse": ip}
+
+    original = geo_utils.extract_geolocation_from_ip
+    geo_utils.extract_geolocation_from_ip = fake_lookup
+    try:
+        a = geo_utils.extract_geolocation_shared(V6)
+        b = geo_utils.extract_geolocation_shared(V6_SIBLING)
+        assert calls == [V6], f"a /48 must cost one lookup, got {calls}"
+        assert b["latitude"] == a["latitude"]
+        # Reverse DNS is per-address, so it must not be copied to a sibling.
+        assert b["reverse"] is None, f"reverse must not be shared, got {b['reverse']}"
+
+        # A different /48 is a different network: it costs its own lookup.
+        geo_utils.extract_geolocation_shared(V6_OTHER)
+        assert calls == [V6, V6_OTHER], f"distinct /48s must not share, got {calls}"
+
+        # IPv4 never shares.
+        geo_utils.extract_geolocation_shared(V4)
+        geo_utils.extract_geolocation_shared(V4)
+        assert calls.count(V4) == 2, "IPv4 must not be cached by prefix"
+
+        # A failed lookup must not poison the /48.
+        geo_utils._PREFIX_GEO.clear()
+        geo_utils.extract_geolocation_from_ip = lambda ip: None
+        assert geo_utils.extract_geolocation_shared(V6) is None
+        assert geo_utils._PREFIX_GEO == {}, "failures must not be cached"
+    finally:
+        geo_utils.extract_geolocation_from_ip = original
+
+    print("OK: one geolocation lookup per /48, failures and IPv4 excluded")
+
+
+if __name__ == "__main__":
+    test_defer_persist()
+    test_geo_shared()

--- a/tests/test_unenriched_query.py
+++ b/tests/test_unenriched_query.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+"""
+Regression check for IpStatsRepo.get_unenriched_ips().
+
+The enrichment task takes a capped batch each run. Two properties keep that batch
+useful, and both were broken before:
+
+1. Rows that are already enriched must not come back. "City is empty" is not the
+   same as "not enriched" — many datacenter ranges have no city — so including
+   city in the filter left enriched rows matching forever.
+2. The batch must be ordered newest-activity-first. Without it the batch was
+   filled in physical row order, so with a 611k backlog the newly seen IPs shown
+   in every "recent" dashboard view were never reached.
+
+Usage: python tests/test_unenriched_query.py
+"""
+
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from database.ip_stats import IpStatsRepo
+from models import Base, IpStats
+
+
+class _FakeDb:
+    """Minimal stand-in for DatabaseManager: a session and a no-op close."""
+
+    def __init__(self, session):
+        self._session = session
+
+    @property
+    def session(self):
+        return self._session
+
+    def close_session(self):
+        pass
+
+
+def _run():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    now = datetime.now()
+
+    session.add_all(
+        [
+            # Enriched, but the provider returned no city. Used to match the
+            # "unenriched" filter forever and monopolise every batch.
+            IpStats(
+                ip="203.0.113.1",
+                last_seen=now - timedelta(days=30),
+                country_code="US",
+                city=None,
+                latitude=37.7,
+                longitude=-122.4,
+            ),
+            # Fully enriched.
+            IpStats(
+                ip="203.0.113.2",
+                last_seen=now - timedelta(days=20),
+                country_code="DE",
+                city="Berlin",
+                latitude=52.5,
+                longitude=13.4,
+            ),
+            # Never enriched, seen a while ago.
+            IpStats(ip="203.0.113.3", last_seen=now - timedelta(days=10)),
+            # Never enriched, seen just now — an active attacker.
+            IpStats(ip="203.0.113.4", last_seen=now),
+        ]
+    )
+    session.commit()
+
+    repo = IpStatsRepo(_FakeDb(session))
+    got = repo.get_unenriched_ips(limit=50)
+
+    assert (
+        "203.0.113.1" not in got
+    ), f"enriched row with no city must not be re-queued, got {got}"
+    assert "203.0.113.2" not in got, f"fully enriched row must not be queued, got {got}"
+    assert got == [
+        "203.0.113.4",
+        "203.0.113.3",
+    ], f"expected only un-geolocated IPs, newest first, got {got}"
+
+    # The cap must not be spent on the oldest rows.
+    assert repo.get_unenriched_ips(limit=1) == [
+        "203.0.113.4"
+    ], "a capped batch must start with the most recently seen IP"
+
+    print("OK: get_unenriched_ips returns only un-geolocated IPs, newest first")
+
+
+if __name__ == "__main__":
+    _run()


### PR DESCRIPTION
This pull request implements two major defenses against IPv6 address floods and optimizes geolocation lookups, along with updating Helm chart and documentation versions to 2.3.1. The IPv6 defenses reduce database bloat and redundant API calls by deferring persistence of one-off IPv6 addresses and sharing geolocation results across IPv6 /48 prefixes. Several tests and documentation updates are included to support and explain these changes.

**IPv6 Flood Defenses and Geolocation Optimization:**

* Added a mechanism (`defer_persist` in `ip_utils.py`) to defer creating database rows for first-time, non-suspicious IPv6 addresses, only persisting them on a second sighting, while always persisting IPv4 and suspicious traffic. This prevents database bloat from rotating proxy pools. [[1]](diffhunk://#diff-7551086f0ce90304604e35a64eb976409eaf148bf22dfdf798a28ecc866a2e0dR154-R220) [[2]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64R511-R519) [[3]](diffhunk://#diff-7551086f0ce90304604e35a64eb976409eaf148bf22dfdf798a28ecc866a2e0dR13-R14) [[4]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64R23)
* Implemented a shared geolocation cache in `geo_utils.py` so that all IPv6 addresses within the same /48 share the same geolocation lookup, greatly reducing redundant external API calls. [[1]](diffhunk://#diff-94d89f515ada8eb33c03d91353701efb9dc4df3c93986f93456faa4297b2d66cR92-R127) [[2]](diffhunk://#diff-801349aa6359d1f462ff2b4e835fa1ecba5bce6924fa3482d40e7d26df980f5eL4-R4) [[3]](diffhunk://#diff-801349aa6359d1f462ff2b4e835fa1ecba5bce6924fa3482d40e7d26df980f5eL32-R32)
* Added `tests/test_ipv6_flood.py` to verify both the deferred persistence and shared geolocation behaviors.

**Database and Reputation Enrichment Improvements:**

* Updated the IP reputation enrichment logic to only consider latitude/longitude as the completeness test for geolocation, preventing rows with legitimately empty city fields from being repeatedly selected for enrichment, and prioritizing recently active IPs.

**Helm Chart and Documentation Updates:**

* Bumped the Helm chart and image versions from 2.3.0 to 2.3.1 in `helm/Chart.yaml`, `README.md`, and all values files to reflect the new release and ensure reproducible deployments. [[1]](diffhunk://#diff-ab3e9fcf0ffe762ed2805586f2e116f0c38db08c3b34d6ba2cfa90e871a1d918L5-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L290-R290) [[3]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L18-R18) [[4]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L65-R65) [[5]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L182-R182) [[6]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L466-R466) [[7]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L476-R476) [[8]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L490-R490) [[9]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L512-R512) [[10]](diffhunk://#diff-23f46adbcfb218afe902d0e15cc6260cbb3b723ef46dbc8e2454d35ea96adce6L12-R12) [[11]](diffhunk://#diff-7d933b18a6a683ee0e4ef9357cfab5d7fd7531aec81db643c1183711e5d66657L12-R12) [[12]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L9-R9)

These changes collectively improve the system’s scalability and efficiency when handling high volumes of unique IPv6 addresses, and ensure documentation and deployment instructions are up to date.