### PR TITLE
Fix: map api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,8 @@ Storage location, how long data is kept, and the dump job.
 | `KRAWL_DATABASE_PERSIST_SUSPICIOUS_ONLY` | Only persist suspicious requests to the access log | `false` |
 | `KRAWL_MAP_TILE_URL` | Tile URL template for the dashboard map (`{z}/{x}/{y}`, optional `{s}`/`{r}`) | Esri dark canvas |
 | `KRAWL_MAP_TILE_ATTRIBUTION` | Attribution shown on the map | Esri/OSM |
-| `KRAWL_MAP_API_KEY` | Appended to every tile request as `?key=` — required by CARTO | _(empty)_ |
+| `KRAWL_MAP_API_KEY` | Appended to every tile request as a query parameter — required by CARTO | _(empty)_ |
+| `KRAWL_MAP_API_KEY_PARAM` | Name of that query parameter (`api_key`, `apikey`, `key`) | `api_key` |
 | `KRAWL_IPV6_IGNORE` | Drop IPv6 requests entirely: still logged to stdout, never persisted, ban-checked or exported | `false` |
 | `KRAWL_IPV6_PURGE_EXISTING` | Also delete existing IPv6 rows at the next startup (irreversible; requires `KRAWL_IPV6_IGNORE`) | `false` |
 | `KRAWL_DATABASE_RETENTION_DAYS` | Days to retain data in database | `30` |

--- a/config.yaml
+++ b/config.yaml
@@ -125,7 +125,8 @@ map:
   tile_url: "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
   attribution: "&copy; Esri, HERE, Garmin, &copy; OpenStreetMap contributors"
 
-  # CARTO dark: watermarks every tile unless api_key is set.
+  # CARTO dark: watermarks every tile unless api_key is set. Raster endpoint
+  # only -- CARTO's docs push vector style.json, which Leaflet cannot render.
   # tile_url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
   # attribution: "&copy; CARTO | &copy; OpenStreetMap contributors"
 
@@ -137,6 +138,9 @@ map:
   # Sent as ?key= on every tile request, and visible in the page source.
   # Restrict it to your dashboard domain at the provider. Also KRAWL_MAP_API_KEY.
   api_key: ""
+  # Query parameter the key rides on: CARTO and Stadia want api_key,
+  # Thunderforest apikey, MapTiler key. Also KRAWL_MAP_API_KEY_PARAM.
+  api_key_param: "api_key"
 
 tarpit:
   enabled: false  # Opt-in: trap AI agents with slow responses and random text

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ Krawl is a cloud-native deception honeypot server built on **FastAPI**. It creat
 | **Reactivity** | Alpine.js 3.14 |
 | **Partial Updates** | HTMX 2.0 |
 | **Charts** | Chart.js 3.9 (doughnut), custom SVG radar |
-| **Maps** | Leaflet 1.9 + CartoDB dark tiles |
+| **Maps** | Leaflet 1.9 + configurable raster tiles (Esri dark canvas by default) |
 | **Scheduling** | APScheduler |
 | **Container** | Docker (python:3.11-slim), Helm/K8s ready |
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -248,6 +248,7 @@ map:
   attribution: "&copy; Esri, HERE, Garmin, &copy; OpenStreetMap contributors"
   subdomains: "abcd"
   api_key: ""
+  api_key_param: "api_key"
 ```
 
 | Env var | Description | Default |
@@ -255,7 +256,8 @@ map:
 | `KRAWL_MAP_TILE_URL` | Tile URL template. `{z}`, `{x}` and `{y}` are required; `{s}` (subdomain) and `{r}` (retina suffix) are optional | Esri dark canvas |
 | `KRAWL_MAP_TILE_ATTRIBUTION` | Credit line shown in the map corner | Esri / OSM |
 | `KRAWL_MAP_TILE_SUBDOMAINS` | Values substituted into `{s}` | `abcd` |
-| `KRAWL_MAP_API_KEY` | Appended to every tile request as `?key=` | _(empty)_ |
+| `KRAWL_MAP_API_KEY` | Appended to every tile request as a query parameter | _(empty)_ |
+| `KRAWL_MAP_API_KEY_PARAM` | Name of that query parameter | `api_key` |
 
 Note the axis order: Esri serves tiles as `{z}/{y}/{x}`, while most other
 providers use `{z}/{x}/{y}`. Copy the template exactly as the provider
@@ -278,6 +280,20 @@ map:
   api_key: "your-key-here"
 ```
 
+Use the **raster** endpoint above, not the vector one. CARTO's documentation
+leads with vector basemaps — a `style.json` handed to MapLibre GL. This map is
+Leaflet, and `tile_url` is a raster `{z}/{x}/{y}` template; a style URL in that
+field produces a blank basemap with no error in the console. The raster
+`basemaps.cartocdn.com` endpoints are still served, and the tiles are pushed
+through a desaturating filter anyway, so vector buys nothing here. The same
+applies to any other provider that documents itself style-JSON-first
+(MapTiler, Stadia): find their raster tile template.
+
+Providers disagree on what to call the query parameter — CARTO and Stadia want
+`api_key`, Thunderforest `apikey`, MapTiler `key` — so `api_key_param` sets it.
+It defaults to `api_key`, which is what CARTO expects, so the block above works
+as written.
+
 **OpenStreetMap** needs no key but is light-themed, so it fights the dashboard
 until you invert it. Add this to your own CSS after setting the URL:
 
@@ -298,6 +314,18 @@ other option tells a third-party CDN when you are looking at it.
 served in the page source. That is unavoidable for a client-side map — restrict
 the key to your dashboard's domain at the provider rather than trying to hide
 it.
+
+On Kubernetes the key still never touches the ConfigMap. Setting
+`config.map.api_key` creates a chart-managed Secret and injects it as
+`KRAWL_MAP_API_KEY`; to keep it out of your values file entirely, point
+`mapExistingSecret` at a Secret you manage (External Secrets Operator, Vault,
+sealed-secrets):
+
+```yaml
+mapExistingSecret:
+  name: krawl-map-tiles
+  key: map-api-key
+```
 
 **Attribution is a licence condition** for every provider above, not
 decoration. It is styled to be unobtrusive; do not remove it.

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.3.5
-appVersion: 2.3.5
+version: 2.3.6
+appVersion: 2.3.6
 keywords:
   - honeypot
   - security

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -109,6 +109,15 @@ Resolve the AI API key Secret name/key to reference.
 {{- end }}
 
 {{/*
+Resolve the map tile API key Secret name/key to reference.
+*/}}
+{{- define "krawl.map.secret" -}}
+{{- $name := .Values.mapExistingSecret.name | default (printf "%s-map" (include "krawl.fullname" .)) }}
+{{- $key := .Values.mapExistingSecret.key | default "map-api-key" }}
+{{- dict "name" $name "key" $key | toJson }}
+{{- end }}
+
+{{/*
 Resolve the canary token URL Secret name/key to reference.
 */}}
 {{- define "krawl.canary.secret" -}}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -87,7 +87,7 @@ data:
       tile_url: {{ .Values.config.map.tile_url | quote }}
       attribution: {{ .Values.config.map.attribution | quote }}
       subdomains: {{ .Values.config.map.subdomains | quote }}
-      api_key: {{ .Values.config.map.api_key | quote }}
+      api_key_param: {{ .Values.config.map.api_key_param | default "api_key" | quote }}
     tarpit:
       enabled: {{ .Values.config.tarpit.enabled }}
       delay_seconds: {{ .Values.config.tarpit.delay_seconds }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -88,6 +88,13 @@ spec:
               name: {{ (include "krawl.ai.secret" . | fromJson).name }}
               key: {{ (include "krawl.ai.secret" . | fromJson).key }}
         {{- end }}
+        {{- if or .Values.config.map.api_key .Values.mapExistingSecret.name }}
+        - name: KRAWL_MAP_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ (include "krawl.map.secret" . | fromJson).name }}
+              key: {{ (include "krawl.map.secret" . | fromJson).key }}
+        {{- end }}
         {{- $canary := include "krawl.canary.secret" . | fromJson }}
         {{- if $canary.name }}
         - name: KRAWL_CANARY_TOKEN_URL

--- a/helm/templates/secret-map.yaml
+++ b/helm/templates/secret-map.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.config.map.api_key (not .Values.mapExistingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "krawl.fullname" . }}-map
+  labels:
+    {{- include "krawl.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  map-api-key: {{ .Values.config.map.api_key | quote }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -113,6 +113,13 @@ aiExistingSecret:
   name: ""
   key: "ai-api-key"
 
+# Map tile API key from an externally-managed Secret instead of the
+# chart-managed one built from `config.map.api_key`. `name` empty =
+# chart-managed. Injected as KRAWL_MAP_API_KEY.
+mapExistingSecret:
+  name: ""
+  key: "map-api-key"
+
 # Canary token URL. Setting `canaryTokenUrl` creates a chart-managed Secret and
 # injects KRAWL_CANARY_TOKEN_URL from it, keeping the URL out of the ConfigMap.
 # Set `canaryExistingSecret.name` to read it from an external Secret instead.
@@ -246,11 +253,17 @@ config:
     purge_existing: false  # Also delete existing IPv6 rows at next startup (irreversible)
 
   map:
-    # CARTO watermarks unkeyed tiles; the default below is keyless. See
-    # config.yaml for alternative providers.
+    # Raster {z}/{x}/{y} template only -- not a vector style.json. CARTO
+    # watermarks unkeyed tiles; the default below is keyless. See
+    # docs/dashboard.md#map-tiles for alternative providers.
     tile_url: "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
     attribution: "&copy; Esri, HERE, Garmin, &copy; OpenStreetMap contributors"
     subdomains: "abcd"
+    # Query parameter the key rides on. CARTO and Stadia want api_key,
+    # Thunderforest apikey, MapTiler key.
+    api_key_param: "api_key"
+    # Never lands in the ConfigMap: it becomes a chart-managed Secret injected
+    # as KRAWL_MAP_API_KEY. Use mapExistingSecret to supply your own instead.
     api_key: ""   # served in the page source; restrict it by domain
 
   tarpit:

--- a/src/config.py
+++ b/src/config.py
@@ -120,6 +120,9 @@ class Config:
     map_tile_attribution: str = _DEFAULT_TILE_ATTRIBUTION
     map_tile_subdomains: str = "abcd"
     map_api_key: str = ""
+    # Query parameter the key is sent as. Providers disagree: CARTO and Stadia
+    # want `api_key`, Thunderforest `apikey`, MapTiler `key`.
+    map_api_key_param: str = "api_key"
 
     # Analyzer settings
     http_risky_methods_threshold: float = 0.1
@@ -347,6 +350,7 @@ class Config:
             ),
             map_tile_subdomains=map_cfg.get("subdomains", "abcd"),
             map_api_key=map_cfg.get("api_key", ""),
+            map_api_key_param=map_cfg.get("api_key_param") or "api_key",
             http_risky_methods_threshold=analyzer.get(
                 "http_risky_methods_threshold", 0.1
             ),

--- a/src/routes/dashboard.py
+++ b/src/routes/dashboard.py
@@ -38,13 +38,15 @@ def _map_tiles(config) -> dict:
     """Resolve the tile layer passed to Leaflet.
 
     The API key is appended as a query parameter because that is how CARTO and
-    most raster providers take it. It ends up in the page source, which is
+    most raster providers take it. They disagree on the parameter name, so it
+    comes from `map.api_key_param`. It ends up in the page source, which is
     unavoidable for a client-side map: the browser requests tiles itself. Lock
     the key to your dashboard domain at the provider.
     """
     url = config.map_tile_url
     if config.map_api_key:
-        url += ("&" if "?" in url else "?") + f"key={config.map_api_key}"
+        param = config.map_api_key_param or "api_key"
+        url += ("&" if "?" in url else "?") + f"{param}={config.map_api_key}"
     return {
         "url": url,
         "attribution": config.map_tile_attribution,


### PR DESCRIPTION
This pull request improves the flexibility and security of map tile API key handling, especially for third-party providers like CARTO, by allowing the query parameter name for the API key to be configured and by supporting external Kubernetes Secrets for key management. Documentation and configuration files have been updated to clarify these changes and to guide users on correct usage, especially regarding raster tile endpoints and provider-specific requirements.

**Map tile API key handling and configuration:**

* Added support for configuring the query parameter name used for the map tile API key (`api_key_param`), since different providers (CARTO, Stadia, Thunderforest, MapTiler) require different parameter names. This is now available in `config.yaml`, `helm/values.yaml`, and is handled in the backend (`src/config.py`, `src/routes/dashboard.py`). [[1]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034R141-R143) [[2]](diffhunk://#diff-f46af54b712d903a1cf3f90323c91eac14dd3357e17ebf07188affe9b2cb1fdeR251-R260) [[3]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R123-R125) [[4]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R353) [[5]](diffhunk://#diff-80d7a7c155f3a3ef5d6700956ae2592ec1cf4740e1282055c26d814f87efa863L41-R49)
* Updated documentation to clarify that only raster tile endpoints are supported (not vector style.json), and to explain the new `api_key_param` setting and its defaults for various providers. [[1]](diffhunk://#diff-f46af54b712d903a1cf3f90323c91eac14dd3357e17ebf07188affe9b2cb1fdeR283-R296) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L17-R17) [[3]](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L128-R129)

**Kubernetes/Helm improvements for API key management:**

* Added support for supplying the map tile API key from an externally-managed Kubernetes Secret (`mapExistingSecret`), in addition to the chart-managed Secret. The deployment and secret templates have been updated accordingly. [[1]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R116-R122) [[2]](diffhunk://#diff-ae9a5ae673f1b57663981c36058ed56ab31e6f7e9dfc34e321809888e2cb49bcR1-R11) [[3]](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435R91-R97) [[4]](diffhunk://#diff-f1a6324c375e55f92a8e4e1e5cc78ba3cc846c4869deb2d1659841257a325bceR111-R119)
* Updated the Helm chart version to 2.3.6 to reflect these changes.

**Documentation and configuration clarity:**

* Improved documentation in `docs/dashboard.md` and comments in configuration files to explain the rationale for these changes, provider-specific requirements, and how to securely manage API keys in Kubernetes. [[1]](diffhunk://#diff-f46af54b712d903a1cf3f90323c91eac14dd3357e17ebf07188affe9b2cb1fdeR318-R329) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L249-R266) [[3]](diffhunk://#diff-f46af54b712d903a1cf3f90323c91eac14dd3357e17ebf07188affe9b2cb1fdeR251-R260) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L379-R380)