### PR TITLE
Feat: improve db efficiency

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,9 +304,9 @@ Managed by `TasksMaster` (APScheduler). Tasks are auto-discovered from `src/task
 | `sync_cloudflare` | Every 1 min | Push banned IPs to a CloudFlare Account IP List (opt-in) |
 | `refresh_banlist` | `banlist.refresh_interval` (default 1 h) | Fetch and merge upstream community banlists |
 | `db_dump` | `backups.cron` | Export database backups |
-| `flag_stale_ips` | Daily (2 AM) | Flag stale IPs for reevaluation by the analyzer |
-| `pre_retention_cleanup` | Daily (2:30 AM) | Prune non-suspicious access rows ahead of retention |
-| `db_retention` | Daily (3 AM) | Clean up old records based on retention policy |
+| `flag_stale_ips` | Daily (8 AM) | Flag stale IPs for reevaluation by the analyzer |
+| `pre_retention_cleanup` | Daily (8:30 AM) | Prune non-suspicious access rows ahead of retention |
+| `db_retention` | Daily (9 AM) | Clean up old records based on retention policy |
 
 ### IP Categorization Model
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.3.3
-appVersion: 2.3.3
+version: 2.3.4
+appVersion: 2.3.4
 keywords:
   - honeypot
   - security

--- a/helm/README.md
+++ b/helm/README.md
@@ -314,7 +314,43 @@ The Krawl service already includes `externalTrafficPolicy: Local` by default to 
 | `postgres.persistence.size` | PVC size | `5Gi` |
 | `postgres.persistence.accessMode` | PVC access mode | `ReadWriteOnce` |
 | `postgres.persistence.storageClassName` | Storage class name | `` |
-| `postgres.resources` | CPU/memory resource requests and limits | `{}` |
+| `postgres.resources` | CPU/memory resource requests and limits | `1Gi` limit / `512Mi` request |
+| `postgres.config` | Server settings passed as `-c name=value` flags; set a key to `null` to drop it | see below |
+| `postgres.shmSize` | Size of `/dev/shm` (tmpfs); `""` leaves the Kubernetes 64Mi default | `256Mi` |
+
+#### PostgreSQL tuning
+
+The chart overrides a few server defaults that are far too small for the table
+sizes Krawl reaches on a busy sensor:
+
+| Setting | Chart default | Server default |
+|---------|---------------|----------------|
+| `shared_buffers` | `256MB` | `128MB` |
+| `effective_cache_size` | `512MB` | `4GB` |
+| `work_mem` | `16MB` | `4MB` |
+| `maintenance_work_mem` | `128MB` | `64MB` |
+| `random_page_cost` | `4` | `4` |
+| `effective_io_concurrency` | `1` | `1` |
+
+The last two are deliberately left at their rotational-disk defaults. On
+SSD-backed storage set `random_page_cost: "1.1"` and
+`effective_io_concurrency: "100"`; both are actively harmful on spinning or
+network-replicated volumes, so the chart does not assume SSD.
+
+`postgres.shmSize` mounts `/dev/shm` as an in-memory `emptyDir`. Kubernetes
+gives a container only 64Mi there, and PostgreSQL allocates dynamic shared
+memory segments per parallel worker — one per index during a parallel `VACUUM`.
+On a table with several large indexes the default is exhausted and the vacuum
+fails with `could not resize shared memory segment ... No space left on device`.
+Because tmpfs usage is charged to the container, `shmSize` comes out of the
+same memory limit as everything else.
+
+Keep the memory limit comfortably above `shared_buffers`. The kernel page cache
+counts against the container's cgroup, and PostgreSQL leans on it as a second
+caching tier — so a tight limit squeezes both tiers at once. An OOM kill also
+discards the cumulative statistics file, which resets the counters autovacuum
+uses to schedule itself; a database that keeps getting killed can stop being
+vacuumed or analyzed altogether.
 
 ### Redis Configuration (Scalable)
 

--- a/helm/templates/postgres.yaml
+++ b/helm/templates/postgres.yaml
@@ -61,6 +61,19 @@ spec:
       - name: postgres
         image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
         imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+        {{- with .Values.postgres.config }}
+        # The image entrypoint forwards a leading `-` argument to the server,
+        # so these become postgres command-line settings. Sorted for a stable
+        # rendering, or every `helm upgrade` shows a spurious diff.
+        args:
+          {{- range $key := (keys . | sortAlpha) }}
+          {{- $value := index $.Values.postgres.config $key }}
+          {{- if $value }}
+          - -c
+          - {{ printf "%s=%v" $key $value | quote }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
         ports:
         - name: postgresql
           containerPort: 5432
@@ -77,10 +90,14 @@ spec:
               key: {{ (include "krawl.postgres.secret" . | fromJson).key }}
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
-        {{- if .Values.postgres.persistence.enabled }}
         volumeMounts:
+        {{- if .Values.postgres.persistence.enabled }}
         - name: data
           mountPath: /var/lib/postgresql/data
+        {{- end }}
+        {{- if .Values.postgres.shmSize }}
+        - name: dshm
+          mountPath: /dev/shm
         {{- end }}
         {{- with .Values.postgres.resources }}
         resources:
@@ -108,10 +125,21 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 3
-      {{- if .Values.postgres.persistence.enabled }}
       volumes:
+      {{- if .Values.postgres.persistence.enabled }}
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "krawl.fullname" . }}-postgres
+      {{- end }}
+      {{- if .Values.postgres.shmSize }}
+      # Kubernetes gives a container 64Mi of /dev/shm, which PostgreSQL uses
+      # for the dynamic shared memory segments that parallel workers allocate.
+      # A parallel VACUUM takes one segment per index, so a table with several
+      # large indexes overruns the default and the vacuum dies with
+      # "could not resize shared memory segment ... No space left on device".
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ .Values.postgres.shmSize }}
       {{- end }}
 {{- end }}

--- a/helm/templates/postgres.yaml
+++ b/helm/templates/postgres.yaml
@@ -62,9 +62,7 @@ spec:
         image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
         imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
         {{- with .Values.postgres.config }}
-        # The image entrypoint forwards a leading `-` argument to the server,
-        # so these become postgres command-line settings. Sorted for a stable
-        # rendering, or every `helm upgrade` shows a spurious diff.
+        # Sorted so `helm upgrade` does not diff on Go map ordering.
         args:
           {{- range $key := (keys . | sortAlpha) }}
           {{- $value := index $.Values.postgres.config $key }}
@@ -132,11 +130,8 @@ spec:
           claimName: {{ include "krawl.fullname" . }}-postgres
       {{- end }}
       {{- if .Values.postgres.shmSize }}
-      # Kubernetes gives a container 64Mi of /dev/shm, which PostgreSQL uses
-      # for the dynamic shared memory segments that parallel workers allocate.
-      # A parallel VACUUM takes one segment per index, so a table with several
-      # large indexes overruns the default and the vacuum dies with
-      # "could not resize shared memory segment ... No space left on device".
+      # The k8s default 64Mi is too small for PostgreSQL's parallel-worker
+      # shared memory (one segment per index during a parallel VACUUM).
       - name: dshm
         emptyDir:
           medium: Memory

--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -65,11 +65,19 @@ spec:
         - name: redis
           containerPort: 6379
           protocol: TCP
-        {{- if .Values.redis.password }}
         command:
           - redis-server
+          {{- if .Values.redis.password }}
           - --requirepass
           - $(REDIS_PASSWORD)
+          {{- end }}
+          {{- if .Values.redis.maxmemory }}
+          - --maxmemory
+          - {{ .Values.redis.maxmemory | quote }}
+          - --maxmemory-policy
+          - {{ .Values.redis.maxmemoryPolicy | quote }}
+          {{- end }}
+        {{- if .Values.redis.password }}
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -314,20 +314,8 @@ postgres:
     size: 5Gi
     accessMode: ReadWriteOnce
     # storageClassName: ""
-  # Server tuning, rendered as `-c name=value` flags on the postgres command.
-  # Set a key to null to drop it and fall back to the server default.
-  #
-  # The stock image ships shared_buffers=128MB and work_mem=4MB, which are
-  # sized for a toy database. Krawl's ip_stats and access_logs tables reach
-  # gigabytes on a busy sensor, and the dashboard aggregates group over all of
-  # them; at the defaults, essentially every one of those reads misses the
-  # cache and every GROUP BY spills to a temp file.
-  #
-  # random_page_cost and effective_io_concurrency are left at their
-  # rotational-disk defaults on purpose. Lower random_page_cost (1.1) if the
-  # data volume is SSD-backed, and raise effective_io_concurrency (100-200)
-  # if it can service parallel random reads — both are actively harmful on
-  # spinning or network-replicated storage.
+  # Server settings, rendered as `-c name=value`. null drops a key.
+  # SSD-backed storage: set random_page_cost 1.1, effective_io_concurrency 100.
   config:
     shared_buffers: 256MB
     effective_cache_size: 512MB
@@ -335,23 +323,11 @@ postgres:
     maintenance_work_mem: 128MB
     random_page_cost: "4"
     effective_io_concurrency: "1"
-  # Size of /dev/shm, mounted as an in-memory emptyDir. Kubernetes defaults a
-  # container to 64Mi, which is not enough for the dynamic shared memory that
-  # PostgreSQL's parallel workers allocate — one segment per index during a
-  # parallel VACUUM, so a table with several large indexes fails outright with
-  # "could not resize shared memory segment". Set to "" to leave /dev/shm at
-  # the Kubernetes default.
-  #
-  # This is tmpfs, so whatever it actually uses counts against the container's
-  # memory limit; keep the limit above shmSize + shared_buffers + working set.
+  # /dev/shm size (tmpfs). The k8s default of 64Mi is too small for parallel
+  # VACUUM. "" leaves it at the default. Counts against the memory limit below.
   shmSize: 256Mi
-  # Memory limits must leave room for shared_buffers *plus* the kernel page
-  # cache, which is charged to the container's cgroup: Postgres relies on the
-  # OS cache as its second tier, so a tight limit squeezes both at once. An
-  # OOM kill is not merely a restart here — the unclean shutdown discards the
-  # cumulative statistics file, which resets the counters autovacuum uses to
-  # decide when to run, and a database whose statistics never accumulate stops
-  # being vacuumed or analyzed at all.
+  # Keep the limit well above shared_buffers + shmSize: the page cache is
+  # charged to the cgroup too, and an OOM kill wipes the stats autovacuum needs.
   resources:
     limits:
       cpu: 500m

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -344,6 +344,12 @@ redis:
   port: 6379
   db: 0
   password: ""
+  # Memory ceiling; "" = unbounded (Redis then grows until OOM-killed).
+  # Keep at ~75% of resources.limits.memory to leave room for fragmentation.
+  # volatile-lru evicts only TTL'd keys, i.e. krawl:cache:* and never a
+  # krawl:counter:* metric. Do not use allkeys-lru.
+  maxmemory: "192mb"
+  maxmemoryPolicy: "volatile-lru"
   # Cache TTL settings (seconds)
   cache_ttl: 600    # Dashboard warmup data (default: 10 minutes)
   hot_ttl: 30       # Hot-path data like ban info (default: 30 seconds)
@@ -371,7 +377,7 @@ redis:
   resources:
     limits:
       cpu: 250m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 50m
       memory: 64Mi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -314,13 +314,51 @@ postgres:
     size: 5Gi
     accessMode: ReadWriteOnce
     # storageClassName: ""
+  # Server tuning, rendered as `-c name=value` flags on the postgres command.
+  # Set a key to null to drop it and fall back to the server default.
+  #
+  # The stock image ships shared_buffers=128MB and work_mem=4MB, which are
+  # sized for a toy database. Krawl's ip_stats and access_logs tables reach
+  # gigabytes on a busy sensor, and the dashboard aggregates group over all of
+  # them; at the defaults, essentially every one of those reads misses the
+  # cache and every GROUP BY spills to a temp file.
+  #
+  # random_page_cost and effective_io_concurrency are left at their
+  # rotational-disk defaults on purpose. Lower random_page_cost (1.1) if the
+  # data volume is SSD-backed, and raise effective_io_concurrency (100-200)
+  # if it can service parallel random reads — both are actively harmful on
+  # spinning or network-replicated storage.
+  config:
+    shared_buffers: 256MB
+    effective_cache_size: 512MB
+    work_mem: 16MB
+    maintenance_work_mem: 128MB
+    random_page_cost: "4"
+    effective_io_concurrency: "1"
+  # Size of /dev/shm, mounted as an in-memory emptyDir. Kubernetes defaults a
+  # container to 64Mi, which is not enough for the dynamic shared memory that
+  # PostgreSQL's parallel workers allocate — one segment per index during a
+  # parallel VACUUM, so a table with several large indexes fails outright with
+  # "could not resize shared memory segment". Set to "" to leave /dev/shm at
+  # the Kubernetes default.
+  #
+  # This is tmpfs, so whatever it actually uses counts against the container's
+  # memory limit; keep the limit above shmSize + shared_buffers + working set.
+  shmSize: 256Mi
+  # Memory limits must leave room for shared_buffers *plus* the kernel page
+  # cache, which is charged to the container's cgroup: Postgres relies on the
+  # OS cache as its second tier, so a tight limit squeezes both at once. An
+  # OOM kill is not merely a restart here — the unclean shutdown discards the
+  # cumulative statistics file, which resets the counters autovacuum uses to
+  # decide when to run, and a database whose statistics never accumulate stops
+  # being vacuumed or analyzed at all.
   resources:
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1Gi
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
 
 # Redis settings (only used when mode=scalable)
 redis:

--- a/src/dashboard_cache.py
+++ b/src/dashboard_cache.py
@@ -114,6 +114,71 @@ def set_cached(key: str, value: Any, ttl: int = None) -> None:
         _cache[key] = value
 
 
+# Items pushed per RPUSH when storing a cached list, so a 100k-row aggregate
+# does not become one enormous command.
+_LIST_PUSH_BATCH = 1_000
+
+
+def set_cached_list(key: str, items: list, ttl: int = None) -> None:
+    """Cache a pre-sorted list so pages can be served without reading it whole.
+
+    In scalable mode the list is stored as a Redis LIST of per-item JSON rather
+    than one JSON blob, which is what lets get_cached_list_page() fetch a
+    ten-row slice with LRANGE. The blob form meant every request for any page
+    transferred and parsed the entire aggregate — tens of MB, for ten rows.
+
+    Standalone keeps the plain in-memory list: there is no serialization
+    boundary to cross, so slicing it directly is already optimal.
+    """
+    if _backend == "scalable" and _redis_client is not None:
+        redis_key = f"{_REDIS_PREFIX}list:{key}"
+        encoded = [json.dumps(i, default=_json_serializer) for i in items]
+        pipe = _redis_client.pipeline()
+        # Build under a temporary key and rename into place, so readers never
+        # observe a half-populated list mid-refresh.
+        staging = f"{redis_key}:staging"
+        pipe.delete(staging)
+        for start in range(0, len(encoded), _LIST_PUSH_BATCH):
+            pipe.rpush(staging, *encoded[start : start + _LIST_PUSH_BATCH])
+        if encoded:
+            pipe.rename(staging, redis_key)
+            pipe.expire(redis_key, ttl or _REDIS_TTL)
+        else:
+            pipe.delete(redis_key)
+        pipe.execute()
+        return
+
+    with _lock:
+        _cache[f"list:{key}"] = list(items)
+
+
+def get_cached_list_page(key: str, page: int, page_size: int) -> dict | None:
+    """Return one page of a cached list, or None if the list is not cached.
+
+    The shape matches paginate_cached_list() so callers are interchangeable.
+    """
+    if _backend == "scalable" and _redis_client is not None:
+        redis_key = f"{_REDIS_PREFIX}list:{key}"
+        total = _redis_client.llen(redis_key)
+        if not total:
+            return None
+        total_pages = max(1, (total + page_size - 1) // page_size)
+        page = max(1, min(page, total_pages))
+        offset = (page - 1) * page_size
+        # LRANGE is inclusive on both ends.
+        raw = _redis_client.lrange(redis_key, offset, offset + page_size - 1)
+        return {
+            "items": [json.loads(r) for r in raw],
+            "pagination": pagination(page, page_size, total),
+        }
+
+    with _lock:
+        items = _cache.get(f"list:{key}")
+    if items is None:
+        return None
+    return paginate_cached_list(items, page, page_size)
+
+
 def get_cached_short(key: str) -> Any | None:
     """Get a value from the short-TTL hot-path cache (scalable mode only).
 

--- a/src/database/core.py
+++ b/src/database/core.py
@@ -388,8 +388,7 @@ class DatabaseManager:
                         mc.increment("honeypot_triggered")
                     if was_first_honeypot:
                         mc.increment("honeypot_ips")
-                    if mc.add_to_set("paths", sanitize_path(path)):
-                        mc.increment("unique_paths")
+                    mc.record_distinct("paths", sanitize_path(path), "unique_paths")
                     if attack_types:
                         for attack_type in attack_types:
                             mc.increment("attack_detections", attack_type[:50])

--- a/src/database/core.py
+++ b/src/database/core.py
@@ -234,6 +234,13 @@ class DatabaseManager:
 
         run_migrations(self._engine)
 
+        # Collect planner statistics if this database has never had any. Runs
+        # after the migrations so the autovacuum thresholds they set are in
+        # place first; a no-op on every boot but the first.
+        from database.maintenance import bootstrap_analyze
+
+        bootstrap_analyze(self._engine)
+
         # Set restrictive file permissions for SQLite (owner read/write only)
         if mode == "standalone" and os.path.exists(database_path):
             try:
@@ -251,6 +258,19 @@ class DatabaseManager:
                 "DatabaseManager not initialized. Call initialize() first."
             )
         return self._Session()
+
+    @property
+    def engine(self):
+        """The SQLAlchemy Engine, for statements that cannot run in a session.
+
+        ANALYZE and friends need connection-level control (AUTOCOMMIT), which a
+        thread-local ORM session does not give.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "DatabaseManager not initialized. Call initialize() first."
+            )
+        return self._engine
 
     def close_session(self) -> None:
         """Close the current thread-local session."""

--- a/src/database/maintenance.py
+++ b/src/database/maintenance.py
@@ -1,0 +1,110 @@
+"""Planner-statistics maintenance for the Krawl database.
+
+Autovacuum owns the steady state — see ``AUTOVACUUM`` in migrations/runner.py,
+which lowers the per-table thresholds so it actually fires on tables this size.
+This module covers the two moments autovacuum is structurally late for:
+
+- **Boot on a database it has never analysed.** Autovacuum's trigger is a
+  *count of modifications since the last analyze*, and PostgreSQL discards
+  those counters on an unclean shutdown. A database that keeps restarting
+  (an OOM-killed container, say) can therefore never accumulate enough to
+  cross the threshold, and its tables stay unanalysed indefinitely — leaving
+  the planner to size a multi-million-row table from its empty-table default.
+  ``bootstrap_analyze`` breaks that cycle once, at boot.
+
+- **Straight after the nightly retention purge.** A bulk delete invalidates the
+  statistics at a moment the application knows about and autovacuum does not
+  yet; analysing there costs one pass at 8 AM instead of a day of bad plans.
+
+Both are PostgreSQL-only. SQLite has no autovacuum daemon and its own ANALYZE
+is a different (and far cheaper) mechanism, so standalone mode skips them.
+"""
+
+import time
+
+from sqlalchemy import text
+
+from logger import get_app_logger
+
+applogger = get_app_logger()
+
+# Tables large enough for a wrong row estimate to change the plan. Kept in sync
+# with AUTOVACUUM in migrations/runner.py.
+ANALYZE_TABLES = ("ip_stats", "access_logs", "category_history", "attack_detections")
+
+
+def _is_postgres(engine) -> bool:
+    return engine.dialect.name == "postgresql"
+
+
+def analyze_tables(engine, tables=ANALYZE_TABLES) -> int:
+    """Run ANALYZE on `tables`. Returns the number successfully analysed.
+
+    ANALYZE cannot run inside a transaction block, hence the AUTOCOMMIT
+    isolation level rather than the usual ``engine.begin()``.
+
+    Each table is analysed in its own statement so one failure (a table that
+    does not exist yet on a fresh install) does not skip the rest.
+    """
+    if not _is_postgres(engine):
+        return 0
+
+    done = 0
+    for table in tables:
+        try:
+            with engine.connect().execution_options(
+                isolation_level="AUTOCOMMIT"
+            ) as conn:
+                conn.execute(text(f"ANALYZE {table}"))
+            done += 1
+        except Exception as e:
+            applogger.error(f"ANALYZE {table} failed: {e}")
+    return done
+
+
+def bootstrap_analyze(engine) -> int:
+    """Analyse any sizeable table that has never been analysed. Returns the count.
+
+    A no-op on every boot after the first, because ``last_analyze`` /
+    ``last_autoanalyze`` stay set once either has run. The size floor keeps a
+    fresh install from paying for an ANALYZE of empty tables.
+
+    That floor is deliberately measured with ``pg_relation_size`` rather than
+    ``n_live_tup``: the row counters come from the same statistics this
+    function exists to repair, and on a database that has never been analysed
+    they read as near-zero however large the table actually is. Physical size
+    is maintained independently of the statistics collector, so it stays
+    truthful in exactly the situation we are detecting.
+    """
+    if not _is_postgres(engine):
+        return 0
+
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT relname FROM pg_stat_user_tables "
+                    "WHERE relname = ANY(:tables) "
+                    "  AND last_analyze IS NULL AND last_autoanalyze IS NULL "
+                    "  AND pg_relation_size(relid) > 8 * 1024 * 1024"
+                ),
+                {"tables": list(ANALYZE_TABLES)},
+            ).fetchall()
+    except Exception as e:
+        applogger.error(f"Bootstrap ANALYZE check failed: {e}")
+        return 0
+
+    pending = [r[0] for r in rows]
+    if not pending:
+        return 0
+
+    applogger.info(
+        f"Bootstrap ANALYZE: {', '.join(pending)} have never been analysed, "
+        "collecting statistics…"
+    )
+    t0 = time.monotonic()
+    done = analyze_tables(engine, pending)
+    applogger.info(
+        f"Bootstrap ANALYZE: analysed {done} table(s) in {time.monotonic() - t0:.1f}s"
+    )
+    return done

--- a/src/metrics_counters.py
+++ b/src/metrics_counters.py
@@ -8,8 +8,8 @@ standalone mode they are a locked in-memory dict. Values feed Prometheus gauges
 (set at scrape time) and the dashboard's aggregate counts.
 
 Encoding: a labeled counter is stored as "metric|label"; an unlabeled one as
-"metric". Distinctness sets (e.g. seen request paths) live under
-krawl:counter:set:<name>.
+"metric". Distinctness estimators (e.g. seen request paths) live under
+krawl:counter:hll:<name>.
 """
 
 import threading
@@ -18,14 +18,31 @@ from collections.abc import Iterable
 from dashboard_cache import get_backend, get_redis_client
 
 _COUNTER_PREFIX = "krawl:counter:"
-_SET_PREFIX = "krawl:counter:set:"
+_HLL_PREFIX = "krawl:counter:hll:"
+# Superseded by _HLL_PREFIX; retained so the one-time migration can find and
+# drop the old exact sets. See migrate_legacy_sets().
+_LEGACY_SET_PREFIX = "krawl:counter:set:"
 _SEED_MARKER = "krawl:counter:_seeded"
 
-# Distinctness sets are append-only by design, and "paths" is keyed on
-# attacker-chosen URLs — so in standalone mode it grows for the lifetime of the
-# process. Redis holds the real set in scalable mode; this cap only bounds the
-# fallback. Past it, `unique_paths` stops rising and becomes a floor rather
-# than an exact count, which is the right trade against an OOM.
+# Names of the distinctness estimators, for the legacy migration to walk.
+_DISTINCT_NAMES = ("paths",)
+
+# Members pushed per PFADD when seeding, so a multi-million-member rebuild does
+# not become one enormous command.
+_HLL_SEED_BATCH = 5_000
+
+# Distinctness tracking is append-only by design, and "paths" is keyed on
+# attacker-chosen URLs — worse, Krawl *generates* random link paths, so the key
+# space has no natural ceiling and the structure only ever grows.
+#
+# Scalable mode uses a Redis HyperLogLog: a fixed ~12 KB per estimator with a
+# 0.81% standard error, regardless of cardinality. It replaced an exact SET
+# that had reached 2.9M members and ~94 MB — all to produce one dashboard
+# integer, and with nothing to stop it consuming the whole instance.
+#
+# Standalone keeps the exact in-memory set, capped: past the cap `unique_paths`
+# stops rising and becomes a floor rather than an exact count, which is the
+# right trade against an OOM.
 _MAX_SET_ENTRIES = 100_000
 
 _lock = threading.Lock()
@@ -90,7 +107,12 @@ def get_many(metrics) -> dict[str, int]:
 
 
 def get_all() -> dict[str, int]:
-    """Return all counters as {encoded_key: value}. Excludes distinctness sets."""
+    """Return all counters as {encoded_key: value}. Excludes distinctness state.
+
+    Both the estimator and legacy-set prefixes are filtered out: they share the
+    krawl:counter: namespace but hold structures, not integers, and a
+    HyperLogLog's value would raise on int().
+    """
     if get_backend() == "scalable":
         r = get_redis_client()
         out: dict[str, int] = {}
@@ -102,7 +124,9 @@ def get_all() -> dict[str, int]:
                 keys.extend(
                     k
                     for k in batch
-                    if not k.startswith(_SET_PREFIX) and k != _SEED_MARKER
+                    if not k.startswith(_HLL_PREFIX)
+                    and not k.startswith(_LEGACY_SET_PREFIX)
+                    and k != _SEED_MARKER
                 )
                 if cursor == 0:
                     break
@@ -118,11 +142,18 @@ def get_all() -> dict[str, int]:
 
 
 def add_to_set(name: str, member: str) -> bool:
-    """Add member to a distinctness set. Return True if it was newly added."""
+    """Record a member as seen. Return True if it looks newly added.
+
+    Scalable mode answers from a HyperLogLog, so "newly added" is an estimate:
+    PFADD reports whether the registers changed, which a genuinely new member
+    may occasionally fail to do. The caller uses this only to step the
+    `unique_paths` counter, which is itself realigned to the estimator on every
+    reconcile — so a rare miss self-corrects rather than accumulating.
+    """
     if get_backend() == "scalable":
         r = get_redis_client()
         if r is not None:
-            return r.sadd(f"{_SET_PREFIX}{name}", member) == 1
+            return r.pfadd(f"{_HLL_PREFIX}{name}", member) == 1
     with _lock:
         s = _sets.setdefault(name, set())
         if member in s:
@@ -133,27 +164,116 @@ def add_to_set(name: str, member: str) -> bool:
         return True
 
 
+def record_distinct(name: str, member: str, counter: str) -> None:
+    """Record `member` as seen and keep `counter` in step with the count.
+
+    The two backends reach the same number by different routes:
+
+    - standalone holds an exact set, so a newly-added member increments the
+      counter directly, as it always has;
+    - scalable holds a HyperLogLog, whose PFADD result is a statement about
+      registers rather than membership — it can report a change for a member
+      already present, and incrementing on that would drift the counter upward
+      with no bound between reconciles. There the counter is instead realigned
+      wholesale by sync_distinct_counter(), which is exact with respect to the
+      estimator and costs one O(1) call.
+    """
+    is_new = add_to_set(name, member)
+    if get_backend() == "scalable":
+        return
+    if is_new:
+        increment(counter)
+
+
+def sync_distinct_counter(name: str, counter: str) -> None:
+    """Set `counter` to the estimator's cardinality (scalable mode only).
+
+    PFCOUNT is O(1) — Redis caches the cardinality in the HyperLogLog header
+    and only recomputes it after a modification — so this is cheap enough to
+    run on the metrics flush schedule.
+    """
+    if get_backend() == "scalable":
+        set_value(counter, "", scard(name))
+
+
 def scard(name: str) -> int:
-    """Return the cardinality of a distinctness set."""
+    """Return the number of distinct members seen.
+
+    Approximate in scalable mode (HyperLogLog, ~0.81% standard error); exact
+    in standalone mode up to _MAX_SET_ENTRIES.
+    """
     if get_backend() == "scalable":
         r = get_redis_client()
         if r is not None:
-            return int(r.scard(f"{_SET_PREFIX}{name}"))
+            return int(r.pfcount(f"{_HLL_PREFIX}{name}"))
     with _lock:
         return len(_sets.get(name, set()))
 
 
 def seed_set(name: str, members: Iterable[str]) -> None:
-    """Replace a distinctness set's contents (used when seeding from the DB)."""
-    members = list(members)
+    """Seed a distinctness estimator (used when rebuilding from the DB).
+
+    Batched, because seeding walks every distinct path ever recorded and that
+    is a seven-figure list on a long-running sensor.
+    """
     if get_backend() == "scalable":
         r = get_redis_client()
         if r is not None:
-            if members:
-                r.sadd(f"{_SET_PREFIX}{name}", *members)
+            batch: list[str] = []
+            for member in members:
+                batch.append(member)
+                if len(batch) >= _HLL_SEED_BATCH:
+                    r.pfadd(f"{_HLL_PREFIX}{name}", *batch)
+                    batch.clear()
+            if batch:
+                r.pfadd(f"{_HLL_PREFIX}{name}", *batch)
             return
     with _lock:
         _sets[name] = set(members)
+
+
+def migrate_legacy_sets() -> None:
+    """Fold any pre-HyperLogLog exact SET into its estimator, then drop it.
+
+    Runs on every boot and is a no-op once done. It deliberately sits *outside*
+    the needs_seed() gate: that marker is already set on any deployment old
+    enough to have the legacy set, so a seed-gated migration would never fire
+    on exactly the installs that need it.
+
+    The estimator is seeded by scanning the old set rather than recomputed from
+    SQL, which keeps the count continuous without a distinct-scan of
+    access_logs. Only then is the old key deleted — an interrupted run just
+    repeats harmlessly next boot, since PFADD is idempotent.
+    """
+    if get_backend() != "scalable":
+        return
+    r = get_redis_client()
+    if r is None:
+        return
+
+    for name in _DISTINCT_NAMES:
+        legacy = f"{_LEGACY_SET_PREFIX}{name}"
+        try:
+            if not r.exists(legacy):
+                continue
+            hll = f"{_HLL_PREFIX}{name}"
+            batch: list[str] = []
+            for member in r.sscan_iter(legacy, count=1000):
+                batch.append(member)
+                if len(batch) >= _HLL_SEED_BATCH:
+                    r.pfadd(hll, *batch)
+                    batch.clear()
+            if batch:
+                r.pfadd(hll, *batch)
+            # UNLINK reclaims a multi-million-member set on a background
+            # thread; DEL would block the event loop for the whole free.
+            r.unlink(legacy)
+        except Exception:
+            import logging
+
+            logging.getLogger("krawl").exception(
+                f"Legacy distinctness set migration failed for {name!r}"
+            )
 
 
 def needs_seed() -> bool:
@@ -214,14 +334,14 @@ def _recompute_heavy(db) -> None:
 
     For tallied metrics, cumulative = count(current rows) + deleted tally, so
     they stay "total ever observed" even after retention purges benign rows.
-    The seen-paths set is left untouched (append-only distinct-ever); we only
-    keep the unique_paths counter aligned to its cardinality.
+    The seen-paths estimator is left untouched (append-only distinct-ever); we
+    only keep the unique_paths counter aligned to its cardinality.
     """
     counts = db.access_logs._compute_dashboard_counts_sql()
     tallies = db.analytics.get_deleted_tallies()
     for metric in HEAVY_METRICS:
         if metric == "unique_paths":
-            continue  # backed by the append-only seen-paths set
+            continue  # backed by the append-only seen-paths estimator
         base = int(counts.get(metric, 0) or 0)
         if metric in _TALLIED_METRICS:
             base += int(tallies.get(metric, 0) or 0)
@@ -248,11 +368,15 @@ def bootstrap(db) -> None:
     avoids a full scan on every pod start) or are recomputed from SQL on first
     run. clients_total is NOT seeded here — it is recomputed live at scrape time.
     """
+    # Before the seed gate: installs carrying the legacy set already hold the
+    # seed marker, so this would never run behind it.
+    migrate_legacy_sets()
+
     if not needs_seed():
         return
 
     try:
-        # Seen-paths distinctness set: rebuild only if absent (e.g. Redis wiped).
+        # Seen-paths estimator: rebuild only if absent (e.g. Redis wiped).
         # It is append-only across restarts, so we never shrink it here.
         if scard("paths") == 0:
             seed_set("paths", db.access_logs.get_distinct_paths())

--- a/src/migrations/runner.py
+++ b/src/migrations/runner.py
@@ -64,6 +64,52 @@ INDEXES = [
     ("ix_ip_stats_last_analysis", "ip_stats", "last_analysis"),
 ]
 
+# (table, {storage parameter: value}) — PostgreSQL only, applied with ALTER TABLE.
+#
+# The stock scale factors (0.2 vacuum / 0.1 analyze) are a fraction of the
+# table, so they scale the *threshold* with the data: at 1.5M rows ip_stats
+# waits for ~300k dead tuples before a vacuum and ~150k modifications before an
+# analyze. On an append-mostly honeypot table that point arrives rarely or
+# never, which leaves the planner sizing a multi-million-row table from its
+# empty-table estimate and leaves dead index entries unreclaimed — a lookup
+# that should return nothing then reads tens of MB to discover that.
+#
+# Lower factors plus a flat threshold keep both maintenance jobs firing on a
+# schedule the table size cannot outrun.
+AUTOVACUUM = [
+    (
+        table,
+        {
+            "autovacuum_vacuum_scale_factor": "0.02",
+            "autovacuum_vacuum_threshold": "1000",
+            "autovacuum_analyze_scale_factor": "0.01",
+            "autovacuum_analyze_threshold": "1000",
+        },
+    )
+    for table in ("ip_stats", "access_logs", "category_history", "attack_detections")
+]
+
+
+def _reloptions(engine: Engine, table: str) -> set[str]:
+    """Current storage parameters of a table, as {"name=value"} (PostgreSQL).
+
+    Returns an empty set when the table is missing or unreadable, so the caller
+    simply applies the settings rather than failing.
+    """
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT unnest(coalesce(reloptions, '{}')) FROM pg_class "
+                    "WHERE relname = :t AND relkind = 'r'"
+                ),
+                {"t": table},
+            ).fetchall()
+        return {r[0] for r in row}
+    except Exception as e:
+        logger.error(f"Migration error (reloptions {table}): {e}")
+        return set()
+
 
 def run_migrations(engine: Engine) -> None:
     """Apply any pending column/index migrations.
@@ -110,6 +156,21 @@ def run_migrations(engine: Engine) -> None:
         if indexes[table] is None or idx_name in indexes[table]:
             continue
         _apply(f"add index {idx_name}", f"CREATE INDEX {idx_name} ON {table}({column})")
+
+    # Storage parameters are a PostgreSQL concept; SQLite has no autovacuum
+    # daemon to tune, so standalone mode skips this entirely.
+    if engine.dialect.name == "postgresql":
+        for table, params in AUTOVACUUM:
+            # ALTER TABLE ... SET is harmless to repeat, but _apply() reports
+            # every call as a migration, so compare against the table's current
+            # reloptions first and stay silent when nothing changes.
+            if _reloptions(engine, table) >= {f"{k}={v}" for k, v in params.items()}:
+                continue
+            settings = ", ".join(f"{k} = {v}" for k, v in params.items())
+            _apply(
+                f"tune autovacuum for {table}",
+                f"ALTER TABLE {table} SET ({settings})",
+            )
 
     if applied:
         for m in applied:

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -35,10 +35,10 @@ from auth_store import (
 from config import get_config
 from dashboard_cache import (
     get_cached,
+    get_cached_list_page,
     get_cached_table,
     invalidate_table_cache,
     is_warm,
-    paginate_cached_list,
     set_cached_table,
 )
 from dependencies import get_client_ip, get_db
@@ -334,9 +334,8 @@ async def all_ips(
         and sort_order == "desc"
         and is_warm()
     ):
-        agg = get_cached("agg:map_ips")
-        if agg is not None:
-            sliced = paginate_cached_list(agg, page=page, page_size=page_size)
+        sliced = get_cached_list_page("agg:map_ips", page=page, page_size=page_size)
+        if sliced is not None:
             return JSONResponse(
                 content={"ips": sliced["items"], "pagination": sliced["pagination"]},
                 headers=_no_cache_headers(),

--- a/src/routes/htmx.py
+++ b/src/routes/htmx.py
@@ -13,9 +13,9 @@ from fastapi.responses import HTMLResponse
 from config import get_config
 from dashboard_cache import (
     get_cached,
+    get_cached_list_page,
     get_cached_table,
     is_warm,
-    paginate_cached_list,
     set_cached_table,
 )
 from dependencies import get_db, get_templates
@@ -60,9 +60,8 @@ async def htmx_honeypot(
         and sort_order == "desc"
         and is_warm()
     ):
-        agg = get_cached("agg:honeypot")
-        if agg is not None:
-            sliced = paginate_cached_list(agg, page=page, page_size=5)
+        sliced = get_cached_list_page("agg:honeypot", page=page, page_size=5)
+        if sliced is not None:
             result = {"honeypots": sliced["items"], "pagination": sliced["pagination"]}
 
     if result is None:
@@ -183,11 +182,10 @@ async def htmx_top_paths(
         and not is_honeypot
         and is_warm()
     ):
-        agg = get_cached("agg:top_paths")
-        if agg is not None:
-            sliced = paginate_cached_list(
-                agg, page=max(1, page), page_size=min(page_size, 100)
-            )
+        sliced = get_cached_list_page(
+            "agg:top_paths", page=max(1, page), page_size=min(page_size, 100)
+        )
+        if sliced is not None:
             result = {"paths": sliced["items"], "pagination": sliced["pagination"]}
 
     # Legacy page-1 warmup fallback
@@ -336,11 +334,10 @@ async def htmx_top_ua(
         and not search
         and is_warm()
     ):
-        agg = get_cached("agg:top_ua")
-        if agg is not None:
-            sliced = paginate_cached_list(
-                agg, page=max(1, page), page_size=min(page_size, 100)
-            )
+        sliced = get_cached_list_page(
+            "agg:top_ua", page=max(1, page), page_size=min(page_size, 100)
+        )
+        if sliced is not None:
             result = {
                 "user_agents": sliced["items"],
                 "pagination": sliced["pagination"],
@@ -407,9 +404,8 @@ async def htmx_attackers(
         and sort_order == "desc"
         and is_warm()
     ):
-        agg = get_cached("agg:attackers")
-        if agg is not None:
-            sliced = paginate_cached_list(agg, page=page, page_size=10)
+        sliced = get_cached_list_page("agg:attackers", page=page, page_size=10)
+        if sliced is not None:
             result = {"attackers": sliced["items"], "pagination": sliced["pagination"]}
 
     if result is None:

--- a/src/tasks/dashboard_warmup.py
+++ b/src/tasks/dashboard_warmup.py
@@ -9,7 +9,7 @@ import time
 
 import metrics
 from config import get_config
-from dashboard_cache import set_cached, set_cached_table
+from dashboard_cache import set_cached, set_cached_list, set_cached_table
 from database import get_database
 from logger import get_app_logger
 
@@ -121,7 +121,7 @@ def main():
                 ),
             )
             agg_ua = [{"user_agent": ua, "count": c} for ua, c in top_ua_all]
-            set_cached("agg:top_ua", agg_ua)
+            set_cached_list("agg:top_ua", agg_ua)
             top_ua = {
                 "user_agents": agg_ua[:5],
                 "pagination": {
@@ -138,7 +138,7 @@ def main():
                 lambda: db.analytics.get_top_paths(limit=100_000, min_count=min_count),
             )
             agg_paths = [{"path": p, "count": c} for p, c in top_paths_all]
-            set_cached("agg:top_paths", agg_paths)
+            set_cached_list("agg:top_paths", agg_paths)
             top_paths = {
                 "paths": agg_paths[:5],
                 "pagination": {
@@ -159,7 +159,7 @@ def main():
                     sort_order="desc",
                 ),
             )
-            set_cached("agg:attackers", attackers_all["attackers"])
+            set_cached_list("agg:attackers", attackers_all["attackers"])
 
             honeypot_all = _timed(
                 "get_honeypot_all",
@@ -167,7 +167,7 @@ def main():
                     page=1, page_size=100_000, sort_by="count", sort_order="desc"
                 ),
             )
-            set_cached("agg:honeypot", honeypot_all["honeypots"])
+            set_cached_list("agg:honeypot", honeypot_all["honeypots"])
         else:
             top_ua = _timed(
                 "get_top_user_agents_paginated",
@@ -194,7 +194,7 @@ def main():
                     sort_order="desc",
                 ),
             )
-            set_cached("agg:map_ips", map_ips_all["ips"])
+            set_cached_list("agg:map_ips", map_ips_all["ips"])
             total_ips = map_ips_all["pagination"]["total"]
             map_ips = {
                 "ips": map_ips_all["ips"][:1000],

--- a/src/tasks/db_retention.py
+++ b/src/tasks/db_retention.py
@@ -24,7 +24,7 @@ DELETE_BATCH_SIZE = 10_000
 
 TASK_CONFIG = {
     "name": "db-retention",
-    "cron": "0 3 * * *",  # Run daily at 3 AM
+    "cron": "0 9 * * *",  # Run daily at 9 AM
     "enabled": True,
     "run_when_loaded": False,
 }
@@ -161,6 +161,23 @@ def main():
             metrics_counters.reconcile(db)
         except Exception as e:
             app_logger.error(f"Error reconciling metrics after retention: {e}")
+
+        # Refresh planner statistics: the purge above just invalidated them,
+        # and this is the one moment we know that for certain. Autovacuum would
+        # get there on its own, but not before the next day's queries have run
+        # against row estimates that count rows we deleted. Only worth the pass
+        # if something was actually removed.
+        if total:
+            try:
+                from database.maintenance import analyze_tables
+
+                analyzed = analyze_tables(db.engine)
+                if analyzed:
+                    app_logger.info(
+                        f"DB retention: refreshed statistics on {analyzed} table(s)"
+                    )
+            except Exception as e:
+                app_logger.error(f"Error analyzing tables after retention: {e}")
 
     except Exception as e:
         app_logger.error(f"Error during DB retention cleanup: {e}")

--- a/src/tasks/flag_stale_ips.py
+++ b/src/tasks/flag_stale_ips.py
@@ -7,9 +7,9 @@ from logger import get_app_logger
 
 TASK_CONFIG = {
     "name": "flag-stale-ips",
-    "cron": "0 2 * * *",  # Run daily at 2 AM
+    "cron": "0 8 * * *",  # Run daily at 8 AM
     "enabled": True,
-    # a daily 02:00 job — running it on every restart makes a daily sweep happen N times a day.
+    # a daily 08:00 job — running it on every restart makes a daily sweep happen N times a day.
     "run_when_loaded": False,
 }
 

--- a/src/tasks/metrics_flush.py
+++ b/src/tasks/metrics_flush.py
@@ -26,6 +26,10 @@ def main():
     task_name = TASK_CONFIG.get("name")
     try:
         db = get_database()
+        # unique_paths is not event-incremented in scalable mode (see
+        # metrics_counters.record_distinct); realign it from the estimator
+        # before snapshotting, or the flushed value never moves.
+        mc.sync_distinct_counter("paths", "unique_paths")
         values = {(metric, ""): mc.get(metric) for metric in mc.HEAVY_METRICS}
         db.analytics.upsert_metrics_summary(values)
         app_logger.info(

--- a/src/tasks/pre_retention_cleanup.py
+++ b/src/tasks/pre_retention_cleanup.py
@@ -21,9 +21,9 @@ from wordlists import get_wordlists
 
 TASK_CONFIG = {
     "name": "pre-retention-cleanup",
-    "cron": "30 2 * * *",  # Run daily at 2:30 AM (before db-retention at 3 AM)
+    "cron": "30 8 * * *",  # Run daily at 8:30 AM (before db-retention at 9 AM)
     "enabled": True,
-    # a daily 02:30 job, same problem, and it is the heavier of the two.
+    # a daily 08:30 job, same problem, and it is the heavier of the two.
     "run_when_loaded": False,
 }
 


### PR DESCRIPTION
This pull request introduces several improvements and optimizations to Krawl's database maintenance, metrics tracking, and Helm chart configuration. The most significant changes include the introduction of a PostgreSQL statistics maintenance module, migration of unique-path tracking to HyperLogLog for efficiency, and enhanced configurability and resource tuning for PostgreSQL and Redis in Kubernetes deployments.

**Database maintenance and metrics improvements:**

* Introduced a new `database/maintenance.py` module that ensures PostgreSQL planner statistics are collected at critical times (on first boot and after retention purges), preventing poor query plans and performance regressions after restarts or bulk deletes. This includes the `bootstrap_analyze` and `analyze_tables` functions. [[1]](diffhunk://#diff-c498da9517a33c2186da8cb56806f9df88aa4e99f77ce0dd0067a8b63702b0a4R1-R110) [[2]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64R237-R243)
* Added a `DatabaseManager.engine` property for direct access to the SQLAlchemy engine, enabling operations like `ANALYZE` that require connection-level control.
* Updated metrics distinctness tracking: replaced the unbounded Redis `SET` for unique paths with a fixed-size HyperLogLog estimator, drastically reducing memory usage while maintaining approximate counts. Includes migration logic for legacy sets. [[1]](diffhunk://#diff-848fc706bd9a6ca1f4c65a3e80ec4d91bc479e44e3f8012b404a5e66dc480d85L11-R12) [[2]](diffhunk://#diff-848fc706bd9a6ca1f4c65a3e80ec4d91bc479e44e3f8012b404a5e66dc480d85L21-R45) [[3]](diffhunk://#diff-848fc706bd9a6ca1f4c65a3e80ec4d91bc479e44e3f8012b404a5e66dc480d85L93-R115) [[4]](diffhunk://#diff-848fc706bd9a6ca1f4c65a3e80ec4d91bc479e44e3f8012b404a5e66dc480d85L105-R129) [[5]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64L371-R391)

**Helm chart and Kubernetes resource/configuration enhancements:**

* PostgreSQL: Added support for custom server settings via `postgres.config`, increased default memory limits and requests, introduced `postgres.shmSize` for tuning `/dev/shm` (critical for parallel vacuum), and documented recommended settings for busy sensors. [[1]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R317-R337) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L360-R380) [[3]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L317-R353) [[4]](diffhunk://#diff-17442822dcbf7f8f38fbd0675c02a144c05de8e0b3d62ab97623ee7c0ff6aa8eR64-R74) [[5]](diffhunk://#diff-17442822dcbf7f8f38fbd0675c02a144c05de8e0b3d62ab97623ee7c0ff6aa8eL80-R99) [[6]](diffhunk://#diff-17442822dcbf7f8f38fbd0675c02a144c05de8e0b3d62ab97623ee7c0ff6aa8eL111-R139)
* Redis: Added configuration options for `maxmemory` and `maxmemoryPolicy` to prevent OOM kills and control eviction behavior, and increased default memory limits. [[1]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R347-R352) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L360-R380) [[3]](diffhunk://#diff-d6b9e928d722755c58f567be61c2ce8232cd92a02486fa3250d3b9947eec3175L68-R80)
* Updated scheduled maintenance task times to later in the morning to avoid early-morning load.
* Bumped Helm chart and app version to 2.3.4.

**Dashboard cache optimization:**

* Added new functions to cache large lists in Redis as LISTs of JSON items (instead of a single blob), allowing efficient paginated retrieval and reducing memory and network overhead for large aggregates.

These changes improve Krawl's performance, scalability, and maintainability, especially in large-scale or Kubernetes environments.