### PR TITLE
Feat: improved attack map

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,9 @@ Storage location, how long data is kept, and the dump job.
 |----------------------|-------------|---------|
 | `KRAWL_DATABASE_PATH` | Database file location | `data/krawl.db` |
 | `KRAWL_DATABASE_PERSIST_SUSPICIOUS_ONLY` | Only persist suspicious requests to the access log | `false` |
+| `KRAWL_MAP_TILE_URL` | Tile URL template for the dashboard map (`{z}/{x}/{y}`, optional `{s}`/`{r}`) | Esri dark canvas |
+| `KRAWL_MAP_TILE_ATTRIBUTION` | Attribution shown on the map | Esri/OSM |
+| `KRAWL_MAP_API_KEY` | Appended to every tile request as `?key=` — required by CARTO | _(empty)_ |
 | `KRAWL_IPV6_IGNORE` | Drop IPv6 requests entirely: still logged to stdout, never persisted, ban-checked or exported | `false` |
 | `KRAWL_IPV6_PURGE_EXISTING` | Also delete existing IPv6 rows at the next startup (irreversible; requires `KRAWL_IPV6_IGNORE`) | `false` |
 | `KRAWL_DATABASE_RETENTION_DAYS` | Days to retain data in database | `30` |

--- a/config.yaml
+++ b/config.yaml
@@ -42,35 +42,24 @@ canary:
   token_tries: 10
 
 dashboard:
-  # if set to "null" this will Auto-generates random path if not set
-  # can be set to "/dashboard" or similar <-- note this MUST include a forward slash
-  # secret_path: super-secret-dashboard-path
+  # Random path generated when null. If set, must start with a forward slash.
   secret_path: null
 
-  # Password for accessing protected dashboard panels.
-  # If null, a random password will be generated and printed in the logs.
-  # Can also be set via KRAWL_DASHBOARD_PASSWORD env var.
+  # Protects the dashboard panels. Random and logged when null.
+  # Also KRAWL_DASHBOARD_PASSWORD.
   password: null
 
-  # Enable background cache warmup task for the dashboard.
-  # When enabled, dashboard data is pre-computed every 5 minutes for instant page loads.
-  # When disabled, all dashboard queries hit the database directly on each request.
-  # In scalable mode with Redis, consider disabling this — paginated table caching
-  # already reduces DB load without needing a background warmup task.
+  # Pre-computes dashboard data every 5 minutes instead of querying per request.
+  # Redundant in scalable mode, where table caching already covers it.
   cache_warmup: true
 
-  # Number of pages to pre-warm per table panel (attacks, attackers, credentials, honeypot).
-  # Only has effect in scalable mode (set_cached_table is a no-op in standalone).
+  # Pages pre-warmed per table panel. Scalable mode only.
   warmup_pages: 10
 
-  # Pre-compute full top_paths/top_ua aggregations so any page is served instantly
-  # with zero DB queries (works in both standalone and scalable modes).
-  # Disabled by default in standalone; enable in scalable via Helm values or this flag.
+  # Pre-computes full top_paths/top_ua aggregations so any page costs no queries.
   warmup_aggregation: false
 
-  # Minimum access count for top paths and top user agents to be shown or cached.
-  # Entries below this threshold are excluded at the database level, reducing noise
-  # and keeping the aggregation data compact. Set to 1 to disable filtering.
+  # Hides top paths / user agents below this many accesses. 1 disables filtering.
   top_n_min_count: 5
 
 backups:
@@ -89,21 +78,15 @@ logging:
 database:
   path: "data/krawl.db"
   retention_days: 30
-  # Only persist suspicious requests to the access log.
-  # When enabled, non-suspicious requests still increment IP stats counters
-  # but won't be stored as individual access log entries, saving disk I/O.
+  # Log only suspicious requests. IP stats counters still count every request.
   persist_suspicious_only: false
 
-# IPv6 handling. Rotating IPv6 proxy pools burn a fresh address on every
-# request, so per-address tracking is worthless and the row/memory growth is
-# unbounded — one operator produced ~24,500 single-request addresses from a
-# single /32.
+# Rotating IPv6 proxy pools burn a fresh address per request, so per-address
+# tracking is worthless and grows rows and memory without bound.
 ipv6:
-  # Drop IPv6 entirely: still written to the access log on stdout, but never
-  # persisted, never ban-checked, never exported.
+  # Drop IPv6: still logged to stdout, never persisted, ban-checked or exported.
   ignore: false
-  # Also delete the IPv6 rows already in the database, once, at the next
-  # startup. Irreversible; only takes effect when `ignore` is true.
+  # Also delete existing IPv6 rows at next startup. Irreversible; needs `ignore`.
   purge_existing: false
 
 behavior:
@@ -122,11 +105,8 @@ crawl:
   max_pages_limit: 250
   ban_duration_seconds: 600
 
-# IPs / CIDR ranges to ignore everywhere: never tracked, banned, exported, and
-# purged from the database on startup. Accepts single IPs (e.g. 203.0.113.5) or
-# CIDR ranges (IPv4 and IPv6). Defaults cover loopback, RFC1918 private,
-# link-local and CGNAT ranges; add your own trusted networks (monitoring,
-# health checks, office egress, etc.) here.
+# Never tracked, banned or exported, and purged at startup. Single IPs or CIDRs.
+# Add your own trusted networks: monitoring, health checks, office egress.
 ignored_ips:
   - 127.0.0.0/8      # loopback
   - 10.0.0.0/8       # RFC1918 private
@@ -139,46 +119,34 @@ ignored_ips:
   - fc00::/7         # IPv6 unique local
   - fe80::/10        # IPv6 link-local
 
-# Map tiles for the dashboard's IP origins map.
-#
-# CARTO now stamps "API KEY REQUIRED" across tiles served without a key, so the
-# default is Esri's dark canvas, which needs no key. To go back to CARTO, sign
-# up at carto.com/basemaps/apikey, set api_key below, and uncomment its URL.
-#
-# `{z}/{x}/{y}` are required; `{s}` (subdomain) and `{r}` (retina) are optional.
+# Basemap for the IP origins map. {z}/{x}/{y} required; {s} and {r} optional.
 map:
-  # Esri dark canvas — keyless, no watermark (default).
+  # Esri dark canvas: keyless, no watermark.
   tile_url: "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
   attribution: "&copy; Esri, HERE, Garmin, &copy; OpenStreetMap contributors"
 
-  # CARTO dark — needs an API key, otherwise every tile is watermarked.
+  # CARTO dark: watermarks every tile unless api_key is set.
   # tile_url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
   # attribution: "&copy; CARTO | &copy; OpenStreetMap contributors"
 
-  # OpenStreetMap — keyless, but light-themed; see docs for the CSS invert.
+  # OpenStreetMap: keyless but light-themed, needs the CSS invert in the docs.
   # tile_url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
   # attribution: "&copy; OpenStreetMap contributors"
 
   subdomains: "abcd"
-  # Appended to every tile request as ?key=... Also KRAWL_MAP_API_KEY.
-  # It is served in the page source (the browser fetches tiles itself), so
-  # restrict the key to your dashboard domain at the provider.
+  # Sent as ?key= on every tile request, and visible in the page source.
+  # Restrict it to your dashboard domain at the provider. Also KRAWL_MAP_API_KEY.
   api_key: ""
 
 tarpit:
   enabled: false  # Opt-in: trap AI agents with slow responses and random text
   delay_seconds: 5  # Extra delay (seconds) added to each response when tarpit is active
 
-# Custom page template settings
-# Operators can provide a custom HTML template file by setting
-# `custom_template_path`. If this key is present and not null, Krawl
-# will attempt to load the template from the provided path. The template
-# may include `{counter}` and `{content}` placeholders but they are
-# optional (no strict validation is performed).
+# Custom honeypot page. Optional {counter} and {content} placeholders.
 # custom_template_path: "/path/to/custom_page.html"
 
-### AI-Generated Deception pages. Here it can be used either OpenRouter or OpenAI as provider, but also self-hosted LLMs with an API-compatible endpoint 
-### by setting the provider to "openai" and pointing the openai_base_url to the local LLM server URL. Note that the krawl-llm is the service name of the llama.cpp server in the docker-compose.yaml.
+# AI-generated deception pages via OpenRouter or OpenAI. For a self-hosted LLM,
+# set provider to "openai" and point openai_base_url at its endpoint.
 ai:
   enabled: false
   provider: "openrouter"  # "openrouter" or "openai"
@@ -218,7 +186,6 @@ banlist:
   refresh_interval: 3600  # Seconds between fetches
 
 deception:
-  # Enable automatic import of deception pages from src/templates/deception directory on startup
-  # Files are mapped to paths by replacing "/" with "_" (e.g., test_blabla.html -> /test/blabla)
-  # A zip file containing deception pages can also be uploaded via the dashboard
+  # Imports src/templates/deception at startup; "/" in a filename becomes a path
+  # separator (test_blabla.html -> /test/blabla). Zips upload via the dashboard.
   import_pages: true

--- a/config.yaml
+++ b/config.yaml
@@ -139,6 +139,32 @@ ignored_ips:
   - fc00::/7         # IPv6 unique local
   - fe80::/10        # IPv6 link-local
 
+# Map tiles for the dashboard's IP origins map.
+#
+# CARTO now stamps "API KEY REQUIRED" across tiles served without a key, so the
+# default is Esri's dark canvas, which needs no key. To go back to CARTO, sign
+# up at carto.com/basemaps/apikey, set api_key below, and uncomment its URL.
+#
+# `{z}/{x}/{y}` are required; `{s}` (subdomain) and `{r}` (retina) are optional.
+map:
+  # Esri dark canvas — keyless, no watermark (default).
+  tile_url: "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+  attribution: "&copy; Esri, HERE, Garmin, &copy; OpenStreetMap contributors"
+
+  # CARTO dark — needs an API key, otherwise every tile is watermarked.
+  # tile_url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+  # attribution: "&copy; CARTO | &copy; OpenStreetMap contributors"
+
+  # OpenStreetMap — keyless, but light-themed; see docs for the CSS invert.
+  # tile_url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+  # attribution: "&copy; OpenStreetMap contributors"
+
+  subdomains: "abcd"
+  # Appended to every tile request as ?key=... Also KRAWL_MAP_API_KEY.
+  # It is served in the page source (the browser fetches tiles itself), so
+  # restrict the key to your dashboard domain at the provider.
+  api_key: ""
+
 tarpit:
   enabled: false  # Opt-in: trap AI agents with slow responses and random text
   delay_seconds: 5  # Extra delay (seconds) added to each response when tarpit is active

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -38,6 +38,17 @@ An interactive world map (powered by Leaflet) displays the geolocation of top IP
 
 The number of displayed IPs is configurable (top 10, 100, 1,000, or all).
 
+Markers cluster as you zoom out, and each cluster is ringed in the proportions
+of the categories inside it, so a cluster that is mostly attackers reads red
+before you click it. The view fits itself to the visible markers rather than
+opening at a fixed zoom, which keeps the framing right on any screen width and
+re-fits when you toggle a category off. It will not zoom past a global
+overview on load — panning in is left to you.
+
+The basemap is deliberately desaturated so that the category colours are the
+only saturated thing on the panel. See [Map tiles](#map-tiles) to change the
+tile provider.
+
 ![Overview — Stats and Map](../img/geoip_dashboard.png)
 
 ### Recent Suspicious Activity
@@ -225,6 +236,81 @@ dashboard:
 | `KRAWL_DASHBOARD_TOP_N_MIN_COUNT` | Minimum access count for top paths/user-agents (set to `1` to disable filtering) | `5` |
 
 > **Scalable mode**: `warmup_aggregation` is enabled by default in Helm and Kubernetes deployments. In standalone mode it is disabled because SQLite handles the load without it.
+
+### Map tiles
+
+The IP Origins Map fetches its basemap from a tile provider. The provider is
+configured under the `map` section, so switching it never needs a code change.
+
+```yaml
+map:
+  tile_url: "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+  attribution: "&copy; Esri, HERE, Garmin, &copy; OpenStreetMap contributors"
+  subdomains: "abcd"
+  api_key: ""
+```
+
+| Env var | Description | Default |
+|---|---|---|
+| `KRAWL_MAP_TILE_URL` | Tile URL template. `{z}`, `{x}` and `{y}` are required; `{s}` (subdomain) and `{r}` (retina suffix) are optional | Esri dark canvas |
+| `KRAWL_MAP_TILE_ATTRIBUTION` | Credit line shown in the map corner | Esri / OSM |
+| `KRAWL_MAP_TILE_SUBDOMAINS` | Values substituted into `{s}` | `abcd` |
+| `KRAWL_MAP_API_KEY` | Appended to every tile request as `?key=` | _(empty)_ |
+
+Note the axis order: Esri serves tiles as `{z}/{y}/{x}`, while most other
+providers use `{z}/{x}/{y}`. Copy the template exactly as the provider
+documents it.
+
+#### Choosing a provider
+
+**Esri dark canvas (default)** needs no account and adds no watermark. It is
+the reason the map works out of the box.
+
+**CARTO** requires an API key. Without one, every tile comes back with
+`API KEY REQUIRED` stamped diagonally across it — the tiles still load, so
+there is no error to notice, just a defaced map. Sign up at
+[carto.com/basemaps/apikey](https://carto.com/basemaps/apikey), then:
+
+```yaml
+map:
+  tile_url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+  attribution: "&copy; CARTO | &copy; OpenStreetMap contributors"
+  api_key: "your-key-here"
+```
+
+**OpenStreetMap** needs no key but is light-themed, so it fights the dashboard
+until you invert it. Add this to your own CSS after setting the URL:
+
+```css
+#attacker-map { --map-tile-filter: invert(1) hue-rotate(180deg) brightness(0.75) saturate(0.4); }
+```
+
+Also read [OSM's tile usage policy](https://operations.osmfoundation.org/policies/tiles/)
+before pointing a busy instance at it.
+
+**A self-hosted tile server** is just another `tile_url`. Worth considering:
+the dashboard is normally the only page you open on the instance, and every
+other option tells a third-party CDN when you are looking at it.
+
+#### Two things to know
+
+**The API key is public.** The browser fetches tiles directly, so the key is
+served in the page source. That is unavoidable for a client-side map — restrict
+the key to your dashboard's domain at the provider rather than trying to hide
+it.
+
+**Attribution is a licence condition** for every provider above, not
+decoration. It is styled to be unobtrusive; do not remove it.
+
+#### Adjusting how the basemap looks
+
+The tiles are desaturated and darkened so the category colours stand out. The
+treatment is a single custom property, so you can retune it without touching
+the rule:
+
+```css
+#attacker-map { --map-tile-filter: saturate(0.35) brightness(0.62) contrast(1.05); }
+```
 
 ## Design system
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.3.2
-appVersion: 2.3.2
+version: 2.3.3
+appVersion: 2.3.3
 keywords:
   - honeypot
   - security

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -83,6 +83,11 @@ data:
     ipv6:
       ignore: {{ .Values.config.ipv6.ignore }}
       purge_existing: {{ .Values.config.ipv6.purge_existing }}
+    map:
+      tile_url: {{ .Values.config.map.tile_url | quote }}
+      attribution: {{ .Values.config.map.attribution | quote }}
+      subdomains: {{ .Values.config.map.subdomains | quote }}
+      api_key: {{ .Values.config.map.api_key | quote }}
     tarpit:
       enabled: {{ .Values.config.tarpit.enabled }}
       delay_seconds: {{ .Values.config.tarpit.delay_seconds }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -245,6 +245,14 @@ config:
     ignore: false          # Drop IPv6 requests: logged to stdout, never persisted or ban-checked
     purge_existing: false  # Also delete existing IPv6 rows at next startup (irreversible)
 
+  map:
+    # CARTO watermarks unkeyed tiles; the default below is keyless. See
+    # config.yaml for alternative providers.
+    tile_url: "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+    attribution: "&copy; Esri, HERE, Garmin, &copy; OpenStreetMap contributors"
+    subdomains: "abcd"
+    api_key: ""   # served in the page source; restrict it by domain
+
   tarpit:
     enabled: false  # Opt-in: trap AI agents with slow responses and random text
     delay_seconds: 5  # Extra delay (seconds) added to each response when tarpit is active

--- a/src/config.py
+++ b/src/config.py
@@ -29,6 +29,17 @@ DEFAULT_IGNORED_IPS = [
 ]
 
 
+# Esri's dark canvas: no API key, no watermark, and a companion labels layer.
+# CARTO's equivalent now requires a key. Swap via the `map:` config section.
+_DEFAULT_TILE_URL = (
+    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/"
+    "World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+)
+_DEFAULT_TILE_ATTRIBUTION = (
+    "&copy; Esri, HERE, Garmin, &copy; OpenStreetMap contributors"
+)
+
+
 @dataclass
 class Config:
     """Configuration class for the deception server"""
@@ -100,6 +111,14 @@ class Config:
     # in the database at the next startup.
     ipv6_ignore: bool = False
     ipv6_purge_existing: bool = False
+
+    # Map tiles. The default provider is keyless; set map_api_key when using a
+    # provider that requires one (CARTO started stamping "API KEY REQUIRED"
+    # across unkeyed tiles). See config.yaml for alternative tile_url values.
+    map_tile_url: str = _DEFAULT_TILE_URL
+    map_tile_attribution: str = _DEFAULT_TILE_ATTRIBUTION
+    map_tile_subdomains: str = "abcd"
+    map_api_key: str = ""
 
     # Analyzer settings
     http_risky_methods_threshold: float = None
@@ -224,6 +243,7 @@ class Config:
         backups = data.get("backups", {})
         database = data.get("database", {})
         ipv6_cfg = data.get("ipv6", {})
+        map_cfg = data.get("map", {})
         behavior = data.get("behavior", {})
         analyzer = data.get("analyzer") or {}
         crawl = data.get("crawl", {})
@@ -315,6 +335,12 @@ class Config:
             ),
             ipv6_ignore=ipv6_cfg.get("ignore", False),
             ipv6_purge_existing=ipv6_cfg.get("purge_existing", False),
+            map_tile_url=map_cfg.get("tile_url") or _DEFAULT_TILE_URL,
+            map_tile_attribution=(
+                map_cfg.get("attribution") or _DEFAULT_TILE_ATTRIBUTION
+            ),
+            map_tile_subdomains=map_cfg.get("subdomains", "abcd"),
+            map_api_key=map_cfg.get("api_key", ""),
             http_risky_methods_threshold=analyzer.get(
                 "http_risky_methods_threshold", 0.1
             ),

--- a/src/routes/dashboard.py
+++ b/src/routes/dashboard.py
@@ -34,6 +34,24 @@ def _get_krawl_version() -> str:
     return "dev"
 
 
+def _map_tiles(config) -> dict:
+    """Resolve the tile layer passed to Leaflet.
+
+    The API key is appended as a query parameter because that is how CARTO and
+    most raster providers take it. It ends up in the page source, which is
+    unavoidable for a client-side map: the browser requests tiles itself. Lock
+    the key to your dashboard domain at the provider.
+    """
+    url = config.map_tile_url
+    if config.map_api_key:
+        url += ("&" if "?" in url else "?") + f"key={config.map_api_key}"
+    return {
+        "url": url,
+        "attribution": config.map_tile_attribution,
+        "subdomains": config.map_tile_subdomains,
+    }
+
+
 KRAWL_VERSION = _get_krawl_version()
 
 
@@ -98,6 +116,7 @@ async def dashboard_page(request: Request):
             "stats": clean_stats,
             "suspicious_activities": suspicious,
             "krawl_version": KRAWL_VERSION,
+            "map_tiles": _map_tiles(config),
         },
     )
 
@@ -135,6 +154,7 @@ async def ip_page(ip_address: str, request: Request):
                     "dashboard_path": dashboard_path,
                     "stats": clean_stats,
                     "ip_address": ip_address,
+                    "map_tiles": _map_tiles(config),
                 },
             )
         else:

--- a/src/templates/jinja2/base.html
+++ b/src/templates/jinja2/base.html
@@ -15,6 +15,10 @@
     <script src="{{ dashboard_path }}/static/vendor/js/htmx.min.js" defer></script>
     <script defer src="{{ dashboard_path }}/static/vendor/js/alpine.min.js"></script>
     <script>window.__DASHBOARD_PATH__ = '{{ dashboard_path }}';</script>
+    {# Tile config is resolved server-side (see Config.map_*). The key is
+       necessarily public — the browser fetches tiles directly — so restrict it
+       by domain at the provider. #}
+    <script>window.__MAP_TILES__ = {{ (map_tiles or {}) | tojson }};</script>
 </head>
 <body>
     {% block content %}{% endblock %}

--- a/src/templates/static/css/dashboard.css
+++ b/src/templates/static/css/dashboard.css
@@ -2095,7 +2095,7 @@ tbody {
         max-height: 300px;
     }
     #attacker-map {
-        height: 350px !important;
+        height: 460px !important;
     }
     .leaflet-popup-content {
         min-width: 200px !important;
@@ -2251,7 +2251,7 @@ tbody {
         font-size: var(--fs-2xs);
     }
     #attacker-map {
-        height: 300px !important;
+        height: 380px !important;
     }
     .leaflet-popup-content {
         min-width: 150px !important;
@@ -2303,7 +2303,7 @@ tbody {
         padding: var(--s2);
     }
     #attacker-map {
-        height: 250px !important;
+        height: 320px !important;
     }
     .ip-stats-dropdown {
         gap: var(--s3);
@@ -3325,7 +3325,7 @@ tbody {
 .col-w-130 { width: 130px; }
 .map-frame { border: 1px solid var(--line); border-radius: var(--r-md); }
 .map-frame-sm { height: 300px; }
-.map-frame-lg { height: 450px; }
+.map-frame-lg { height: 620px; }
 .dot-inline {
     display: inline-block;
     width: var(--s3);

--- a/src/templates/static/css/dashboard.css
+++ b/src/templates/static/css/dashboard.css
@@ -1139,8 +1139,23 @@ tbody {
 .leaflet-container {
     background: var(--bg) !important;
 }
+/* ── Map: the basemap is substrate, the markers are the subject ────
+   This panel answers one question — where is hostile traffic coming
+   from — and the category colours are the answer. So everything that is
+   not a marker gets its colour taken away: the tiles are desaturated and
+   pushed down toward --bg until the five --cat-* hues are the only
+   saturated things on screen. Saturation means threat here.
+
+   It also makes the panel provider-agnostic. Esri, CARTO and OSM tiles
+   all land in roughly the same place, which matters now that the tile
+   source is configurable. A light provider needs a stronger treatment:
+   override the token, e.g.
+       #attacker-map { --map-tile-filter: invert(1) hue-rotate(180deg) brightness(.75) saturate(.4); } */
+#attacker-map {
+    --map-tile-filter: saturate(0.35) brightness(0.62) contrast(1.05);
+}
 .leaflet-tile {
-    filter: none;
+    filter: var(--map-tile-filter);
 }
 .leaflet-popup-content-wrapper {
     background-color: var(--bg);
@@ -1223,8 +1238,65 @@ tbody {
     background: none !important;
     border: none !important;
 }
-.leaflet-bottom.leaflet-right {
-    display: none !important;
+/* Attribution is a licence condition for every provider we ship a URL for,
+   so it is styled down rather than hidden — quiet, but present and legible. */
+.leaflet-control-attribution {
+    background: color-mix(in srgb, var(--bg) 78%, transparent) !important;
+    color: var(--text-faint) !important;
+    font-family: var(--font-ui);
+    font-size: var(--fs-2xs);
+    padding: 2px var(--s2);
+    border-top-left-radius: var(--r-md);
+}
+.leaflet-control-attribution a {
+    color: var(--text-dim);
+    text-decoration: none;
+}
+.leaflet-control-attribution a:hover { color: var(--accent); }
+
+/* Zoom control: stock Leaflet ships a white box with black glyphs, which on
+   this page was the brightest thing on screen — chrome outshouting the data.
+   Same shape and hit target as the header actions, so the dashboard's
+   controls read as one family. */
+.leaflet-control-zoom {
+    border: none !important;
+    box-shadow: none !important;
+}
+.leaflet-control-zoom a.leaflet-control-zoom-in,
+.leaflet-control-zoom a.leaflet-control-zoom-out {
+    width: 30px;
+    height: 30px;
+    line-height: 28px;
+    background: color-mix(in srgb, var(--surface) 88%, transparent);
+    color: var(--text-dim);
+    border: 1px solid var(--line);
+    font-size: var(--fs-lg);
+    font-weight: 400;
+    transition: color var(--dur) var(--ease),
+        background var(--dur) var(--ease),
+        border-color var(--dur) var(--ease);
+}
+.leaflet-control-zoom a.leaflet-control-zoom-in {
+    border-radius: var(--r-md) var(--r-md) 0 0;
+}
+.leaflet-control-zoom a.leaflet-control-zoom-out {
+    border-radius: 0 0 var(--r-md) var(--r-md);
+    border-top: none;
+}
+.leaflet-control-zoom a:hover {
+    background: var(--raised);
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.leaflet-control-zoom a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    z-index: 1;
+}
+.leaflet-control-zoom a.leaflet-disabled {
+    background: color-mix(in srgb, var(--surface) 60%, transparent);
+    color: var(--line);
+    cursor: not-allowed;
 }
 .charts-container {
     display: grid;

--- a/src/templates/static/js/map.js
+++ b/src/templates/static/js/map.js
@@ -340,12 +340,7 @@ async function fetchAndBuildMap(limit, sortBy) {
         await new Promise(r => setTimeout(r, 80));
     }
 
-    // Fit bounds to visible markers
-    const visibleMarkers = mapMarkers.filter(m => !hiddenCategories.has(m.options.category));
-    if (visibleMarkers.length > 0) {
-        const bounds = L.featureGroup(visibleMarkers).getBounds();
-        attackerMap.fitBounds(bounds, { padding: [50, 50] });
-    }
+    fitToMarkers();
 }
 
 // Legacy wrapper kept for filter rebuilds
@@ -378,16 +373,35 @@ function buildMapMarkers(ips) {
     });
 
     attackerMap.addLayer(clusterGroup);
-    const visibleMarkers = mapMarkers.filter(m => !hiddenCategories.has(m.options.category));
-    if (visibleMarkers.length > 0) {
-        const bounds = L.featureGroup(visibleMarkers).getBounds();
-        attackerMap.fitBounds(bounds, { padding: [50, 50] });
-    }
+    fitToMarkers();
 }
 
-// Everything above ~72N and below ~55S is ice and empty ocean; excluding it
-// from the default view buys real estate for the latitudes traffic comes from.
-const INHABITED_BOUNDS = [[-55, -168], [72, 178]];
+// Breathing room around the data. The map is wider than it is tall, so the
+// vertical padding is what actually sets the zoom; at 50px the outermost
+// markers sat almost on the frame edge with no surrounding context.
+const MARKER_FIT_PADDING = [90, 90];
+
+// Never zoom past a global overview on load. Without a cap, an instance whose
+// traffic all comes from one city would open zoomed into that city, which is
+// not what a map called "IP Origins" is for — panning in is a deliberate act.
+const MAX_OVERVIEW_ZOOM = 4;
+
+// Fit the visible markers, with padding and the overview cap applied. Called
+// after a load and after a category filter changes, so both paths frame the
+// data the same way.
+function fitToMarkers() {
+    const visible = mapMarkers.filter(m => !hiddenCategories.has(m.options.category));
+    if (visible.length === 0) return;
+    attackerMap.fitBounds(L.featureGroup(visible).getBounds(), {
+        padding: MARKER_FIT_PADDING,
+        maxZoom: MAX_OVERVIEW_ZOOM,
+        animate: false
+    });
+}
+
+// The view before any data arrives: the whole span of longitude, and far
+// enough north and south to keep every inhabited coastline off the edge.
+const INHABITED_BOUNDS = [[-58, -180], [80, 180]];
 
 // Tile source comes from the server (Config.map_*), so an operator can point
 // the map at any provider — and supply the API key that CARTO now requires —

--- a/src/templates/static/js/map.js
+++ b/src/templates/static/js/map.js
@@ -385,6 +385,10 @@ function buildMapMarkers(ips) {
     }
 }
 
+// Everything above ~72N and below ~55S is ice and empty ocean; excluding it
+// from the default view buys real estate for the latitudes traffic comes from.
+const INHABITED_BOUNDS = [[-55, -168], [72, 178]];
+
 // Tile source comes from the server (Config.map_*), so an operator can point
 // the map at any provider — and supply the API key that CARTO now requires —
 // without editing this file. Falls back to the previous hardcoded CARTO layer
@@ -407,12 +411,22 @@ async function initializeAttackerMap() {
 
     try {
         attackerMap = L.map('attacker-map', {
-            center: [20, 0],
+            center: [25, 5],
+            // Quarter-step zoom so the default view can fill the frame instead
+            // of leaving bands of empty ocean. A whole step to 3 would cut a
+            // third of the globe off the sides, which is the wrong trade for an
+            // origins map, so the zoom is fitted below rather than hardcoded.
+            zoomSnap: 0.25,
             zoom: 2,
             layers: [
                 _tileLayer()
             ]
         });
+
+        // Fit the inhabited latitude band to the frame. The right zoom depends
+        // on the container, which changes with the breakpoint, so letting
+        // Leaflet solve it beats a hardcoded value that only suits one width.
+        attackerMap.fitBounds(INHABITED_BOUNDS, { animate: false, padding: [0, 0] });
 
         const activeBtn = document.querySelector('#map-limit-selector .map-limit-btn.active');
         const limit = activeBtn ? activeBtn.dataset.value : '1000';

--- a/src/templates/static/js/map.js
+++ b/src/templates/static/js/map.js
@@ -426,11 +426,20 @@ async function initializeAttackerMap() {
     try {
         attackerMap = L.map('attacker-map', {
             center: [25, 5],
-            // Quarter-step zoom so the default view can fill the frame instead
-            // of leaving bands of empty ocean. A whole step to 3 would cut a
-            // third of the globe off the sides, which is the wrong trade for an
-            // origins map, so the zoom is fitted below rather than hardcoded.
-            zoomSnap: 0.25,
+            // Half-level zoom steps. Fractional zoom is what lets the default
+            // view fit the frame instead of snapping to a whole level and
+            // leaving bands of empty ocean; finer than this made the wheel
+            // crawl, because a trackpad's small deltas each round to a tiny
+            // step.
+            zoomSnap: 0.5,
+            // Wheel speed, in pixels of scroll per zoom level. Leaflet's
+            // default of 60 assumes whole-level steps; with zoomSnap at 0.5
+            // each gesture rounds up to half a level instead of a full one,
+            // which halves the distance travelled and is what made the wheel
+            // feel slow. Measured against stock Leaflet — 240px of scroll
+            // moves 4 levels — 15 restores that, and lower is faster still.
+            wheelPxPerZoomLevel: 15,
+            wheelDebounceTime: 20,
             zoom: 2,
             layers: [
                 _tileLayer()

--- a/src/templates/static/js/map.js
+++ b/src/templates/static/js/map.js
@@ -385,6 +385,22 @@ function buildMapMarkers(ips) {
     }
 }
 
+// Tile source comes from the server (Config.map_*), so an operator can point
+// the map at any provider — and supply the API key that CARTO now requires —
+// without editing this file. Falls back to the previous hardcoded CARTO layer
+// if the page did not supply one.
+function _tileLayer() {
+    const cfg = window.__MAP_TILES__ || {};
+    return L.tileLayer(
+        cfg.url || 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+        {
+            attribution: cfg.attribution || '&copy; CartoDB | &copy; OpenStreetMap contributors',
+            maxZoom: 19,
+            subdomains: cfg.subdomains || 'abcd'
+        }
+    );
+}
+
 async function initializeAttackerMap() {
     const mapContainer = document.getElementById('attacker-map');
     if (!mapContainer || attackerMap) return;
@@ -394,11 +410,7 @@ async function initializeAttackerMap() {
             center: [20, 0],
             zoom: 2,
             layers: [
-                L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
-                    attribution: '&copy; CartoDB | &copy; OpenStreetMap contributors',
-                    maxZoom: 19,
-                    subdomains: 'abcd'
-                })
+                _tileLayer()
             ]
         });
 

--- a/tests/test_map_tiles.py
+++ b/tests/test_map_tiles.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+"""
+Map tile configuration (github.com/BlessedRebuS/Krawl/issues/295).
+
+CARTO began stamping "API KEY REQUIRED" across tiles served without a key, so
+the tile source and its key must be configurable rather than hardcoded.
+
+Usage: python tests/test_map_tiles.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from config import Config
+from routes.dashboard import _map_tiles
+
+CARTO = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+
+
+def test_key_is_appended():
+    """CARTO and friends take the key as a query parameter."""
+    tiles = _map_tiles(Config(map_tile_url=CARTO, map_api_key="abc123"))
+    assert tiles["url"] == CARTO + "?key=abc123", tiles["url"]
+
+    # A URL that already carries a query gets & rather than a second ?.
+    withq = "https://tiles.example.com/{z}/{x}/{y}.png?style=dark"
+    tiles = _map_tiles(Config(map_tile_url=withq, map_api_key="abc123"))
+    assert tiles["url"] == withq + "&key=abc123", tiles["url"]
+
+    # No key configured: the URL is untouched, no stray "?key=".
+    tiles = _map_tiles(Config(map_tile_url=CARTO))
+    assert tiles["url"] == CARTO, tiles["url"]
+    assert "key=" not in tiles["url"]
+    print("OK: api key appended with ? or & as appropriate, omitted when unset")
+
+
+def test_default_is_keyless():
+    """Out of the box the map must render without an account anywhere."""
+    tiles = _map_tiles(Config())
+    assert "cartocdn" not in tiles["url"], (
+        "default must not be the watermarked provider"
+    )
+    assert "key=" not in tiles["url"]
+    for placeholder in ("{z}", "{x}", "{y}"):
+        assert placeholder in tiles["url"], f"{placeholder} missing from default URL"
+    assert tiles["attribution"], "attribution is a licence condition, not optional"
+    print(f"OK: default is keyless — {tiles['url'].split('/rest/')[0]}…")
+
+
+def test_operator_override():
+    """A fully custom provider needs no code change."""
+    tiles = _map_tiles(
+        Config(
+            map_tile_url="https://tiles.internal/{z}/{x}/{y}.png",
+            map_tile_attribution="Internal basemap",
+            map_tile_subdomains="",
+        )
+    )
+    assert tiles == {
+        "url": "https://tiles.internal/{z}/{x}/{y}.png",
+        "attribution": "Internal basemap",
+        "subdomains": "",
+    }, tiles
+    print("OK: a self-hosted tile server is a config change, not a code change")
+
+
+if __name__ == "__main__":
+    test_key_is_appended()
+    test_default_is_keyless()
+    test_operator_override()


### PR DESCRIPTION
This pull request introduces a configurable map tile provider for the dashboard's IP origins map, making it possible to switch the basemap (e.g., Esri, CARTO, OSM, or self-hosted) without code changes. The configuration is available via YAML, environment variables, and Helm values, and is passed through to the frontend for Leaflet rendering. The default is now a keyless Esri dark canvas, but alternatives are documented and supported. The PR also improves documentation and clarifies configuration options and comments throughout.

<img width="1471" height="752" alt="image" src="https://github.com/user-attachments/assets/5149c262-c3c4-4f94-8ffa-77a25a726b71" />


**Map tile provider configuration:**

* Adds a new `map` section in `config.yaml`, `helm/values.yaml`, and `helm/templates/configmap.yaml` for specifying `tile_url`, `attribution`, `subdomains`, and `api_key` for the dashboard map. The server passes these settings to the frontend, and the default is Esri dark canvas. [[1]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034R122-R149) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R248-R255) [[3]](diffhunk://#diff-bfc6a602171deb9937fdee53ff0c20b633450fe90d995958f68b1e0035175ccbR86-R90) [[4]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R32-R42) [[5]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R115-R122) [[6]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R246) [[7]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R338-R343) [[8]](diffhunk://#diff-80d7a7c155f3a3ef5d6700956ae2592ec1cf4740e1282055c26d814f87efa863R37-R54) [[9]](diffhunk://#diff-80d7a7c155f3a3ef5d6700956ae2592ec1cf4740e1282055c26d814f87efa863R119) [[10]](diffhunk://#diff-80d7a7c155f3a3ef5d6700956ae2592ec1cf4740e1282055c26d814f87efa863R157) [[11]](diffhunk://#diff-4a4689e230a3db78924debcb5df5f84fcfe19cbb9662ab1a5864806420e8e4fdR18-R21)

**Documentation improvements:**

* Documents the new map tile provider options, including how to configure different providers, the meaning of each setting, and CSS for visual adjustments. Explains public nature of API keys and importance of attribution. [[1]](diffhunk://#diff-f46af54b712d903a1cf3f90323c91eac14dd3357e17ebf07188affe9b2cb1fdeR41-R51) [[2]](diffhunk://#diff-f46af54b712d903a1cf3f90323c91eac14dd3357e17ebf07188affe9b2cb1fdeR240-R314)

**Dashboard visual and style enhancements:**

* Adds a CSS variable to desaturate and darken the basemap so that category colors stand out, and documents how to adjust the appearance for different tile providers.

**Configuration and comments cleanup:**

* Refines and clarifies comments and documentation in `config.yaml`, especially around dashboard, IPv6, ignored IPs, and deception page import, making configuration intent and effect clearer. [[1]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L45-R62) [[2]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L92-R89) [[3]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L125-R109) [[4]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L195-R190) [[5]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034R122-R149)

**Helm chart version bump:**

* Increments the Helm chart and app version to `2.3.3`.

Closes #295 