### PR TITLE
Threat-intel enhancement, TLSH campaign clustering, referer tracking, captured file index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 
 # gosu lets the entrypoint drop privileges after fixing mount ownership
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends gosu postgresql-client && \
+# build-essential: py-tlsh compile its C++ extension from source at install time
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends gosu postgresql-client build-essential && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -m -u 1000 krawl && \
     mkdir -p /app/logs /app/data /app/exports && \

--- a/README.md
+++ b/README.md
@@ -420,6 +420,19 @@ Thresholds that decide how an IP gets classified.
 </details>
 
 <details>
+<summary><b>Threat-intel capture</b> (2 variables)</summary>
+
+Fuzzy-hash captured payloads (files and flagged request bodies) and group
+near-duplicate variants into campaign clusters. Requires `py-tlsh`.
+
+| Environment Variable | Description | Default |
+|----------------------|-------------|---------|
+| `KRAWL_TLSH_ENABLED` | Hash uploaded files and flagged request bodies with TLSH for near-duplicate clustering | `false` |
+| `KRAWL_TLSH_CLUSTER_THRESHOLD` | TLSH distance below which a payload joins an existing campaign (0 = identical bytes; variants of a webshell typically diff < 100) | `150` |
+
+</details>
+
+<details>
 <summary><b>Banlist and ignored IPs</b> (4 variables)</summary>
 
 Sharing banlists with other instances, and traffic to never track.

--- a/config.yaml
+++ b/config.yaml
@@ -99,6 +99,10 @@ analyzer:
   uneven_request_timing_time_window_seconds: 300
   user_agents_used_threshold: 2
   attack_urls_threshold: 1
+  # Compute TLSH fuzzy hashes for captured payloads/files (near-duplicate clustering).
+  tlsh_enabled: true
+  # Capture the inbound HTTP Referer header on access logs for bait-chain tracking.
+  referer_enabled: true
 
 crawl:
   infinite_pages_for_malicious: true
@@ -193,8 +197,8 @@ ai:
 
 banlist:
   export_path:  # Public banlist download path, e.g. "/public_banlist.txt". Unauthenticated, and supports the same ?categories= and ?fwtype= parameters as the main banlist API. Empty = disabled.
-  sources:
-    - "https://demo.krawlme.com/das_dashboard/api/export-ips?categories=attacker&fwtype=raw" # Upstream banlist URLs to fetch, e.g. ["https://krawl.example.com/public_banlist.txt"]. You can add an array of URLs here. Even external "".txt" banlists are supported.
+#  sources:
+#    - "https://demo.krawlme.com/das_dashboard/api/export-ips?categories=attacker&fwtype=raw" # Upstream banlist URLs to fetch, e.g. ["https://krawl.example.com/public_banlist.txt"]. You can add an array of URLs here. Even external "".txt" banlists are supported.
   refresh_interval: 3600  # Seconds between fetches
 
 deception:

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.3.6
-appVersion: 2.3.6
+version: 2.3.7
+appVersion: 2.3.7
 keywords:
   - honeypot
   - security

--- a/helm/README.md
+++ b/helm/README.md
@@ -404,6 +404,9 @@ A one-shot Kubernetes Job that copies data from an existing SQLite PVC into Post
 | `config.analyzer.uneven_request_timing_time_window_seconds` | Time window for request timing analysis | `300` |
 | `config.analyzer.user_agents_used_threshold` | User agents threshold | `2` |
 | `config.analyzer.attack_urls_threshold` | Attack URLs threshold | `1` |
+| `config.analyzer.tlsh_enabled` | TLSH-hash captured payloads/files for near-duplicate campaign clustering (`KRAWL_TLSH_ENABLED`) | `false` |
+| `config.analyzer.tlsh_cluster_threshold` | TLSH distance below which a payload joins an existing campaign (`KRAWL_TLSH_CLUSTER_THRESHOLD`) | `150` |
+| `config.analyzer.referer_enabled` | Capture the inbound HTTP Referer header for bait-chain tracking (`KRAWL_REFERER_ENABLED`) | `false` |
 
 ### Crawl Configuration
 

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -49,6 +49,9 @@ data:
       uneven_request_timing_time_window_seconds: {{ .Values.config.analyzer.uneven_request_timing_time_window_seconds }}
       user_agents_used_threshold: {{ .Values.config.analyzer.user_agents_used_threshold }}
       attack_urls_threshold: {{ .Values.config.analyzer.attack_urls_threshold }}
+      tlsh_enabled: {{ .Values.config.analyzer.tlsh_enabled }}
+      tlsh_cluster_threshold: {{ .Values.config.analyzer.tlsh_cluster_threshold }}
+      referer_enabled: {{ .Values.config.analyzer.referer_enabled }}
     crawl:
       infinite_pages_for_malicious: {{ .Values.config.crawl.infinite_pages_for_malicious }}
       max_pages_limit: {{ .Values.config.crawl.max_pages_limit }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -196,6 +196,10 @@ config:
     uneven_request_timing_time_window_seconds: 300
     user_agents_used_threshold: 2
     attack_urls_threshold: 1
+    # Threat-intel capture
+    tlsh_enabled: false  # TLSH-hash captured payloads/files (near-duplicate campaign clustering)
+    tlsh_cluster_threshold: 150  # TLSH distance below which a payload joins an existing campaign
+    referer_enabled: false  # Capture the inbound HTTP Referer header (bait-chain tracking)
   crawl:
     infinite_pages_for_malicious: true
     max_pages_limit: 250

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ pydantic>=2.0.0
 psycopg2-binary>=2.9.0
 redis>=5.0.0
 prometheus-client>=0.25.0
+
+# Fuzzy hashing (near-duplicate payload clustering)
+py-tlsh>=5.0.0

--- a/scripts/backfill_clusters.py
+++ b/scripts/backfill_clusters.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Backfill campaign clustering for historical payloads.
+
+Rows already carrying a TLSH digest but no cluster_id (captured_payloads +
+attack_detections) are run through the same incremental clustering as live
+captures, in chronological order (first_seen ascending) so cluster formation
+reflects real timeline order.
+
+Historical rows that predate TLSH hashing (tlsh_hash IS NULL) stay unclustered:
+raw file content / request bodies are not retained, so their hashes cannot be
+recomputed. Hashing happens at ingest; only the metadata (including the digest)
+is persisted.
+
+Usage:
+    .venv/bin/python scripts/backfill_clusters.py            # data/krawl.db
+    KRAWL_STANDALONE_DB=/path/to.db .venv/bin/python scripts/backfill_clusters.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import database as dbpkg
+from config import get_config
+from models import AccessLog, AttackDetection, CapturedPayload
+
+
+def main() -> None:
+    cfg = get_config()
+    threshold = cfg.tlsh_cluster_threshold
+    db_path = os.environ.get("KRAWL_STANDALONE_DB", "data/krawl.db")
+    db_path = os.path.abspath(db_path)
+
+    dbpkg.DatabaseManager._instance = None
+    db = dbpkg.DatabaseManager()
+    db.initialize(database_path=db_path, mode="standalone")
+    session = db.session
+
+    # Files: hashed but unclustered, oldest first.
+    files = (
+        session.query(CapturedPayload)
+        .filter(
+            CapturedPayload.tlsh_hash.isnot(None),
+            CapturedPayload.cluster_id.is_(None),
+        )
+        .order_by(CapturedPayload.timestamp.asc())
+        .all()
+    )
+    # Attack bodies: hashed but unclustered, ordered by the access-log timestamp.
+    attack_rows = (
+        session.query(
+            AttackDetection.id.label("id"),
+            AttackDetection.tlsh_hash.label("tlsh_hash"),
+            AccessLog.timestamp.label("stamp"),
+        )
+        .join(AccessLog, AttackDetection.access_log_id == AccessLog.id)
+        .filter(
+            AttackDetection.tlsh_hash.isnot(None),
+            AttackDetection.cluster_id.is_(None),
+        )
+        .order_by(AccessLog.timestamp.asc())
+        .all()
+    )
+
+    total = len(files) + len(attack_rows)
+    assigned = 0
+    session.close()
+
+    for row in files:
+        cid = db.payloads.assign_cluster(row.tlsh_hash, row.timestamp, threshold=threshold)
+        if cid:
+            session = db.session
+            session.query(CapturedPayload).filter_by(id=row.id).update(
+                {"cluster_id": cid}
+            )
+            session.commit()
+            db.close_session()
+            assigned += 1
+
+    for row in attack_rows:
+        cid = db.payloads.assign_cluster(row.tlsh_hash, row.stamp, threshold=threshold)
+        if cid:
+            session = db.session
+            session.query(AttackDetection).filter_by(id=row.id).update(
+                {"cluster_id": cid}
+            )
+            session.commit()
+            db.close_session()
+            assigned += 1
+
+    print(f"backfill done: {assigned}/{total} rows clustered (threshold={threshold})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -136,6 +136,16 @@ class Config:
     tarpit_enabled: bool = False
     tarpit_delay_seconds: int = 5
 
+    # Threat-intel capture settings
+    # TLSH fuzzy-hash captured payloads/files for near-duplicate variant clustering.
+    tlsh_enabled: bool = False
+    # TLSH distance below which a payload joins an existing cluster (< = same
+    # campaign family). 0 = byte-identical; 150 is the conservative default
+    # (variants of a webshell typically diff < 100).
+    tlsh_cluster_threshold: int = 150
+    # Capture the inbound HTTP Referer header on access logs (bait-chain tracking).
+    referer_enabled: bool = False
+
     log_level: str = "INFO"
 
     # AI generation settings
@@ -363,6 +373,9 @@ class Config:
             ),
             user_agents_used_threshold=analyzer.get("user_agents_used_threshold", 2),
             attack_urls_threshold=analyzer.get("attack_urls_threshold", 1),
+            tlsh_enabled=analyzer.get("tlsh_enabled", False),
+            tlsh_cluster_threshold=analyzer.get("tlsh_cluster_threshold", 150),
+            referer_enabled=analyzer.get("referer_enabled", False),
             infinite_pages_for_malicious=crawl.get(
                 "infinite_pages_for_malicious", True
             ),

--- a/src/database/analytics.py
+++ b/src/database/analytics.py
@@ -473,11 +473,24 @@ class AnalyticsRepo:
                     "user_agent": log.user_agent,
                     "timestamp": log.timestamp.isoformat() if log.timestamp else None,
                     "attack_types": [d.attack_type for d in log.attack_detections],
+                    "tlsh_hash": next(
+                        (d.tlsh_hash for d in log.attack_detections if d.tlsh_hash),
+                        None,
+                    ),
+                    "cluster_id": next(
+                        (d.cluster_id for d in log.attack_detections if d.cluster_id),
+                        None,
+                    ),
                     "request_size": len(log.raw_request) if log.raw_request else 0,
                     "raw_request": log.raw_request,  # Keep for backward compatibility
                 }
                 for log in logs
             ]
+            hashes = self._db.payloads.rep_hash_map(
+                {r["cluster_id"] for r in paginated if r["cluster_id"]}
+            )
+            for row in paginated:
+                row["cluster_hash"] = (hashes.get(row["cluster_id"]) or "")[:12]
 
             return {
                 "attacks": paginated,

--- a/src/database/core.py
+++ b/src/database/core.py
@@ -20,6 +20,7 @@ from database.analytics import AnalyticsRepo
 from database.credentials import CredentialRepo
 from database.generated_pages import GeneratedPageRepo
 from database.ip_stats import IpStatsRepo
+from database.payloads import PayloadRepo
 from ip_utils import defer_persist
 from logger import get_app_logger
 from models import (
@@ -154,6 +155,7 @@ class DatabaseManager:
             cls._instance.analytics = AnalyticsRepo(cls._instance)
             cls._instance.ip_stats = IpStatsRepo(cls._instance)
             cls._instance.access_logs = AccessLogRepo(cls._instance)
+            cls._instance.payloads = PayloadRepo(cls._instance)
         return cls._instance
 
     def initialize(
@@ -287,7 +289,11 @@ class DatabaseManager:
         is_honeypot_trigger: bool = False,
         attack_types: list[str] | None = None,
         matched_patterns: dict[str, str] | None = None,
+        tlsh_hashes: dict[str, str] | None = None,
+        tlsh_clusters: dict[str, str] | None = None,
         raw_request: str | None = None,
+        referer: str | None = None,
+        file_payloads: list[dict] | None = None,
         increment_page_visit: bool = False,
         max_pages_limit: int = 0,
     ) -> int:
@@ -303,7 +309,12 @@ class DatabaseManager:
             is_honeypot_trigger: Whether a honeypot path was accessed
             attack_types: List of detected attack types
             matched_patterns: Dict mapping attack_type to matched pattern
+            tlsh_hashes: Dict mapping attack_type to TLSH digest of the payload
+            tlsh_clusters: Dict mapping attack_type to campaign cluster_id
             raw_request: Full raw HTTP request for forensic analysis
+            referer: Inbound HTTP Referer header (bait-chain tracking)
+            file_payloads: Uploaded-file dicts {filename, content_type, size,
+                content(bytes)} to persist as captured_payloads rows
             increment_page_visit: Also bump the page visit counter in the same tx
             max_pages_limit: Ban threshold (used with increment_page_visit)
 
@@ -331,7 +342,11 @@ class DatabaseManager:
                         is_honeypot_trigger=is_honeypot_trigger,
                         attack_types=attack_types,
                         matched_patterns=matched_patterns,
+                        tlsh_hashes=tlsh_hashes,
+                        tlsh_clusters=tlsh_clusters,
                         raw_request=raw_request,
+                        referer=referer,
+                        file_payloads=file_payloads,
                     )
             else:
                 if not persist_suspicious_only or is_suspicious:
@@ -344,12 +359,15 @@ class DatabaseManager:
                         is_honeypot_trigger=is_honeypot_trigger,
                         timestamp=datetime.now(),
                         raw_request=raw_request,
+                        referer=sanitize_path(referer) if referer else None,
                     )
                     session.add(access_log)
                     session.flush()
 
                     if attack_types:
                         matched_patterns = matched_patterns or {}
+                        tlsh_hashes = tlsh_hashes or {}
+                        tlsh_clusters = tlsh_clusters or {}
                         for attack_type in attack_types:
                             detection = AttackDetection(
                                 access_log_id=access_log.id,
@@ -357,8 +375,36 @@ class DatabaseManager:
                                 matched_pattern=sanitize_attack_pattern(
                                     matched_patterns.get(attack_type, "")
                                 ),
+                                tlsh_hash=tlsh_hashes.get(attack_type),
+                                cluster_id=tlsh_clusters.get(attack_type),
                             )
                             session.add(detection)
+
+                    # Persist captured file payloads (WebShell/uploads) linked to this log.
+                    if file_payloads:
+                        from models import CapturedPayload
+
+                        for fp in file_payloads:
+                            session.add(
+                                CapturedPayload(
+                                    access_log_id=access_log.id,
+                                    ip=sanitize_ip(ip),
+                                    filename=(
+                                        fp.get("filename")[:255]
+                                        if fp.get("filename")
+                                        else None
+                                    ),
+                                    content_type=(
+                                        fp.get("content_type")[:128]
+                                        if fp.get("content_type")
+                                        else None
+                                    ),
+                                    size=fp.get("size", 0),
+                                    tlsh_hash=fp.get("tlsh_hash"),
+                                    cluster_id=fp.get("cluster_id"),
+                                    sha256=fp.get("sha256"),
+                                )
+                            )
 
             # Always update IP stats counters (+ optional page visit increment)
             page_visit_count, was_new_ip, was_first_honeypot = self._update_ip_stats(
@@ -436,15 +482,19 @@ class DatabaseManager:
         """Insert one batch of buffered entries: two statements, not two per row."""
         session = self.session
         try:
-            logs, attacks_per_entry = [], []
+            logs, attacks_per_entry, payloads_per_entry = [], [], []
             for entry in entries:
                 ts = entry.pop("_buffered_at", datetime.now())
                 attacks_per_entry.append(
                     (
                         entry.pop("attack_types", None),
                         entry.pop("matched_patterns", None) or {},
+                        entry.pop("tlsh_hashes", None) or {},
+                        entry.pop("tlsh_clusters", None) or {},
                     )
                 )
+                file_payloads = entry.pop("file_payloads", None)
+                payloads_per_entry.append(file_payloads)
                 logs.append(
                     {
                         "ip": sanitize_ip(entry["ip"]),
@@ -455,6 +505,9 @@ class DatabaseManager:
                         "is_honeypot_trigger": entry.get("is_honeypot_trigger", False),
                         "timestamp": ts,
                         "raw_request": entry.get("raw_request"),
+                        "referer": sanitize_path(entry.get("referer"))
+                        if entry.get("referer")
+                        else None,
                     }
                 )
 
@@ -472,8 +525,10 @@ class DatabaseManager:
                     "matched_pattern": sanitize_attack_pattern(
                         patterns.get(attack_type, "")
                     ),
+                    "tlsh_hash": tlshs.get(attack_type),
+                    "cluster_id": clusters.get(attack_type),
                 }
-                for log_id, (types, patterns) in zip(
+                for log_id, (types, patterns, tlshs, clusters) in zip(
                     log_ids, attacks_per_entry, strict=True
                 )
                 if types
@@ -481,6 +536,33 @@ class DatabaseManager:
             ]
             if detections:
                 session.execute(insert(AttackDetection), detections)
+
+            # Insert captured file payloads, linked to their access logs.
+            from models import CapturedPayload
+
+            captured_rows = [
+                {
+                    "access_log_id": log_id,
+                    "ip": sanitize_ip(entry["ip"]),
+                    "filename": (
+                        fp.get("filename")[:255] if fp.get("filename") else None
+                    ),
+                    "content_type": (
+                        fp.get("content_type")[:128] if fp.get("content_type") else None
+                    ),
+                    "size": fp.get("size", 0),
+                    "tlsh_hash": fp.get("tlsh_hash"),
+                    "cluster_id": fp.get("cluster_id"),
+                    "sha256": fp.get("sha256"),
+                }
+                for log_id, (entry, file_payloads) in zip(
+                    log_ids, zip(entries, payloads_per_entry, strict=True), strict=True
+                )
+                if file_payloads
+                for fp in file_payloads
+            ]
+            if captured_rows:
+                session.execute(insert(CapturedPayload), captured_rows)
 
             session.commit()
             return len(logs)

--- a/src/database/core.py
+++ b/src/database/core.py
@@ -505,9 +505,11 @@ class DatabaseManager:
                         "is_honeypot_trigger": entry.get("is_honeypot_trigger", False),
                         "timestamp": ts,
                         "raw_request": entry.get("raw_request"),
-                        "referer": sanitize_path(entry.get("referer"))
-                        if entry.get("referer")
-                        else None,
+                        "referer": (
+                            sanitize_path(entry.get("referer"))
+                            if entry.get("referer")
+                            else None
+                        ),
                     }
                 )
 

--- a/src/database/credentials.py
+++ b/src/database/credentials.py
@@ -69,6 +69,7 @@ class CredentialRepo:
         page_size: int = 5,
         sort_by: str = "timestamp",
         sort_order: str = "desc",
+        ip_filter: str | None = None,
     ) -> dict[str, Any]:
         """
         Retrieve paginated list of credential attempts.
@@ -78,6 +79,7 @@ class CredentialRepo:
             page_size: Number of results per page
             sort_by: Field to sort by (timestamp, ip, username)
             sort_order: Sort order (asc or desc)
+            ip_filter: Optional IP to scope results to (IP Insight tab)
 
         Returns:
             Dictionary with credentials list and pagination info
@@ -93,12 +95,14 @@ class CredentialRepo:
                 sort_order.lower() if sort_order.lower() in {"asc", "desc"} else "desc"
             )
 
-            total_credentials = (
-                session.query(func.count(CredentialAttempt.id)).scalar() or 0
-            )
-
-            # Build query with sorting
+            count_query = session.query(func.count(CredentialAttempt.id))
             query = session.query(CredentialAttempt)
+            if ip_filter:
+                sanitized = sanitize_ip(ip_filter)
+                count_query = count_query.filter(CredentialAttempt.ip == sanitized)
+                query = query.filter(CredentialAttempt.ip == sanitized)
+
+            total_credentials = count_query.scalar() or 0
 
             if sort_by == "timestamp":
                 query = query.order_by(

--- a/src/database/payloads.py
+++ b/src/database/payloads.py
@@ -29,6 +29,7 @@ def _request_body(raw_request: str | None) -> str | None:
     body = raw_request.split("\r\n\r\n", 1)[1] if "\r\n\r\n" in raw_request else ""
     return unquote(body) if body else None
 
+
 applogger = get_app_logger()
 
 
@@ -74,9 +75,7 @@ class PayloadRepo:
 
     # ---- Reads ----
 
-    def get_by_ip(
-        self, ip: str, page: int = 1, page_size: int = 10
-    ) -> dict[str, Any]:
+    def get_by_ip(self, ip: str, page: int = 1, page_size: int = 10) -> dict[str, Any]:
         """Paginated payloads uploaded by a single IP (IP Insight tab)."""
         session = self._db.session
         try:
@@ -109,9 +108,11 @@ class PayloadRepo:
         try:
             if not cluster_ids:
                 return {}
-            rows = session.query(
-                PayloadCluster.id, PayloadCluster.representative_hash
-            ).filter(PayloadCluster.id.in_(cluster_ids)).all()
+            rows = (
+                session.query(PayloadCluster.id, PayloadCluster.representative_hash)
+                .filter(PayloadCluster.id.in_(cluster_ids))
+                .all()
+            )
             return dict(rows)
         finally:
             self._db.close_session()
@@ -139,9 +140,7 @@ class PayloadRepo:
             base = (
                 session.query(
                     CapturedPayload.filename,
-                    func.count(func.distinct(CapturedPayload.ip)).label(
-                        "distinct_ips"
-                    ),
+                    func.count(func.distinct(CapturedPayload.ip)).label("distinct_ips"),
                     func.count(CapturedPayload.id).label("total"),
                     func.min(CapturedPayload.timestamp).label("first_seen"),
                     func.max(CapturedPayload.timestamp).label("last_seen"),
@@ -160,24 +159,25 @@ class PayloadRepo:
                 "distinct_ips": func.count(func.distinct(CapturedPayload.ip)),
             }
             order = valid_sort.get(sort_by, valid_sort["last_seen"])
-            rows = base.order_by(order.desc()).offset((page - 1) * page_size).limit(
-                page_size
-            ).all()
+            rows = (
+                base.order_by(order.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
 
             # access_log_id of the most recent capture per filename, so clicking a
             # filename in the Threats tab can open that payload directly.
-            latest = (
-                session.query(
-                    CapturedPayload.filename.label("fname"),
-                    CapturedPayload.access_log_id.label("log_id"),
-                    func.row_number()
-                    .over(
-                        partition_by=CapturedPayload.filename,
-                        order_by=CapturedPayload.id.desc(),
-                    )
-                    .label("rn"),
-                ).subquery()
-            )
+            latest = session.query(
+                CapturedPayload.filename.label("fname"),
+                CapturedPayload.access_log_id.label("log_id"),
+                func.row_number()
+                .over(
+                    partition_by=CapturedPayload.filename,
+                    order_by=CapturedPayload.id.desc(),
+                )
+                .label("rn"),
+            ).subquery()
             latest_by_filename = {
                 r.fname: r.log_id
                 for r in session.query(latest).filter(latest.c.rn == 1).all()
@@ -463,11 +463,11 @@ class PayloadRepo:
                 types_q = types_q.join(
                     AccessLog, AttackDetection.access_log_id == AccessLog.id
                 )
-            for cid, atype, cnt in types_q.filter(
-                AttackDetection.cluster_id.isnot(None), *attack_win
-            ).group_by(
-                AttackDetection.cluster_id, AttackDetection.attack_type
-            ).all():
+            for cid, atype, cnt in (
+                types_q.filter(AttackDetection.cluster_id.isnot(None), *attack_win)
+                .group_by(AttackDetection.cluster_id, AttackDetection.attack_type)
+                .all()
+            ):
                 c = clusters.get(cid)
                 if c is not None:
                     c["types"][atype] = cnt
@@ -494,7 +494,8 @@ class PayloadRepo:
                     "path": c["path"],
                     "top_path": c["top_path"] or c["path"],
                     "attack_types": [
-                        t for t, _ in sorted(
+                        t
+                        for t, _ in sorted(
                             c["types"].items(), key=lambda kv: (-kv[1], kv[0])
                         )
                     ],

--- a/src/database/payloads.py
+++ b/src/database/payloads.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+
+"""
+Queries and inserts over captured_payloads (files/uploaded payloads) plus
+referer-history reads over access_logs for the IP Insight and Threat tabs.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from urllib.parse import unquote
+
+from sqlalchemy import func, select
+
+from dashboard_cache import pagination
+from logger import get_app_logger
+from models import AccessLog, AttackDetection, CapturedPayload, PayloadCluster
+from sanitizer import sanitize_ip
+from tlsh_utils import SIMILARITY_THRESHOLD, tlsh_diff
+
+if TYPE_CHECKING:
+    from database.core import DatabaseManager
+
+
+def _request_body(raw_request: str | None) -> str | None:
+    """Decoded request body (headers stripped, URL-unescaped) for inline
+    display in the campaign dive, or None when absent."""
+    if not raw_request:
+        return None
+    body = raw_request.split("\r\n\r\n", 1)[1] if "\r\n\r\n" in raw_request else ""
+    return unquote(body) if body else None
+
+applogger = get_app_logger()
+
+
+class PayloadRepo:
+    """Reads and writes captured file payloads, plus referer-history reads."""
+
+    def __init__(self, db: "DatabaseManager") -> None:
+        self._db = db
+
+    # ---- Writes ----
+
+    def add_payload(
+        self,
+        access_log_id: int,
+        ip: str,
+        filename: str | None,
+        content_type: str | None,
+        size: int,
+        tlsh_hash: str | None,
+        sha256: str | None,
+    ) -> int | None:
+        """Persist one captured file/upload. Returns the new row id or None."""
+        session = self._db.session
+        try:
+            payload = CapturedPayload(
+                access_log_id=access_log_id,
+                ip=sanitize_ip(ip),
+                filename=filename[:255] if filename else None,
+                content_type=content_type[:128] if content_type else None,
+                size=size,
+                tlsh_hash=tlsh_hash,
+                sha256=sha256,
+            )
+            session.add(payload)
+            session.commit()
+            return payload.id
+        except Exception as e:
+            session.rollback()
+            applogger.error(f"Failed to persist captured payload: {e}")
+            return None
+        finally:
+            self._db.close_session()
+
+    # ---- Reads ----
+
+    def get_by_ip(
+        self, ip: str, page: int = 1, page_size: int = 10
+    ) -> dict[str, Any]:
+        """Paginated payloads uploaded by a single IP (IP Insight tab)."""
+        session = self._db.session
+        try:
+            q = session.query(CapturedPayload).filter(
+                CapturedPayload.ip == sanitize_ip(ip)
+            )
+            total = q.count()
+            rows = (
+                q.order_by(CapturedPayload.timestamp.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            payloads = [self._serialize(p) for p in rows]
+            hashes = self.rep_hash_map(
+                {p["cluster_id"] for p in payloads if p["cluster_id"]}
+            )
+            for p in payloads:
+                p["cluster_hash"] = (hashes.get(p["cluster_id"]) or "")[:12]
+            return {
+                "payloads": payloads,
+                "pagination": pagination(page, page_size, total),
+            }
+        finally:
+            self._db.close_session()
+
+    def rep_hash_map(self, cluster_ids: set[str]) -> dict[str, str]:
+        """Map campaign cluster ids to their representative hash."""
+        session = self._db.session
+        try:
+            if not cluster_ids:
+                return {}
+            rows = session.query(
+                PayloadCluster.id, PayloadCluster.representative_hash
+            ).filter(PayloadCluster.id.in_(cluster_ids)).all()
+            return dict(rows)
+        finally:
+            self._db.close_session()
+
+    def get_global_index(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        filename: str | None = None,
+        ip: str | None = None,
+        sort_by: str = "last_seen",
+    ) -> dict[str, Any]:
+        """Global filename index across all IPs (Threat tab).
+
+        Groups by filename, counting distinct source IPs and first/last seen,
+        so recurring file names (WebShell/script uploads) surface as campaigns.
+        """
+        session = self._db.session
+        try:
+            filename_q = CapturedPayload.filename.isnot(None)
+            if filename:
+                filename_q = CapturedPayload.filename.ilike(f"%{filename}%")
+            ip_q = CapturedPayload.ip == sanitize_ip(ip) if ip else None
+
+            base = (
+                session.query(
+                    CapturedPayload.filename,
+                    func.count(func.distinct(CapturedPayload.ip)).label(
+                        "distinct_ips"
+                    ),
+                    func.count(CapturedPayload.id).label("total"),
+                    func.min(CapturedPayload.timestamp).label("first_seen"),
+                    func.max(CapturedPayload.timestamp).label("last_seen"),
+                )
+                .filter(filename_q)
+                .group_by(CapturedPayload.filename)
+            )
+            if ip_q is not None:
+                base = base.filter(ip_q)
+
+            total_rows = base.count()
+            valid_sort = {
+                "last_seen": func.max(CapturedPayload.timestamp),
+                "first_seen": func.min(CapturedPayload.timestamp),
+                "filename": CapturedPayload.filename,
+                "distinct_ips": func.count(func.distinct(CapturedPayload.ip)),
+            }
+            order = valid_sort.get(sort_by, valid_sort["last_seen"])
+            rows = base.order_by(order.desc()).offset((page - 1) * page_size).limit(
+                page_size
+            ).all()
+
+            # access_log_id of the most recent capture per filename, so clicking a
+            # filename in the Threats tab can open that payload directly.
+            latest = (
+                session.query(
+                    CapturedPayload.filename.label("fname"),
+                    CapturedPayload.access_log_id.label("log_id"),
+                    func.row_number()
+                    .over(
+                        partition_by=CapturedPayload.filename,
+                        order_by=CapturedPayload.id.desc(),
+                    )
+                    .label("rn"),
+                ).subquery()
+            )
+            latest_by_filename = {
+                r.fname: r.log_id
+                for r in session.query(latest).filter(latest.c.rn == 1).all()
+            }
+
+            return {
+                "index": [
+                    {
+                        "filename": r.filename or "(untitled)",
+                        "log_id": latest_by_filename.get(r.filename),
+                        "distinct_ips": r.distinct_ips,
+                        "total": r.total,
+                        "first_seen": r.first_seen,
+                        "last_seen": r.last_seen,
+                    }
+                    for r in rows
+                ],
+                "pagination": pagination(page, page_size, total_rows),
+            }
+        finally:
+            self._db.close_session()
+
+    def get_similar_events(
+        self,
+        base_hash: str,
+        threshold: int = SIMILARITY_THRESHOLD,
+        limit: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Events whose TLSH digest is within `threshold` of base_hash — attack
+        request bodies (SQLi/XSS/...) and uploaded files across all IPs.
+
+        A digest of 0 from another IP is an exact copy (the campaign signal) and
+        is deliberately kept.
+        ponytail: O(N) in-Python diff over every hashed event; fine for the current
+        table sizes, prefilter by hash prefix in SQL if this grows.
+        """
+        session = self._db.session
+        try:
+            attack_rows = (
+                session.query(
+                    AttackDetection.tlsh_hash,
+                    AttackDetection.attack_type,
+                    AttackDetection.matched_pattern,
+                    AccessLog.id.label("access_log_id"),
+                    AccessLog.ip,
+                    AccessLog.path,
+                    AccessLog.timestamp,
+                )
+                .join(AccessLog, AttackDetection.access_log_id == AccessLog.id)
+                .filter(AttackDetection.tlsh_hash.isnot(None))
+                .all()
+            )
+            file_rows = (
+                session.query(CapturedPayload)
+                .filter(CapturedPayload.tlsh_hash.isnot(None))
+                .all()
+            )
+
+            similar: list[dict[str, Any]] = []
+            groups: dict[int, dict[str, Any]] = {}
+            for h, atype, pattern, log_id, ip, path, ts in attack_rows:
+                d = tlsh_diff(base_hash, h)
+                if d is None or d > threshold:
+                    continue
+                g = groups.get(log_id)
+                if g is None:
+                    g = groups[log_id] = {
+                        "kind": "attack",
+                        "diff": d,
+                        "attack_types": [],
+                        "matched_pattern": [],
+                        "filename": None,
+                        "ip": ip,
+                        "path": path,
+                        "access_log_id": log_id,
+                        "timestamp": ts,
+                        "content_type": None,
+                        "size": None,
+                    }
+                if d < g["diff"]:
+                    g["diff"] = d
+                g["attack_types"].append(atype)
+                if pattern and pattern not in g["matched_pattern"]:
+                    g["matched_pattern"].append(pattern)
+            for g in groups.values():
+                g["attack_type"] = ", ".join(g["attack_types"])
+                g["matched_pattern"] = ", ".join(g["matched_pattern"]) or None
+            similar += groups.values()
+            for p in file_rows:
+                d = tlsh_diff(base_hash, p.tlsh_hash)
+                if d is not None and d <= threshold:
+                    similar.append(
+                        {
+                            "kind": "file",
+                            "diff": d,
+                            "attack_type": "file",
+                            "matched_pattern": None,
+                            "filename": p.filename,
+                            "ip": p.ip,
+                            "path": None,
+                            "access_log_id": p.access_log_id,
+                            "timestamp": p.timestamp,
+                            "content_type": p.content_type,
+                            "size": p.size,
+                        }
+                    )
+            similar.sort(key=lambda r: r["diff"])
+            return similar[:limit]
+        finally:
+            self._db.close_session()
+
+    def assign_cluster(
+        self, digest: str | None, timestamp, threshold: int = SIMILARITY_THRESHOLD
+    ) -> str | None:
+        """Campaign assignment for one TLSH digest (incremental, O(#clusters)).
+
+        Pulls one representative hash per existing cluster, compares with
+        tlsh.diff, and either joins the nearest cluster under `threshold`
+        (bumping capture_count / last_seen) or starts a new cluster with
+        `digest` as its representative. Returns the cluster id, or None for an
+        unclusterable digest (TNULL / already assigned).
+        ponytail: concurrent writers (scalable mode) could double-create a
+        cluster for the same digest; a startup merge pass would tidy that if
+        it ever shows up.
+        """
+        if not digest:
+            return None
+        session = self._db.session
+        try:
+            reps = session.execute(
+                select(PayloadCluster.id, PayloadCluster.representative_hash)
+            ).all()
+            match_id, best = None, None
+            for cid, rep in reps:
+                d = tlsh_diff(digest, rep)
+                if d is not None and d <= threshold and (best is None or d < best):
+                    best, match_id = d, cid
+            if match_id:
+                session.execute(
+                    PayloadCluster.__table__.update()
+                    .where(PayloadCluster.id == match_id)
+                    .values(
+                        last_seen=timestamp,
+                        capture_count=PayloadCluster.capture_count + 1,
+                    )
+                )
+                session.commit()
+                return match_id
+            cluster = PayloadCluster(
+                representative_hash=digest,
+                first_seen=timestamp,
+                last_seen=timestamp,
+                capture_count=1,
+            )
+            session.add(cluster)
+            session.commit()
+            return cluster.id
+        finally:
+            self._db.close_session()
+
+    def get_campaign_clusters(
+        self, limit: int = 30, start: Any = None, end: Any = None
+    ) -> list[dict[str, Any]]:
+        """Campaign view, one row per payload_clusters entry. Captures/first-last
+        come from the cluster row itself (maintained incrementally at ingest);
+        distinct IPs and a sample member are pulled live from both member tables.
+
+        With ``start``/``end`` (naive datetimes), only campaigns whose activity
+        window overlaps the range are returned — used by the Threats tab
+        Global/1D/7D/30D filter and the day navigator.
+        """
+        session = self._db.session
+        try:
+            cluster_q = session.query(PayloadCluster)
+            if start is not None and end is not None:
+                cluster_q = cluster_q.filter(
+                    PayloadCluster.last_seen >= start,
+                    PayloadCluster.first_seen < end,
+                )
+            clusters = {
+                row.id: {
+                    "id": row.id,
+                    "rep_hash": row.representative_hash,
+                    "first_seen": row.first_seen,
+                    "last_seen": row.last_seen,
+                    "events": row.capture_count,
+                    "ips": set(),
+                    "sources": set(),
+                    "sample": None,
+                    "path": None,
+                    "types": {},
+                    "top_path": None,
+                    "top_path_cnt": 0,
+                }
+                for row in cluster_q.all()
+            }
+
+            # Window predicates: when start/end are set, the detail aggregates
+            # below scope to members whose own timestamp falls in the range
+            # (bucket via the timestamp index, not a scan of clustered history).
+            attack_win = (
+                [AccessLog.timestamp >= start, AccessLog.timestamp < end]
+                if start is not None and end is not None
+                else []
+            )
+            files_win = (
+                [CapturedPayload.timestamp >= start, CapturedPayload.timestamp < end]
+                if start is not None and end is not None
+                else []
+            )
+
+            for cid, fname in (
+                session.query(CapturedPayload.cluster_id, CapturedPayload.filename)
+                .filter(CapturedPayload.cluster_id.isnot(None), *files_win)
+                .all()
+            ):
+                c = clusters.get(cid)
+                if c is not None:
+                    c["sources"].add("files")
+                    if not c["sample"]:
+                        c["sample"] = fname
+                    if not c["path"]:
+                        c["path"] = fname
+
+            pattern_q = session.query(
+                AttackDetection.cluster_id, AttackDetection.matched_pattern
+            )
+            if attack_win:
+                pattern_q = pattern_q.join(
+                    AccessLog, AttackDetection.access_log_id == AccessLog.id
+                )
+            for cid, pattern in pattern_q.filter(
+                AttackDetection.cluster_id.isnot(None),
+                AttackDetection.matched_pattern.isnot(None),
+                *attack_win,
+            ).all():
+                c = clusters.get(cid)
+                if c is not None:
+                    c["sources"].add("attacks")
+                    if not c["sample"]:
+                        c["sample"] = pattern
+
+            # Representative path per cluster (fallback for file-only clusters
+            # is the filename, set above); first-seen order is irrelevant here
+            # since the per-cluster aggregates already scope to the window.
+            for cid, path in (
+                session.query(AttackDetection.cluster_id, AccessLog.path)
+                .join(AccessLog, AttackDetection.access_log_id == AccessLog.id)
+                .filter(AttackDetection.cluster_id.isnot(None), *attack_win)
+                .all()
+            ):
+                c = clusters.get(cid)
+                if c is not None and not c["path"]:
+                    c["path"] = path
+
+            # distinct IPs per cluster, from both member tables
+            for cid, ip in (
+                session.query(CapturedPayload.cluster_id, CapturedPayload.ip)
+                .filter(CapturedPayload.cluster_id.isnot(None), *files_win)
+                .distinct()
+                .all()
+            ):
+                if cid in clusters:
+                    clusters[cid]["ips"].add(ip)
+            for cid, ip in (
+                session.query(AttackDetection.cluster_id, AccessLog.ip)
+                .join(AccessLog, AttackDetection.access_log_id == AccessLog.id)
+                .filter(AttackDetection.cluster_id.isnot(None), *attack_win)
+                .distinct()
+                .all()
+            ):
+                if cid in clusters:
+                    clusters[cid]["ips"].add(ip)
+
+            # Signature mix: distinct attack types with counts, plus the most
+            # frequent target path (a campaign can span several paths).
+            types_q = session.query(
+                AttackDetection.cluster_id,
+                AttackDetection.attack_type,
+                func.count(),
+            )
+            if attack_win:
+                types_q = types_q.join(
+                    AccessLog, AttackDetection.access_log_id == AccessLog.id
+                )
+            for cid, atype, cnt in types_q.filter(
+                AttackDetection.cluster_id.isnot(None), *attack_win
+            ).group_by(
+                AttackDetection.cluster_id, AttackDetection.attack_type
+            ).all():
+                c = clusters.get(cid)
+                if c is not None:
+                    c["types"][atype] = cnt
+            for cid, path, cnt in (
+                session.query(
+                    AttackDetection.cluster_id,
+                    AccessLog.path,
+                    func.count(),
+                )
+                .join(AccessLog, AttackDetection.access_log_id == AccessLog.id)
+                .filter(AttackDetection.cluster_id.isnot(None), *attack_win)
+                .group_by(AttackDetection.cluster_id, AccessLog.path)
+                .all()
+            ):
+                c = clusters.get(cid)
+                if c is not None and cnt > c["top_path_cnt"]:
+                    c["top_path"] = path
+                    c["top_path_cnt"] = cnt
+
+            result = [
+                {
+                    "id": c["id"],
+                    "rep_hash": c["rep_hash"],
+                    "path": c["path"],
+                    "top_path": c["top_path"] or c["path"],
+                    "attack_types": [
+                        t for t, _ in sorted(
+                            c["types"].items(), key=lambda kv: (-kv[1], kv[0])
+                        )
+                    ],
+                    "events": c["events"],
+                    "ips": len(c["ips"]),
+                    "sources": " + ".join(sorted(c["sources"])) or "unlinked",
+                    "first_seen": c["first_seen"],
+                    "last_seen": c["last_seen"],
+                    "sample": c["sample"],
+                }
+                for c in clusters.values()
+            ]
+            result.sort(key=lambda c: c["events"], reverse=True)
+            return result[:limit]
+        finally:
+            self._db.close_session()
+
+    def get_cluster_events(
+        self, cluster_id: str, limit: int = 30
+    ) -> list[dict[str, Any]]:
+        """Members of one campaign: file captures and attack request bodies,
+        most recent first."""
+        session = self._db.session
+        try:
+            files = (
+                session.query(CapturedPayload)
+                .filter(CapturedPayload.cluster_id == cluster_id)
+                .all()
+            )
+            attacks = (
+                session.query(
+                    AttackDetection.attack_type,
+                    AttackDetection.access_log_id,
+                    AccessLog.ip,
+                    AccessLog.path,
+                    AccessLog.timestamp,
+                    AccessLog.raw_request,
+                )
+                .join(AccessLog, AttackDetection.access_log_id == AccessLog.id)
+                .filter(AttackDetection.cluster_id == cluster_id)
+                .all()
+            )
+            events = [
+                {
+                    "kind": "file",
+                    "attack_type": "file",
+                    "filename": p.filename,
+                    "ip": p.ip,
+                    "path": None,
+                    "access_log_id": p.access_log_id,
+                    "timestamp": p.timestamp,
+                }
+                for p in files
+            ]
+            # One request can trip several detectors (e.g. a multipart upload
+            # flagged as sql_injection + command_injection): group by access log
+            # into a single row listing every matched attack type.
+            groups: dict[int, dict[str, Any]] = {}
+            for atype, log_id, ip, path, ts, raw in attacks:
+                g = groups.get(log_id)
+                if g is None:
+                    g = groups[log_id] = {
+                        "kind": "attack",
+                        "attack_types": [],
+                        "filename": None,
+                        "ip": ip,
+                        "path": path,
+                        "access_log_id": log_id,
+                        "timestamp": ts,
+                        "body": "",
+                    }
+                g["attack_types"].append(atype)
+                if not g["body"]:
+                    g["body"] = _request_body(raw)
+            for g in groups.values():
+                g["attack_type"] = ", ".join(g["attack_types"])
+            events += list(groups.values())
+            events.sort(key=lambda e: e["timestamp"] or datetime.min, reverse=True)
+            return events[:limit]
+        finally:
+            self._db.close_session()
+
+    def get_referer_history(self, ip: str, limit: int = 50) -> list[dict[str, Any]]:
+        """Chronological referer trail for an IP (which bait led to which path)."""
+        session = self._db.session
+        try:
+            rows = (
+                session.query(
+                    AccessLog.id, AccessLog.referer, AccessLog.path, AccessLog.timestamp
+                )
+                .filter(
+                    AccessLog.ip == sanitize_ip(ip),
+                    AccessLog.referer.isnot(None),
+                    AccessLog.referer != "",
+                )
+                .order_by(AccessLog.timestamp.desc())
+                .limit(limit)
+                .all()
+            )
+            return [
+                {
+                    "id": r.id,
+                    "referer": r.referer,
+                    "path": r.path,
+                    "timestamp": r.timestamp,
+                }
+                for r in rows
+            ]
+        finally:
+            self._db.close_session()
+
+    @staticmethod
+    def _serialize(p: CapturedPayload) -> dict[str, Any]:
+        return {
+            "id": p.id,
+            "access_log_id": p.access_log_id,
+            "ip": p.ip,
+            "filename": p.filename,
+            "content_type": p.content_type,
+            "size": p.size,
+            "tlsh_hash": p.tlsh_hash,
+            "cluster_id": p.cluster_id,
+            "sha256": p.sha256,
+            "timestamp": p.timestamp.isoformat() if p.timestamp else None,
+        }

--- a/src/migrations/runner.py
+++ b/src/migrations/runner.py
@@ -37,6 +37,13 @@ COLUMNS = [
     ("ip_stats", "is_proxy", "BOOLEAN"),
     ("ip_stats", "is_hosting", "BOOLEAN"),
     ("ip_stats", "reverse", "VARCHAR(255)"),
+    # Threat-intel: inbound Referer header for bait-chain tracking.
+    ("access_logs", "referer", "VARCHAR(2048)"),
+    # Threat-intel: TLSH fuzzy hash on attack detections for near-duplicate clustering.
+    ("attack_detections", "tlsh_hash", "VARCHAR(72)"),
+    # Campaign clustering: payload_clusters.id, assigned incrementally at ingest.
+    ("captured_payloads", "cluster_id", "VARCHAR(36)"),
+    ("attack_detections", "cluster_id", "VARCHAR(36)"),
 ]
 
 # (index name, table, column) — created if the index is missing.
@@ -62,6 +69,10 @@ INDEXES = [
     # last analysis time. Both were full scans of ip_stats without these.
     ("ix_ip_stats_ban_timestamp", "ip_stats", "ban_timestamp"),
     ("ix_ip_stats_last_analysis", "ip_stats", "last_analysis"),
+    ("ix_attack_detections_tlsh_hash", "attack_detections", "tlsh_hash"),
+    # Cluster membership lookups (cluster drill-downs, campaign filter).
+    ("ix_captured_payloads_cluster_id", "captured_payloads", "cluster_id"),
+    ("ix_attack_detections_cluster_id", "attack_detections", "cluster_id"),
 ]
 
 # (table, {storage parameter: value}) — PostgreSQL only, applied with ALTER TABLE.

--- a/src/models.py
+++ b/src/models.py
@@ -419,9 +419,7 @@ class CapturedPayload(Base):
         DateTime, nullable=False, default=datetime.utcnow, index=True
     )
 
-    __table_args__ = (
-        Index("ix_captured_payloads_ip_timestamp", "ip", "timestamp"),
-    )
+    __table_args__ = (Index("ix_captured_payloads_ip_timestamp", "ip", "timestamp"),)
 
     def __repr__(self) -> str:
         return f"<CapturedPayload(id={self.id}, ip='{self.ip}', filename='{self.filename}')>"

--- a/src/models.py
+++ b/src/models.py
@@ -6,6 +6,7 @@ Stores access logs, credential attempts, attack detections, and IP statistics.
 """
 
 from datetime import datetime
+from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
@@ -67,6 +68,8 @@ class AccessLog(Base):
     # Deferred: largest column on the busiest table, read only by the
     # raw-request modal (by id). Eager loading dragged it into every query.
     raw_request: Mapped[str | None] = mapped_column(Text, nullable=True, deferred=True)
+    # Inbound HTTP Referer header — which bait page/URL this request came from.
+    referer: Mapped[str | None] = mapped_column(String(MAX_PATH_LENGTH), nullable=True)
 
     # Relationship to attack detections
     attack_detections: Mapped[list["AttackDetection"]] = relationship(
@@ -135,6 +138,12 @@ class AttackDetection(Base):
     attack_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     matched_pattern: Mapped[str | None] = mapped_column(
         String(MAX_ATTACK_PATTERN_LENGTH), nullable=True
+    )
+    # TLSH fuzzy hash of the payload that matched (near-duplicate variant clustering).
+    tlsh_hash: Mapped[str | None] = mapped_column(String(72), nullable=True, index=True)
+    # Campaign membership: payload_clusters.id (NULL until a valid hash is clustered).
+    cluster_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("payload_clusters.id"), nullable=True, index=True
     )
 
     # Relationship back to access log
@@ -345,6 +354,77 @@ class MetricsSummary(Base):
 
     def __repr__(self) -> str:
         return f"<MetricsSummary(metric='{self.metric}', label='{self.label}', value={self.value})>"
+
+
+class PayloadCluster(Base):
+    """
+    A campaign: a family of near-duplicate payloads (captured files or flagged
+    attack request bodies) with the same TL Hash family.
+
+    Representative hash is the first member's digest; every later member within
+    TLSH_CLUSTER_THRESHOLD of a cluster's representative joins it. Both
+    captured_payloads and attack_detections may point here (cluster_id).
+    """
+
+    __tablename__ = "payload_clusters"
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid4())
+    )
+    representative_hash: Mapped[str] = mapped_column(
+        String(72), nullable=False, index=True
+    )
+    first_seen: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )
+    last_seen: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )
+    capture_count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    def __repr__(self) -> str:
+        return f"<PayloadCluster(id={self.id[:8]}, count={self.capture_count})>"
+
+
+class CapturedPayload(Base):
+    """
+    Files/attachments captured from honeypot requests.
+
+    Stores per-file metadata plus a TLSH fuzzy hash so near-duplicate payloads
+    (WebShell/script variants) can be clustered across attackers and IPs.
+    """
+
+    __tablename__ = "captured_payloads"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    access_log_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("access_logs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    ip: Mapped[str] = mapped_column(String(MAX_IP_LENGTH), nullable=False, index=True)
+    filename: Mapped[str] = mapped_column(String(255), nullable=True, index=True)
+    content_type: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    size: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # TLSH fuzzy hash (70-72 hex chars, T1 prefix); NULL if payload too small/low-entropy.
+    tlsh_hash: Mapped[str | None] = mapped_column(String(72), nullable=True, index=True)
+    # Campaign membership: payload_clusters.id (NULL until a valid hash is clustered).
+    cluster_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("payload_clusters.id"), nullable=True, index=True
+    )
+    # Exact SHA-256 for exact dedupe + linking raw content, complementing fuzzy TLSH.
+    sha256: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, index=True
+    )
+
+    __table_args__ = (
+        Index("ix_captured_payloads_ip_timestamp", "ip", "timestamp"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<CapturedPayload(id={self.id}, ip='{self.ip}', filename='{self.filename}')>"
 
 
 # class IpLog(Base):

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -16,7 +16,7 @@ import secrets
 import threading
 import time
 import zipfile
-from datetime import UTC
+from datetime import UTC, datetime, timedelta
 from email import policy
 
 from fastapi import APIRouter, Depends, Query, Request, Response
@@ -59,6 +59,45 @@ def _no_cache_headers() -> dict:
         "Expires": "0",
         "Access-Control-Allow-Origin": "*",
     }
+
+
+def _parse_day(day: str):
+    """ISO date string -> datetime.date, or None when absent/invalid."""
+    if not day:
+        return None
+    try:
+        return datetime.fromisoformat(day.strip()).date()
+    except ValueError:
+        return None
+
+
+def _campaign_window(day: str = "", days: int = 0, offset: int = 0):
+    """Range window for the campaigns filter.
+
+    ``day``: explicit ISO date -> that single day.
+    ``days``: span length (1/7/30); window is the ``days`` days ending
+    ``offset*days`` days ago (mirrors the attack-trends period pager).
+    Returns (start_dt, end_dt) naive datetimes, or None for the global view.
+    """
+    from datetime import time
+
+    if day:
+        d = _parse_day(day)
+        if d is None:
+            return None
+        start = datetime.combine(d, time.min)
+        return start, start + timedelta(days=1)
+
+    if days:
+        days = min(max(1, days), 90)
+        offset = max(0, offset)
+        end_date = (datetime.now() - timedelta(days=offset * days)).date()
+        start_date = end_date - timedelta(days=days - 1)
+        start = datetime.combine(start_date, time.min)
+        end = datetime.combine(end_date, time.min) + timedelta(days=1)
+        return start, end
+
+    return None
 
 
 class AuthRequest(BaseModel):
@@ -575,6 +614,54 @@ async def attack_types_stats(
         return JSONResponse(content=result, headers=_no_cache_headers())
     except Exception as e:
         get_app_logger().error(f"Error fetching attack types stats: {e}")
+        return JSONResponse(content={"error": str(e)}, headers=_no_cache_headers())
+
+
+@router.get("/api/campaign-stats")
+async def campaign_stats(
+    request: Request,
+    limit: int = Query(12),
+    day: str = Query(""),
+    days: int = Query(0),
+    offset: int = Query(0),
+):
+    limit = min(max(1, limit), 50)
+    window = _campaign_window(day, days=days, offset=offset)
+    cache_key = f"api:campaign_stats:{limit}:{day or days or 0}:{offset}"
+    cached = get_cached_table(cache_key)
+    if cached:
+        return JSONResponse(content=cached, headers=_no_cache_headers())
+
+    db = get_db()
+    try:
+        kwargs = {"limit": limit}
+        if window is not None:
+            kwargs["start"], kwargs["end"] = window
+        clusters = await asyncio.to_thread(
+            db.payloads.get_campaign_clusters, **kwargs
+        )
+        campaigns = [
+            {
+                "id": c["id"],
+                "label": (c["rep_hash"] or "")[:8],
+                "path": c["path"],
+                "top_path": c["top_path"],
+                "sample": c["sample"],
+                "sources": c["sources"],
+                "captures": c["events"],
+                "ips": c["ips"],
+                "first_seen": (
+                    c["first_seen"].isoformat() if c["first_seen"] else None
+                ),
+                "last_seen": c["last_seen"].isoformat() if c["last_seen"] else None,
+            }
+            for c in clusters
+        ]
+        result = {"campaigns": campaigns}
+        set_cached_table(cache_key, result)
+        return JSONResponse(content=result, headers=_no_cache_headers())
+    except Exception as e:
+        get_app_logger().error(f"Error fetching campaign stats: {e}")
         return JSONResponse(content={"error": str(e)}, headers=_no_cache_headers())
 
 

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -637,9 +637,7 @@ async def campaign_stats(
         kwargs = {"limit": limit}
         if window is not None:
             kwargs["start"], kwargs["end"] = window
-        clusters = await asyncio.to_thread(
-            db.payloads.get_campaign_clusters, **kwargs
-        )
+        clusters = await asyncio.to_thread(db.payloads.get_campaign_clusters, **kwargs)
         campaigns = [
             {
                 "id": c["id"],

--- a/src/routes/honeypot.py
+++ b/src/routes/honeypot.py
@@ -13,7 +13,7 @@ from urllib.parse import parse_qs
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
-from config import Config
+from config import Config, get_config
 from deception_responses import (
     detect_xss_pattern,
     generate_server_error,
@@ -59,6 +59,7 @@ async def _track_honeypot_request(request: Request):
     tracker = request.app.state.tracker
     client_ip = get_client_ip(request)
     user_agent = request.headers.get("User-Agent", "")
+    referer = request.headers.get("Referer", "") if get_config().referer_enabled else ""
     path = request.url.path
     get_app_logger().debug(f"[HoneypotDep] {request.method} {path} from {client_ip}")
 
@@ -79,6 +80,15 @@ async def _track_honeypot_request(request: Request):
     if attack_findings or tracker.is_honeypot_path(path):
         import asyncio
 
+        raw_request = build_raw_request(request, body)
+
+        # Capture uploaded files (WebShells, etc.) as TLSH-indexed payloads.
+        file_payloads = None
+        if get_config().tlsh_enabled:
+            from tlsh_utils import extract_file_payloads
+
+            file_payloads = extract_file_payloads(raw_request)
+
         await asyncio.to_thread(
             tracker.record_access,
             ip=client_ip,
@@ -86,7 +96,9 @@ async def _track_honeypot_request(request: Request):
             user_agent=user_agent,
             body=body,
             method=request.method,
-            raw_request=build_raw_request(request, body),
+            raw_request=raw_request,
+            referer=referer,
+            file_payloads=file_payloads,
         )
 
 

--- a/src/routes/htmx.py
+++ b/src/routes/htmx.py
@@ -6,6 +6,7 @@ Server-rendered HTML partials for table pagination, sorting, IP details, and sea
 """
 
 import asyncio
+from datetime import datetime
 
 from fastapi import APIRouter, Query, Request, Response
 from fastapi.responses import HTMLResponse
@@ -19,7 +20,7 @@ from dashboard_cache import (
     set_cached_table,
 )
 from dependencies import get_db, get_templates
-from routes.api import verify_auth
+from routes.api import _campaign_window, verify_auth
 
 router = APIRouter()
 
@@ -37,6 +38,16 @@ _INLINE_401 = "<p style='color:#f85149;'>Unauthorized</p>"
 def _dashboard_path(request: Request) -> str:
     config = request.app.state.config
     return "/" + config.dashboard_secret_path.lstrip("/")
+
+
+def _parse_day(day: str):
+    """ISO date string -> datetime.date, or None when absent/invalid."""
+    if not day:
+        return None
+    try:
+        return datetime.fromisoformat(day.strip()).date()
+    except ValueError:
+        return None
 
 
 # ── Honeypot Triggers ────────────────────────────────────────────────
@@ -499,9 +510,10 @@ async def htmx_credentials(
     page: int = Query(1),
     sort_by: str = Query("timestamp"),
     sort_order: str = Query("desc"),
+    ip_filter: str = Query(""),
 ):
     page = max(1, page)
-    cache_key = f"credentials:{page}:{sort_by}:{sort_order}"
+    cache_key = f"credentials:{page}:{sort_by}:{sort_order}:{ip_filter}"
     cached = get_cached_table(cache_key)
     if cached:
         result = cached
@@ -513,6 +525,7 @@ async def htmx_credentials(
             page_size=5,
             sort_by=sort_by,
             sort_order=sort_order,
+            ip_filter=ip_filter or None,
         )
         set_cached_table(cache_key, result)
 
@@ -526,6 +539,7 @@ async def htmx_credentials(
             "pagination": result["pagination"],
             "sort_by": sort_by,
             "sort_order": sort_order,
+            "ip_filter": ip_filter,
         },
     )
 
@@ -589,6 +603,9 @@ async def htmx_attacks(
                 "user_agent": attack.get("user_agent", ""),
                 "timestamp": attack.get("timestamp"),
                 "log_id": attack.get("id"),
+                "tlsh_hash": attack.get("tlsh_hash"),
+                "cluster_id": attack.get("cluster_id"),
+                "cluster_hash": attack.get("cluster_hash"),
             }
         )
 
@@ -793,6 +810,151 @@ async def htmx_ip_detail(ip_address: str, request: Request):
             "dashboard_path": _dashboard_path(request),
             "stats": clean_stats,
             "is_tracked": is_tracked,
+        },
+    )
+
+
+# ── IP Payloads (files uploaded by one IP) ───────────────────────────
+
+
+@router.get("/htmx/ip-referers")
+async def htmx_ip_referers(
+    request: Request,
+    ip_filter: str = Query(""),
+):
+    db = get_db()
+    items = await asyncio.to_thread(
+        db.payloads.get_referer_history, ip=ip_filter, limit=50
+    )
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/referer_history_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "items": items,
+            "ip_filter": ip_filter,
+        },
+    )
+
+
+@router.get("/htmx/ip-payloads")
+async def htmx_ip_payloads(
+    request: Request,
+    ip_filter: str = Query(""),
+    page: int = Query(1),
+):
+    page = max(1, page)
+    db = get_db()
+    result = await asyncio.to_thread(
+        db.payloads.get_by_ip, ip=ip_filter, page=page, page_size=10
+    )
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/payloads_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "items": result["payloads"],
+            "pagination": result["pagination"],
+            "ip_filter": ip_filter,
+        },
+    )
+
+
+# ── Global Filename Index (Threat tab) ───────────────────────────────
+
+
+@router.get("/htmx/global-filenames")
+async def htmx_global_filenames(
+    request: Request,
+    page: int = Query(1),
+):
+    page = max(1, page)
+    db = get_db()
+    result = await asyncio.to_thread(
+        db.payloads.get_global_index, page=page, page_size=20
+    )
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/filenames_index_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "index": result["index"],
+            "pagination": result["pagination"],
+        },
+    )
+
+
+# ── Similar events (fuzzy TLSH match across attacks + files) ─────────
+
+
+@router.get("/htmx/similar-events")
+async def htmx_similar_events(
+    request: Request,
+    tlsh: str = Query(""),
+):
+    db = get_db()
+    items = await asyncio.to_thread(
+        db.payloads.get_similar_events, base_hash=tlsh
+    )
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/similar_threats_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "items": items,
+            "tlsh": tlsh,
+        },
+    )
+
+
+# ── Recurring patterns / campaign clusters (Threats tab) ─────────────
+
+
+@router.get("/htmx/pattern-clusters")
+async def htmx_pattern_clusters(
+    request: Request,
+    day: str = Query(""),
+    days: int = Query(0),
+    offset: int = Query(0),
+):
+    db = get_db()
+    window = _campaign_window(day, days=days, offset=offset)
+    kwargs: dict = {}
+    if window is not None:
+        kwargs["start"], kwargs["end"] = window
+    clusters = await asyncio.to_thread(
+        db.payloads.get_campaign_clusters, **kwargs
+    )
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/pattern_clusters_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "clusters": clusters,
+        },
+    )
+
+
+@router.get("/htmx/cluster-events")
+async def htmx_cluster_events(
+    request: Request,
+    cluster: str = Query(""),
+):
+    db = get_db()
+    events = await asyncio.to_thread(db.payloads.get_cluster_events, cluster_id=cluster)
+    templates = get_templates()
+    return templates.TemplateResponse(
+        request,
+        "dashboard/partials/cluster_events_table.html",
+        {
+            "dashboard_path": _dashboard_path(request),
+            "items": events,
+            "cluster": cluster,
         },
     )
 

--- a/src/routes/htmx.py
+++ b/src/routes/htmx.py
@@ -896,9 +896,7 @@ async def htmx_similar_events(
     tlsh: str = Query(""),
 ):
     db = get_db()
-    items = await asyncio.to_thread(
-        db.payloads.get_similar_events, base_hash=tlsh
-    )
+    items = await asyncio.to_thread(db.payloads.get_similar_events, base_hash=tlsh)
     templates = get_templates()
     return templates.TemplateResponse(
         request,
@@ -926,9 +924,7 @@ async def htmx_pattern_clusters(
     kwargs: dict = {}
     if window is not None:
         kwargs["start"], kwargs["end"] = window
-    clusters = await asyncio.to_thread(
-        db.payloads.get_campaign_clusters, **kwargs
-    )
+    clusters = await asyncio.to_thread(db.payloads.get_campaign_clusters, **kwargs)
     templates = get_templates()
     return templates.TemplateResponse(
         request,

--- a/src/templates/jinja2/dashboard/index.html
+++ b/src/templates/jinja2/dashboard/index.html
@@ -64,6 +64,7 @@
     <div class="tabs-container">
         <a class="tab-button" :class="{ active: tab === 'overview' }" @click.prevent="switchToOverview()" href="#overview">Overview</a>
         <a class="tab-button" :class="{ active: tab === 'attacks' }" @click.prevent="switchToAttacks()" href="#ip-stats">Attacks</a>
+        <a class="tab-button" :class="{ active: tab === 'threats' }" @click.prevent="switchToThreats()" href="#threats">Threats</a>
         <a class="tab-button" :class="{ active: tab === 'ip-insight', disabled: !insightIp }" @click.prevent="insightIp && switchToIpInsight()" href="#ip-insight">
             IP Insight<span x-show="insightIp" x-text="' (' + insightIp + ')'"></span>
         </a>
@@ -280,6 +281,48 @@
         <div id="webhooks-htmx-container"></div>
     </div>
 
+    {# ==================== THREAT TAB (global captured-file index) ==================== #}
+    <div x-show="tab === 'threats'" x-cloak>
+        <div class="table-container alert-section">
+            <div class="chart-head">
+                <h2 class="m-0">Attack Campaigns <span class="chart-head-hint">(click a bar to open its members)</span></h2>
+                <div class="row">
+                    <div class="row gap-1" id="campaigns-span-selector">
+                        <button class="map-limit-btn active" data-days="1" onclick="setCampaignSpan(1, this)">1D</button>
+                        <button class="map-limit-btn" data-days="7" onclick="setCampaignSpan(7, this)">7D</button>
+                        <button class="map-limit-btn" data-days="30" onclick="setCampaignSpan(30, this)">30D</button>
+                    </div>
+                    <div class="row">
+                        <button id="campaigns-period-prev" onclick="shiftCampaignPeriod(1)" class="pagination-btn fs-sm">&#8592;</button>
+                        <span id="campaigns-period-label" class="period-label"></span>
+                        <button id="campaigns-period-next" onclick="shiftCampaignPeriod(-1)" class="pagination-btn fs-sm" disabled>&#8594;</button>
+                    </div>
+                </div>
+            </div>
+            <div class="chart-row">
+                <div class="chart-wrapper chart-main">
+                    <canvas id="campaigns-chart"></canvas>
+                </div>
+            </div>
+        </div>
+        <div class="table-container alert-section">
+            <div class="row-top">
+                <h2>Campaign Members</h2>
+            </div>
+            <div id="patterns-htmx-container">
+                <div class="htmx-indicator">Loading...</div>
+            </div>
+        </div>
+        <div class="table-container alert-section">
+            <div class="row-top">
+                <h2>Captured Files</h2>
+            </div>
+            <div id="threats-htmx-container">
+                <div class="htmx-indicator">Loading...</div>
+            </div>
+        </div>
+    </div>
+
     {# Export IPs modal - Alpine.js #}
     {% include "dashboard/partials/export_modal.html" %}
 
@@ -288,6 +331,9 @@
 
     {# Raw request modal - Alpine.js #}
     {% include "dashboard/partials/raw_request_modal.html" %}
+
+    {# Captured file viewer modal - Alpine.js #}
+    {% include "dashboard/partials/file_view_modal.html" %}
 
     {# Auth modal - Alpine.js #}
     {% include "dashboard/partials/auth_modal.html" %}

--- a/src/templates/jinja2/dashboard/ip.html
+++ b/src/templates/jinja2/dashboard/ip.html
@@ -55,5 +55,28 @@
             </div>
         </div>
     </div>
+
+    {# Captured file viewer modal #}
+    <div class="raw-request-modal" x-show="fileModal.show" x-cloak @click.self="closeFileModal()" @keydown.escape.window="closeFileModal()">
+        <div class="raw-request-modal-content">
+            <div class="raw-request-modal-header">
+                <h3 x-text="fileModal.filename || 'Captured File'"></h3>
+                <span class="raw-request-modal-close" @click="closeFileModal()">&times;</span>
+            </div>
+            <div class="raw-request-modal-body">
+                <div class="file-modal-meta">
+                    <span x-text="fileModal.contentType"></span>
+                    <span x-text="fileModal.size"></span>
+                </div>
+                <pre class="raw-request-content" x-text="fileModal.content"></pre>
+            </div>
+            <div class="raw-request-modal-footer">
+                <button class="raw-request-icon-btn" @click="downloadPayloadFile()" title="Download file">
+                    <svg class="icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"/><path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06Z"/></svg>
+                    <span class="raw-request-icon-tooltip">Download file</span>
+                </button>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/src/templates/jinja2/dashboard/partials/_ip_detail.html
+++ b/src/templates/jinja2/dashboard/partials/_ip_detail.html
@@ -225,6 +225,39 @@
 </div>
 {% endif %}
 
+{# Referer history – bait-chain tracking #}
+<div class="table-container alert-section mt-5">
+    <h2>Referer History</h2>
+    <div class="htmx-container"
+         hx-get="{{ dashboard_path }}/htmx/ip-referers?ip_filter={{ ip_address }}"
+         hx-trigger="revealed"
+         hx-swap="innerHTML">
+        <div class="htmx-indicator">Loading...</div>
+    </div>
+</div>
+
+{# Captured payloads / files uploaded by this IP #}
+<div class="table-container alert-section mt-5">
+    <h2>Captured Payloads / Files</h2>
+    <div class="htmx-container"
+         hx-get="{{ dashboard_path }}/htmx/ip-payloads?ip_filter={{ ip_address }}&page=1"
+         hx-trigger="revealed"
+         hx-swap="innerHTML">
+        <div class="htmx-indicator">Loading...</div>
+    </div>
+</div>
+
+{# Credentials attempted / used by this IP #}
+<div class="table-container alert-section mt-5">
+    <h2>Captured Credentials</h2>
+    <div class="htmx-container"
+         hx-get="{{ dashboard_path }}/htmx/credentials?ip_filter={{ ip_address }}&page=1"
+         hx-trigger="revealed"
+         hx-swap="innerHTML">
+        <div class="htmx-indicator">Loading...</div>
+    </div>
+</div>
+
 {# Access History table #}
 <div class="table-container alert-section mt-5" id="access-history-section">
     <h2>Access History</h2>

--- a/src/templates/jinja2/dashboard/partials/attack_types_table.html
+++ b/src/templates/jinja2/dashboard/partials/attack_types_table.html
@@ -1,6 +1,6 @@
 {# HTMX fragment: Detected Attack Types table #}
 {% set filter_qs %}{% if ip_filter %}&ip_filter={{ ip_filter }}{% endif %}{% if attack_type_filter %}&attack_type_filter={{ attack_type_filter | e }}{% endif %}{% if search %}&search={{ search | e }}{% endif %}{% if method_filter %}&method_filter={{ method_filter | e }}{% endif %}{% endset %}
-<div class="panel-header">
+<div class="panel-header similar-host">
     <div class="row row-wrap">
         <span class="pagination-info">Page {{ pagination.page }}/{{ pagination.total_pages }} &mdash; {{ pagination.total }} total</span>
         {% if attack_type_filter %}
@@ -60,6 +60,12 @@
             </th>
             <th>Path</th>
             <th>Attack Types</th>
+            <th title="Campaign hash for grouped attacks, TLSH for standalone threats">TL Hash
+                <span class="th-hint" tabindex="0">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#e3e3e3"><path d="M440-280h80v-240h-80v240Zm68.5-331.5Q520-623 520-640t-11.5-28.5Q497-680 480-680t-28.5 11.5Q440-657 440-640t11.5 28.5Q463-600 480-600t28.5-11.5ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/></svg>
+                    <span class="th-hint-tip">Campaign hash for grouped attacks, click to open the campaign.</span>
+                </span>
+            </th>
             <th>User-Agent</th>
             <th class="sortable {% if sort_by == 'timestamp' %}{{ sort_order }}{% endif %}"
                 hx-get="{{ dashboard_path }}/htmx/attacks?page=1&page_size={{ pagination.page_size }}&sort_by=timestamp&sort_order={% if sort_by == 'timestamp' and sort_order == 'desc' %}asc{% else %}desc{% endif %}{{ filter_qs }}"
@@ -102,6 +108,19 @@
                     {% endif %}
                 </div>
             </td>
+            <td class="data-mono tl-hash">
+                {% if attack.cluster_hash %}
+                <a href="#"
+                   class="data-link campaign-hash-link"
+                   @click.prevent="openExpandOverlay('{{ attack.cluster_hash }}', 'campaign', '', '{{ attack.cluster_id | e }}')"
+                   title="Campaign members ({{ attack.cluster_hash | e }})">{{ attack.cluster_hash | e }}</a>
+                {% elif attack.tlsh_hash %}
+                <a href="#"
+                   class="data-link"
+                   @click.prevent="openExpandOverlay('{{ attack.tlsh_hash[:12] }}', 'similar', '', '{{ attack.tlsh_hash | e }}')"
+                   title="{{ attack.tlsh_hash | e }}">{{ attack.tlsh_hash[:12] }}</a>
+                {% endif %}
+            </td>
             <td class="ua-cell">{{ (attack.user_agent | default(''))[:50] | e }}</td>
             <td class="ts-cell">{{ attack.timestamp | format_ts }}</td>
             <td>
@@ -119,14 +138,14 @@
             </td>
         </tr>
         <tr class="ip-stats-row" style="display: none;">
-            <td colspan="9" class="ip-stats-cell">
+            <td colspan="10" class="ip-stats-cell">
                 <div class="ip-stats-dropdown">
                     <div class="loading">Loading stats...</div>
                 </div>
             </td>
         </tr>
         {% else %}
-        <tr><td colspan="9" class="empty-state">No attacks detected</td></tr>
+        <tr><td colspan="10" class="empty-state">No attacks detected</td></tr>
         {% endfor %}
     </tbody>
 </table>

--- a/src/templates/jinja2/dashboard/partials/auth_modal.html
+++ b/src/templates/jinja2/dashboard/partials/auth_modal.html
@@ -3,7 +3,6 @@
      x-show="authModal.show"
      x-cloak
      @click.self="closeAuthModal()"
-     @keydown.escape.window="authModal.show && closeAuthModal()"
 >
     <div class="auth-modal-content">
         <div class="auth-modal-header">

--- a/src/templates/jinja2/dashboard/partials/cluster_events_table.html
+++ b/src/templates/jinja2/dashboard/partials/cluster_events_table.html
@@ -1,0 +1,62 @@
+{# HTMX fragment: one campaign's members (cluster drill-down).
+ # Expects: items (cluster event dicts), cluster, dashboard_path. #}
+<div class="panel-header">
+    <span class="pagination-info">Campaign members</span>
+</div>
+<table>
+    <thead>
+        <tr>
+            <th>Kind</th>
+            <th>Request</th>
+            <th>IP</th>
+            <th>Path</th>
+            <th>Time</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for item in items %}
+        <tr>
+            <td>
+                {% if item.kind == 'file' %}
+                <span class="method-badge">file</span>
+                {% else %}
+                <div class="badge-row">
+                    {% for t in (item.attack_types or [item.attack_type]) %}
+                    <span class="method-badge method-{{ t | lower | replace('_', '-') | e }}">{{ t | e }}</span>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </td>
+            <td class="data">
+                {% if item.kind == 'attack' %}
+                <a href="#"
+                   class="cluster-body"
+                   @click.prevent="viewRawRequest({{ item.access_log_id }})"
+                   title="View full request">{{ (item.body or item.path | default('')) | truncate(140) | e }}</a>
+                {% endif %}
+            </td>
+            <td class="data data-mono">
+                <a href="#"
+                   class="data-link"
+                   @click.prevent="openIpInsight('{{ item.ip | default('') | e }}')">{{ item.ip | default('') | e }}</a>
+            </td>
+            <td class="data data-mono">
+                {% if item.kind == 'file' %}
+                <a href="#"
+                   class="data-link"
+                   data-filename="{{ item.filename | default('(untitled)') | e }}"
+                   @click.prevent="viewPayload({{ item.access_log_id }}, $event.currentTarget.dataset.filename)"
+                   title="View file">{{ item.filename | default('(untitled)') | e }}</a>
+                {% elif item.path %}
+                <a href="{{ item.path }}" class="data-link" target="_blank" rel="noopener" title="Open in Krawl">{{ item.path | truncate(30) | e }}</a>
+                {% else %}
+                <span class="muted"></span>
+                {% endif %}
+            </td>
+            <td class="ts-cell">{{ item.timestamp | format_ts }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="5" class="empty-state">Cluster has no members</td></tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/src/templates/jinja2/dashboard/partials/credentials_table.html
+++ b/src/templates/jinja2/dashboard/partials/credentials_table.html
@@ -2,16 +2,18 @@
 <div class="panel-header">
     <span class="pagination-info">Page {{ pagination.page }}/{{ pagination.total_pages }} &mdash; {{ pagination.total }} total</span>
     <div class="row">
+        {% if not ip_filter %}
         <button class="btn btn-sm" onclick="downloadCredentials()" title="Download unique usernames and passwords">
             Download Credentials
         </button>
+        {% endif %}
         <button class="pagination-btn"
-                hx-get="{{ dashboard_path }}/htmx/credentials?page={{ pagination.page - 1 }}&sort_by={{ sort_by }}&sort_order={{ sort_order }}"
+                hx-get="{{ dashboard_path }}/htmx/credentials?page={{ pagination.page - 1 }}&sort_by={{ sort_by }}&sort_order={{ sort_order }}&ip_filter={{ ip_filter }}"
                 hx-target="closest .htmx-container"
                 hx-swap="innerHTML"
                 {% if pagination.page <= 1 %}disabled{% endif %}>Prev</button>
         <button class="pagination-btn"
-                hx-get="{{ dashboard_path }}/htmx/credentials?page={{ pagination.page + 1 }}&sort_by={{ sort_by }}&sort_order={{ sort_order }}"
+                hx-get="{{ dashboard_path }}/htmx/credentials?page={{ pagination.page + 1 }}&sort_by={{ sort_by }}&sort_order={{ sort_order }}&ip_filter={{ ip_filter }}"
                 hx-target="closest .htmx-container"
                 hx-swap="innerHTML"
                 {% if pagination.page >= pagination.total_pages %}disabled{% endif %}>Next</button>
@@ -21,12 +23,14 @@
     <thead>
         <tr>
             <th>#</th>
+            {% if not ip_filter %}
             <th>IP Address</th>
+            {% endif %}
             <th>Username</th>
             <th>Password</th>
             <th>Path</th>
             <th class="sortable {% if sort_by == 'timestamp' %}{{ sort_order }}{% endif %}"
-                hx-get="{{ dashboard_path }}/htmx/credentials?page=1&sort_by=timestamp&sort_order={% if sort_by == 'timestamp' and sort_order == 'desc' %}asc{% else %}desc{% endif %}"
+                hx-get="{{ dashboard_path }}/htmx/credentials?page=1&sort_by=timestamp&sort_order={% if sort_by == 'timestamp' and sort_order == 'desc' %}asc{% else %}desc{% endif %}&ip_filter={{ ip_filter }}"
                 hx-target="closest .htmx-container"
                 hx-swap="innerHTML">
                 Time
@@ -38,6 +42,7 @@
         {% for cred in items %}
         <tr class="ip-row" data-ip="{{ cred.ip | e }}">
             <td class="rank">{{ loop.index + (pagination.page - 1) * pagination.page_size }}</td>
+            {% if not ip_filter %}
             <td class="ip-clickable"
                 hx-get="{{ dashboard_path }}/htmx/ip-detail/{{ cred.ip | e }}"
                 hx-target="next .ip-stats-row .ip-stats-dropdown"
@@ -45,6 +50,7 @@
                 @click="toggleIpDetail($event)">
                 {{ cred.ip | e }}
             </td>
+            {% endif %}
             <td class="data">{{ cred.username | default('N/A') | e }}</td>
             <td class="data">{{ cred.password | default('N/A') | e }}</td>
             <td class="data">{{ cred.path | default('') | e }}</td>

--- a/src/templates/jinja2/dashboard/partials/expand_overlay.html
+++ b/src/templates/jinja2/dashboard/partials/expand_overlay.html
@@ -3,7 +3,6 @@
      id="expand-overlay"
      x-show="expandOverlay.show"
      x-cloak
-     @keydown.escape.window="expandOverlay.show && (expandOverlay.show = false)"
 >
     <div class="expand-overlay-content">
         <div class="expand-overlay-header">
@@ -14,7 +13,9 @@
                        placeholder="Filter..."
                        x-model="expandOverlay.search"
                        @input.debounce.300ms="triggerExpandSearch()"
-                       autocomplete="off" />
+                       autocomplete="off"
+                       x-show="expandOverlay.endpoint !== 'campaign' && expandOverlay.endpoint !== 'similar'"
+                       x-cloak />
                 <span class="auth-modal-close overlay-close" @click="expandOverlay.show = false">&times;</span>
             </div>
         </div>

--- a/src/templates/jinja2/dashboard/partials/export_modal.html
+++ b/src/templates/jinja2/dashboard/partials/export_modal.html
@@ -3,7 +3,6 @@
      x-show="exportModal.show"
      x-cloak
      @click.self="exportModal.show = false"
-     @keydown.escape.window="exportModal.show && (exportModal.show = false)"
 >
     <div class="auth-modal-content export-modal-content">
         <div class="auth-modal-header">

--- a/src/templates/jinja2/dashboard/partials/file_view_modal.html
+++ b/src/templates/jinja2/dashboard/partials/file_view_modal.html
@@ -1,0 +1,27 @@
+{# Captured file viewer modal - Alpine.js controlled.
+ # Shows the payload file content itself (not the HTTP request wrapper). #}
+<div class="raw-request-modal"
+     x-show="fileModal.show"
+     x-cloak
+     @click.self="closeFileModal()"
+>
+    <div class="raw-request-modal-content">
+        <div class="raw-request-modal-header">
+            <h3 x-text="fileModal.filename || 'Captured File'"></h3>
+            <span class="raw-request-modal-close" @click="closeFileModal()">&times;</span>
+        </div>
+        <div class="raw-request-modal-body">
+            <div class="file-modal-meta">
+                <span x-text="fileModal.contentType"></span>
+                <span x-text="fileModal.size"></span>
+            </div>
+            <pre class="raw-request-content" x-text="fileModal.content"></pre>
+        </div>
+        <div class="raw-request-modal-footer">
+            <button class="raw-request-icon-btn" @click="downloadPayloadFile()" title="Download file">
+                <svg class="icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"/><path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06Z"/></svg>
+                <span class="raw-request-icon-tooltip">Download file</span>
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/templates/jinja2/dashboard/partials/filenames_index_table.html
+++ b/src/templates/jinja2/dashboard/partials/filenames_index_table.html
@@ -1,0 +1,51 @@
+{# HTMX fragment: Global captured-file index (Threats tab) #
+ # Groups captured payload filenames across all IPs; same name from many IPs # 
+ # signals a recurring campaign artifact (WebShell / script upload name).
+ # Clicking a filename shows the most recent capture's payload (raw request). #}
+<div class="panel-header">
+    <span class="pagination-info">Page {{ pagination.page }}/{{ pagination.total_pages }} &mdash; {{ pagination.total }} filenames</span>
+    <div class="row">
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/global-filenames?page={{ pagination.page - 1 }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page <= 1 %}disabled{% endif %}>Prev</button>
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/global-filenames?page={{ pagination.page + 1 }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page >= pagination.total_pages %}disabled{% endif %}>Next</button>
+    </div>
+</div>
+<table>
+    <thead>
+        <tr>
+            <th>Filename</th>
+            <th title="Distinct source IPs sharing this filename">Distinct IPs</th>
+            <th>Captures</th>
+            <th>First Seen</th>
+            <th>Last Seen</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for item in index %}
+        <tr>
+            <td class="data data-mono">
+                <a href="#"
+                   class="data-link"
+                   data-filename="{{ item.filename | e }}"
+                   @click.prevent="viewPayload({{ item.log_id }}, $event.currentTarget.dataset.filename)"
+                   title="View file {{ item.filename | e }}">
+                    {{ item.filename | e }}
+                </a>
+            </td>
+            <td class="ts-cell">{{ item.distinct_ips }}</td>
+            <td class="ts-cell">{{ item.total }}</td>
+            <td class="ts-cell">{{ item.first_seen | format_ts }}</td>
+            <td class="ts-cell">{{ item.last_seen | format_ts }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="5" class="empty-state">No captured payloads yet &mdash; captured files will appear here once TLSH capture is enabled and files arrive</td></tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/src/templates/jinja2/dashboard/partials/pattern_clusters_table.html
+++ b/src/templates/jinja2/dashboard/partials/pattern_clusters_table.html
@@ -1,0 +1,51 @@
+{# HTMX fragment: campaign clusters (Threats tab Attack Campaigns).
+ # Expects: clusters, dashboard_path. Clicking the rep hash opens the
+ # campaign's members in the shared expand overlay viewbox. #}
+<div class="panel-header similar-host">
+    <span class="pagination-info">Attacks or payloads grouped into campaigns</span>
+</div>
+<table>
+    <thead>
+        <tr>
+            <th title="Attack types that make up this campaign (click to see the members)">Attack Types</th>
+            <th title="Most frequently targeted path within this campaign">Most Hit Target</th>
+            <th>Captures</th>
+            <th title="Distinct source IPs">IPs</th>
+            <th>First Seen</th>
+            <th>Last Seen</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for c in clusters %}
+        <tr>
+            <td>
+                <a href="#"
+                   class="campaign-cell-link"
+                   @click.prevent="openExpandOverlay('{{ c.rep_hash[:12] }}', 'campaign', {{ c.events }}, '{{ c.id | e }}')"
+                   title="Campaign {{ c.rep_hash }} ({{ c.id }})">
+                    <div class="badge-row">
+                        {% for t in (c.attack_types or []) %}
+                        <span class="method-badge method-{{ t | lower | replace('_', '-') | e }}">{{ t | e }}</span>
+                        {% endfor %}
+                    </div>
+                    <div class="campaign-path-hint data-mono">{{ (c.rep_hash | default(''))[:8] | e }}</div>
+                </a>
+            </td>
+            <td>
+                <a href="#"
+                   class="campaign-target-link"
+                   @click.prevent="openExpandOverlay('{{ c.rep_hash[:12] }}', 'campaign', {{ c.events }}, '{{ c.id | e }}')"
+                   title="Most hit target: {{ (c.top_path | default('')) | e }}">
+                    {{ (c.top_path | default('—')) | e }}
+                </a>
+            </td>
+            <td class="ts-cell">{{ c.events }}</td>
+            <td class="ts-cell">{{ c.ips }}</td>
+            <td class="ts-cell">{{ c.first_seen | format_ts }}</td>
+            <td class="ts-cell">{{ c.last_seen | format_ts }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="6" class="empty-state">No campaigns yet. A campaign appears once a second near-duplicate payload lands within TLSH threshold</td></tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/src/templates/jinja2/dashboard/partials/payloads_table.html
+++ b/src/templates/jinja2/dashboard/partials/payloads_table.html
@@ -1,0 +1,75 @@
+{# HTMX fragment: Captured file payloads for an IP #
+ # Expects: items (payload dicts), pagination, dashboard_path, ip_filter. #
+ # Filename cells open the file content; TL hash cells list fuzzy-similar events. #}
+<div class="panel-header similar-host">
+    <span class="pagination-info">Page {{ pagination.page }}/{{ pagination.total_pages }} &mdash; {{ pagination.total }} total</span>
+    <div class="row">
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/ip-payloads?page={{ pagination.page - 1 }}&ip_filter={{ ip_filter }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page <= 1 %}disabled{% endif %}>Prev</button>
+        <button class="pagination-btn"
+                hx-get="{{ dashboard_path }}/htmx/ip-payloads?page={{ pagination.page + 1 }}&ip_filter={{ ip_filter }}"
+                hx-target="closest .htmx-container"
+                hx-swap="innerHTML"
+                {% if pagination.page >= pagination.total_pages %}disabled{% endif %}>Next</button>
+    </div>
+</div>
+<table>
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Filename</th>
+            <th>Type</th>
+            <th>Size</th>
+            <th class="data-mono" title="Campaign hash for clustered payloads, TLSH for standalone files">TL Hash
+                <span class="th-hint" tabindex="0">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#e3e3e3"><path d="M440-280h80v-240h-80v240Zm68.5-331.5Q520-623 520-640t-11.5-28.5Q497-680 480-680t-28.5 11.5Q440-657 440-640t11.5 28.5Q463-600 480-600t28.5-11.5ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/></svg>
+                    <span class="th-hint-tip">Campaign hash for clustered payloads — click to open the campaign. Standalone files show their TLSH — click for similar payloads</span>
+                </span>
+            </th>
+            <th title="SHA-256">SHA256</th>
+            <th>Time</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for item in items %}
+        <tr>
+            <td class="rank">{{ loop.index + (pagination.page - 1) * pagination.page_size }}</td>
+            <td class="data data-mono">
+                <a href="#"
+                   class="data-link"
+                   data-filename="{{ item.filename | e }}"
+                   @click.prevent="viewPayload({{ item.access_log_id }}, $event.currentTarget.dataset.filename)"
+                   title="View file {{ item.filename | e }}">
+                    {{ item.filename | default('(untitled)') | e }}
+                </a>
+            </td>
+            <td class="data">{{ item.content_type | default('') | e }}</td>
+            <td class="ts-cell">{{ item.size }} B</td>
+            <td class="data-mono tl-hash">
+                {% if item.cluster_hash %}
+                <a href="#"
+                   class="data-link campaign-hash-link"
+                   @click.prevent="openExpandOverlay('{{ item.cluster_hash }}', 'campaign', '', '{{ item.cluster_id | e }}')"
+                   title="Campaign members ({{ item.cluster_hash | e }})">{{ item.cluster_hash | e }}</a>
+                {% elif item.tlsh_hash %}
+                <a href="#"
+                   class="data-link"
+                   @click.prevent="openExpandOverlay('{{ item.tlsh_hash[:12] }}', 'similar', '', '{{ item.tlsh_hash | e }}')"
+                   title="{{ item.tlsh_hash | e }}">{{ item.tlsh_hash[:12] }}</a>
+                {% else %}
+                &mdash;
+                {% endif %}
+            </td>
+            <td class="data-mono sha" title="{{ item.sha256 | default('') }}">
+                {{ (item.sha256 | default(''))[:12] or '&mdash;' }}
+            </td>
+            <td class="ts-cell">{{ item.timestamp | format_ts }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="7" class="empty-state">No captured payloads for this IP</td></tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/src/templates/jinja2/dashboard/partials/raw_request_modal.html
+++ b/src/templates/jinja2/dashboard/partials/raw_request_modal.html
@@ -3,7 +3,6 @@
      x-show="rawModal.show"
      x-cloak
      @click.self="closeRawModal()"
-     @keydown.escape.window="closeRawModal()"
 >
     <div class="raw-request-modal-content">
         <div class="raw-request-modal-header">

--- a/src/templates/jinja2/dashboard/partials/referer_history_table.html
+++ b/src/templates/jinja2/dashboard/partials/referer_history_table.html
@@ -1,0 +1,27 @@
+{# HTMX fragment: Referer history for a single IP #
+ # Shows which referring URL (bait) led the attacker onto which trap path. #}
+<div class="panel-header">
+    <span class="pagination-info">Recent referers &mdash; {{ items | length }} shown</span>
+</div>
+<table>
+    <thead>
+        <tr>
+            <th>Referer</th>
+            <th>Path</th>
+            <th>Time</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for item in items %}
+        <tr>
+            <td class="data data-mono">
+                <a href="{{ item.referer | e }}" target="_blank" rel="noopener noreferrer" class="data-link">{{ item.referer | e }}</a>
+            </td>
+            <td class="data"><a href="#" @click.prevent="viewRawRequest({{ item.id }})" class="data-link">{{ item.path | e }}</a></td>
+            <td class="ts-cell">{{ item.timestamp | format_ts }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3" class="empty-state">No referer data captured for this IP</td></tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/src/templates/jinja2/dashboard/partials/similar_threats_table.html
+++ b/src/templates/jinja2/dashboard/partials/similar_threats_table.html
@@ -1,0 +1,61 @@
+{# HTMX fragment: events (attack bodies + files) fuzzy-similar to a TLSH digest.
+ # Expects: items, tlsh, dashboard_path. Diff = TLSH distance (0 = identical). #}
+<div class="panel-header">
+    <span class="pagination-info">Similar patterns &mdash; diff &le; 150 &middot; {{ items | length }} events</span>
+</div>
+<table>
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Kind</th>
+            <th title="TLSH distance (0 = identical bytes)">Diff</th>
+            <th title="Detector regex / fragment that matched this event">Matched Pattern</th>
+            <th>IP</th>
+            <th>Path</th>
+            <th>Time</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for item in items %}
+        <tr>
+            <td class="rank">{{ loop.index }}</td>
+            <td>
+                <div class="badge-row">
+                    {% for t in (item.attack_types or [item.attack_type]) %}
+                    <span class="method-badge method-{{ t | lower | replace('_', '-') | e }}">{{ t | e }}</span>
+                    {% endfor %}
+                </div>
+            </td>
+            <td class="ts-cell diff-{{ 'ok' if item.diff == 0 else 'near' }}">{{ item.diff }}</td>
+            <td class="data data-mono" title="Detector regex / fragment that matched">
+                {% if item.kind == 'file' %}
+                {{ item.content_type | default('') | e }}
+                {% else %}
+                {{ item.matched_pattern | default('(pattern)') | truncate(34) | e }}
+                {% endif %}
+            </td>
+            <td class="data data-mono">
+                <a href="#"
+                   class="data-link"
+                   @click.prevent="openIpInsight('{{ item.ip | default('') | e }}')">{{ item.ip | default('') | e }}</a>
+            </td>
+            <td class="data data-mono">
+                {% if item.kind == 'file' %}
+                <a href="#"
+                   class="data-link"
+                   data-filename="{{ item.filename | default('(untitled)') | e }}"
+                   @click.prevent="viewPayload({{ item.access_log_id }}, $event.currentTarget.dataset.filename)"
+                   title="View file">{{ item.filename | default('(untitled)') | e }}</a>
+                {% elif item.path %}
+                <a href="{{ item.path }}" class="data-link" target="_blank" rel="noopener" title="Open in Krawl">{{ item.path | truncate(30) | e }}</a>
+                {% else %}
+                <span class="muted"></span>
+                {% endif %}
+            </td>
+            <td class="ts-cell">{{ item.timestamp | format_ts }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="7" class="empty-state">No similar patterns within diff {{ threshold | default(150) }}</td></tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/src/templates/jinja2/dashboard/partials/suspicious_table.html
+++ b/src/templates/jinja2/dashboard/partials/suspicious_table.html
@@ -26,7 +26,7 @@
                     @click="toggleIpDetail($event)">
                     {{ activity.ip | e }}
                 </td>
-                <td>{{ activity.path | e }}</td>
+                <td><a href="#" class="data-link path-jump" data-path="{{ activity.path | e }}" @click.prevent="jumpToPath($event)">{{ activity.path | e }}</a></td>
                 <td class="break-all">{{ (activity.user_agent | default(''))[:80] | e }}</td>
                 <td class="ts-cell">{{ activity.timestamp | format_ts(time_only=True) }}</td>
                 <td>

--- a/src/templates/jinja2/dashboard/partials/top_paths_table.html
+++ b/src/templates/jinja2/dashboard/partials/top_paths_table.html
@@ -34,7 +34,7 @@
         {% for item in items %}
         <tr>
             <td class="rank">{{ loop.index + (pagination.page - 1) * pagination.page_size }}</td>
-            <td>{{ item.path | e }}</td>
+            <td><a href="#" class="data-link path-jump" data-path="{{ item.path | e }}" @click.prevent="jumpToPath($event)">{{ item.path | e }}</a></td>
             <td>{{ item.count }}</td>
         </tr>
         {% else %}

--- a/src/templates/static/css/dashboard.css
+++ b/src/templates/static/css/dashboard.css
@@ -852,6 +852,40 @@ tbody {
     font-weight: 700;
     letter-spacing: 0.04em;
 }
+.badge-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+    row-gap: 5px;
+}
+.badge-row .method-badge {
+    font-size: 0.8em;
+    padding: 1px 6px;
+}
+.diff-ok {
+    color: var(--ok);
+    font-weight: 700;
+}
+.diff-near {
+    color: var(--warn, #d29922);
+}
+.cluster-body {
+    display: inline-block;
+    max-width: 320px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: top;
+    font-family: var(--font-mono, monospace);
+    font-size: 0.78em;
+    color: color-mix(in srgb, var(--text-primary, #ddd) 75%, transparent);
+}
+.cluster-body[href] {
+    color: var(--accent);
+    cursor: pointer;
+    text-decoration: none;
+    border-bottom: 1px dotted color-mix(in srgb, var(--accent) 40%, transparent);
+}
 .method-get {
     border-color: color-mix(in srgb, var(--accent) 30%, transparent);
     background: color-mix(in srgb, var(--accent) 15%, transparent);
@@ -2394,6 +2428,93 @@ tbody {
 .view-btn:hover .view-btn-tooltip {
     opacity: 1;
 }
+/* Info icon + tooltip next to a column header (TL Hash) */
+.th-hint {
+    position: relative;
+    display: inline-block;
+    margin-left: 4px;
+    vertical-align: middle;
+    cursor: help;
+}
+.th-hint svg {
+    width: 14px;
+    height: 14px;
+    display: block;
+    opacity: 0.7;
+}
+.th-hint:hover svg {
+    opacity: 1;
+}
+.th-hint-tip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: var(--s1) var(--s2);
+    background: var(--raised);
+    color: var(--text-strong);
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    font-size: var(--fs-2xs);
+    font-weight: 400;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s;
+    z-index: var(--z-sticky);
+}
+.th-hint:hover .th-hint-tip {
+    opacity: 1;
+}
+/* Clickable table cells (IP Insight referers/paths, payload filenames, Threats) */
+.data-link {
+    color: var(--accent);
+    text-decoration: none;
+    cursor: pointer;
+    border-bottom: 1px dotted color-mix(in srgb, var(--accent) 45%, transparent);
+}
+.data-link:hover {
+    color: var(--accent-strong, var(--accent));
+    border-bottom-style: solid;
+}
+.campaign-cell-link {
+    display: block;
+    cursor: pointer;
+    text-decoration: none;
+    color: var(--text);
+}
+.campaign-target-link {
+    display: block;
+    max-width: 320px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-decoration: none;
+    color: var(--accent);
+}
+.campaign-target-link:hover {
+    color: var(--accent-strong, var(--accent));
+    text-decoration: underline;
+}
+.campaign-path-hint {
+    margin-top: 4px;
+    max-width: 320px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text-dim);
+    font-size: 0.85em;
+}
+.campaign-cell-link:hover .campaign-path-hint {
+    color: var(--accent);
+}
+.file-modal-meta {
+    display: flex;
+    gap: var(--s2);
+    padding-bottom: var(--s2);
+    color: var(--text-dim);
+    font-size: var(--fs-2xs);
+}
 #access-history-section table tr:not(:last-child) td {
     border-bottom: 1px solid var(--line);
 }
@@ -2846,6 +2967,7 @@ tbody {
 .expand-overlay-body {
     padding: var(--s4) var(--s6) var(--s5);
     overflow-y: auto;
+    overscroll-behavior: contain;
     flex: 1;
 }
 .expand-btn {

--- a/src/templates/static/js/charts.js
+++ b/src/templates/static/js/charts.js
@@ -423,3 +423,173 @@ function filterAttackTableByType(attackType) {
         htmx.ajax('GET', DASHBOARD_PATH + '/htmx/attacks?page=1&attack_type_filter=' + encodeURIComponent(attackType), { target: container, swap: 'innerHTML' });
     }
 }
+
+/**
+ * Attack Campaigns horizontal bar chart (Threats tab).
+ * One bar per payload cluster: captures vs distinct IPs. Clicking a bar
+ * opens the campaign members overlay. Day-navigable like the attack trends
+ * chart: each view is the top campaigns active on the selected day.
+ */
+let campaignsChart = null;
+let _campaignDays = 1;
+let _campaignOffset = 0;
+
+function _campaignEndDate() {
+    const d = new Date();
+    d.setDate(d.getDate() - (_campaignOffset * _campaignDays));
+    return d;
+}
+
+function _campaignStartDate() {
+    const d = _campaignEndDate();
+    d.setDate(d.getDate() - (_campaignDays - 1));
+    return d;
+}
+
+function _campaignLabel() {
+    const label = document.getElementById('campaigns-period-label');
+    if (label) {
+        const end = _campaignEndDate();
+        if (_campaignDays === 1) {
+            label.textContent = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+        } else {
+            label.textContent = `${_campaignStartDate().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} — ${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
+        }
+    }
+    const next = document.getElementById('campaigns-period-next');
+    if (next) next.disabled = _campaignOffset === 0;
+}
+
+async function loadCampaignsChart() {
+    const DASHBOARD_PATH = window.__DASHBOARD_PATH__ || '';
+
+    try {
+        const canvas = document.getElementById('campaigns-chart');
+        if (!canvas) return;
+
+        _campaignLabel();
+
+        const response = await fetch(
+            DASHBOARD_PATH + `/api/campaign-stats?limit=5&days=${_campaignDays}&offset=${_campaignOffset}`,
+            {
+                cache: 'no-store',
+                headers: { 'Cache-Control': 'no-cache', 'Pragma': 'no-cache' }
+            }
+        );
+        if (!response.ok) throw new Error('Failed to fetch campaign stats');
+
+        const data = await response.json();
+        const campaigns = data.campaigns || [];
+
+        if (campaignsChart) campaignsChart.destroy();
+
+        if (campaigns.length === 0) {
+            canvas.parentElement.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-dim);font-size:13px;">No campaigns in this period</div>';
+            return;
+        }
+
+        const labels = campaigns.map(c => c.label || (c.id || '').slice(0, 8));
+
+        const ctx = canvas.getContext('2d');
+        campaignsChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Captures',
+                        data: campaigns.map(c => c.captures),
+                        backgroundColor: 'hsl(210, 85%, 60%)',
+                        hoverBackgroundColor: 'hsl(210, 85%, 68%)'
+                    },
+                    {
+                        label: 'Distinct IPs',
+                        data: campaigns.map(c => c.ips),
+                        backgroundColor: 'hsl(280, 70%, 65%)',
+                        hoverBackgroundColor: 'hsl(280, 70%, 73%)'
+                    }
+                ]
+            },
+            options: {
+                indexAxis: 'y',
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        labels: { color: krawlToken('--text') }
+                    },
+                    tooltip: {
+                        backgroundColor: 'rgba(22, 27, 34, 0.95)',
+                        titleColor: krawlToken('--accent'),
+                        bodyColor: krawlToken('--text'),
+                        borderColor: krawlToken('--accent'),
+                        borderWidth: 2,
+                        padding: 14,
+                        callbacks: {
+                            label: (context) =>
+                                `${context.dataset.label}: ${context.parsed.x}`,
+                            afterLabel: (context) => {
+                                const c = campaigns[context.dataIndex];
+                                const parts = [`source: ${c.sources}`];
+                                if (c.top_path) parts.push(`most hit target: ${c.top_path}`);
+                                if (c.first_seen) parts.push(`first: ${new Date(c.first_seen).toLocaleString()}`);
+                                if (c.last_seen) parts.push(`last: ${new Date(c.last_seen).toLocaleString()}`);
+                                return parts;
+                            }
+                        }
+                    }
+                },
+                animation: { enabled: false },
+                onClick: (evt, elements) => {
+                    if (!elements.length) return;
+                    const c = campaigns[elements[0].index];
+                    window.openExpandOverlay(c.label, 'campaign', '', c.id);
+                },
+                onHover: (event, activeElements) => {
+                    const canvas = event.native && event.native.target;
+                    if (canvas) canvas.style.cursor = activeElements.length > 0 ? 'pointer' : 'default';
+                },
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        grid: { color: 'rgba(255,255,255,0.06)' },
+                        ticks: { color: krawlToken('--text-dim'), precision: 0 }
+                    },
+                    y: {
+                        grid: { display: false },
+                        ticks: { color: krawlToken('--text-dim'), font: { size: 11 } }
+                    }
+                }
+            },
+            plugins: [{
+                id: 'customCanvasBackgroundColor',
+                beforeDraw: (chart) => {
+                    if (chart.ctx) {
+                        chart.ctx.save();
+                        chart.ctx.globalCompositeOperation = 'destination-over';
+                        chart.ctx.fillStyle = 'rgba(0,0,0,0)';
+                        chart.ctx.fillRect(0, 0, chart.width, chart.height);
+                        chart.ctx.restore();
+                    }
+                }
+            }]
+        });
+    } catch (err) {
+        console.error('Error loading campaigns chart:', err);
+    }
+}
+
+/** Shift the campaigns chart period by N spans (negative = newer, towards now) */
+function shiftCampaignPeriod(direction) {
+    _campaignOffset = Math.max(0, _campaignOffset + direction);
+    loadCampaignsChart();
+}
+
+/** Switch the campaigns chart span (1, 7, 30 days) and reset to the current period */
+function setCampaignSpan(days, btn) {
+    _campaignDays = days;
+    _campaignOffset = 0;
+    document.querySelectorAll('#campaigns-span-selector .map-limit-btn').forEach(b => b.classList.remove('active'));
+    if (btn) btn.classList.add('active');
+    loadCampaignsChart();
+}

--- a/src/templates/static/js/dashboard.js
+++ b/src/templates/static/js/dashboard.js
@@ -398,6 +398,9 @@ document.addEventListener('alpine:init', () => {
         // Raw request modal
         rawModal: { show: false, content: '', highlightedContent: '', logId: null, attachments: [], attachmentsShow: false, hasAttachments: false },
 
+        // Captured file viewer modal
+        fileModal: { show: false, content: '', filename: '', contentType: '', size: '', logId: null, index: null },
+
         // Map state
         mapInitialized: false,
 
@@ -415,8 +418,18 @@ document.addEventListener('alpine:init', () => {
         // Expand overlay state
         expandOverlay: { show: false, title: '', endpoint: '', pageSize: 25, search: '', categories: [], honeypotOnly: false, method: '', attackType: '', attackTypes: [], ipFilter: '' },
 
+        // LIFO of active popups (raw/file modal can open over the expand
+        // overlay); ESC closes only the most recently opened one.
+        _popupStack: [],
+
         // Flag to prevent double-triggering during init
         _initializingHash: false,
+
+        _trackPopup(show, key) {
+            const idx = this._popupStack.indexOf(key);
+            if (show && idx === -1) this._popupStack.push(key);
+            else if (!show && idx !== -1) this._popupStack.splice(idx, 1);
+        },
 
         async init() {
             // Check if already authenticated (cookie-based)
@@ -428,6 +441,26 @@ document.addEventListener('alpine:init', () => {
             // Sync ban action button visibility with auth state
             this.$watch('authenticated', (val) => updateBanActionVisibility(val));
             updateBanActionVisibility(this.authenticated);
+
+            // Track popup z-order so Escape closes only the topmost one.
+            this.$watch('expandOverlay.show', (show) => {
+                document.body.style.overflow = show ? 'hidden' : '';
+                this._trackPopup(show, 'overlay');
+            });
+            this.$watch('rawModal.show', (show) => this._trackPopup(show, 'raw'));
+            this.$watch('fileModal.show', (show) => this._trackPopup(show, 'file'));
+            this.$watch('authModal.show', (show) => this._trackPopup(show, 'auth'));
+            this.$watch('exportModal.show', (show) => this._trackPopup(show, 'export'));
+            document.addEventListener('keydown', (e) => {
+                if (e.key !== 'Escape') return;
+                if (!this._popupStack.length) return;
+                const top = this._popupStack[this._popupStack.length - 1];
+                if (top === 'overlay') this.expandOverlay.show = false;
+                else if (top === 'raw') this.closeRawModal();
+                else if (top === 'file') this.closeFileModal();
+                else if (top === 'auth') this.authModal.show = false;
+                else if (top === 'export') this.exportModal.show = false;
+            });
 
             // Fetch banlist sources when export modal opens
             this.$watch('exportModal.show', async (show) => {
@@ -459,6 +492,8 @@ document.addEventListener('alpine:init', () => {
                 this.switchToDeception();
             } else if (hash === 'webhooks' && this.authenticated) {
                 this.switchToWebhooks();
+            } else if (hash === 'threats') {
+                this.switchToThreats();
 
             } else if (hash === 'overview' || !hash) {
                 this.switchToOverview();
@@ -486,6 +521,8 @@ document.addEventListener('alpine:init', () => {
                         if (this.authenticated) this.switchToDeception();
                     } else if (h === 'webhooks') {
                         if (this.authenticated) this.switchToWebhooks();
+                    } else if (h === 'threats') {
+                        if (this.tab !== 'threats') this.switchToThreats();
                     } else if (h !== 'ip-insight') {
                         if (this.tab !== 'ip-insight') {
                             this.switchToOverview();
@@ -594,6 +631,28 @@ document.addEventListener('alpine:init', () => {
                 if (container && typeof htmx !== 'undefined') {
                     htmx.ajax('GET', `${this.dashboardPath}/htmx/webhooks`, {
                         target: '#webhooks-htmx-container',
+                        swap: 'innerHTML'
+                    });
+                }
+            });
+        },
+
+        switchToThreats() {
+            if (this.tab === 'threats') return;
+            this.tab = 'threats';
+            window.location.hash = '#threats';
+            this.$nextTick(() => {
+                if (typeof loadCampaignsChart === 'function') {
+                    loadCampaignsChart();
+                }
+                const container = document.getElementById('threats-htmx-container');
+                if (container && typeof htmx !== 'undefined') {
+                    htmx.ajax('GET', `${this.dashboardPath}/htmx/global-filenames?page=1`, {
+                        target: '#threats-htmx-container',
+                        swap: 'innerHTML'
+                    });
+                    htmx.ajax('GET', `${this.dashboardPath}/htmx/pattern-clusters`, {
+                        target: '#patterns-htmx-container',
                         swap: 'innerHTML'
                     });
                 }
@@ -767,6 +826,10 @@ document.addEventListener('alpine:init', () => {
             // Collapse any open search results before switching to the insight tab
             this.collapseSearch();
 
+            // Close any popup overlaying the dashboard (campaign / similar
+            // panel) when navigating to the IP insight tab.
+            this.expandOverlay.show = false;
+
             // Set the IP and load the insight content
             this.insightIp = ip;
             this.tab = 'ip-insight';
@@ -917,6 +980,57 @@ document.addEventListener('alpine:init', () => {
             a.click();
             document.body.removeChild(a);
             this.rawModal.attachmentsShow = false;
+        },
+
+        async viewPayload(logId, filename) {
+            try {
+                const resp = await fetch(
+                    `${this.dashboardPath}/api/attachments/${logId}`,
+                    { cache: 'no-store' }
+                );
+                const data = await resp.json();
+                const list = data.attachments || [];
+                let att = list.find(a => a.filename === filename);
+                if (!att && list.length) att = list[0];
+                if (!att) {
+                    krawlModal.error('No file content available');
+                    return;
+                }
+                const contentResp = await fetch(
+                    `${this.dashboardPath}/api/attachments/${logId}/download/${att.index}`,
+                    { cache: 'no-store' }
+                );
+                if (!contentResp.ok) throw new Error('download failed');
+                this.fileModal.logId = logId;
+                this.fileModal.index = att.index;
+                this.fileModal.filename = att.filename || filename || 'file';
+                this.fileModal.contentType = att.content_type || '';
+                this.fileModal.size = att.size != null ? `${att.size} B` : '';
+                this.fileModal.content = await contentResp.text();
+                this.fileModal.show = true;
+            } catch (err) {
+                krawlModal.error('Failed to load file content');
+            }
+        },
+
+        closeFileModal() {
+            this.fileModal.show = false;
+            this.fileModal.content = '';
+            this.fileModal.filename = '';
+            this.fileModal.contentType = '';
+            this.fileModal.size = '';
+            this.fileModal.logId = null;
+            this.fileModal.index = null;
+        },
+
+        downloadPayloadFile() {
+            if (this.fileModal.logId == null || this.fileModal.index == null) return;
+            const a = document.createElement('a');
+            a.href = `${this.dashboardPath}/api/attachments/${this.fileModal.logId}/download/${this.fileModal.index}`;
+            a.download = this.fileModal.filename || 'file';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
         },
 
         toggleIpDetail(event) {
@@ -1460,15 +1574,15 @@ window.submitUploadPage = async function() {
 };
 
 // === Expand overlay for Top X tables ===
-window.openExpandOverlay = function(title, endpoint, pageSize) {
+window.openExpandOverlay = function(title, endpoint, pageSize, cluster, searchVal) {
     const app = _getAlpineData();
     if (!app) return;
     Object.assign(app.expandOverlay, {
         show: true, title: title, endpoint: endpoint,
-        pageSize: pageSize || 25, search: '',
+        pageSize: pageSize || 25, search: searchVal || '',
         categories: [], honeypotOnly: false,
         method: '', attackType: '', attackTypes: [],
-        ipFilter: '',
+        ipFilter: '', cluster: cluster || '',
     });
     _reloadExpandOverlay();
     // For attacks, lazily load the list of distinct attack types for the
@@ -1476,6 +1590,12 @@ window.openExpandOverlay = function(title, endpoint, pageSize) {
     if (endpoint === 'attacks') {
         _loadExpandAttackTypes();
     }
+};
+
+window.jumpToPath = function(event) {
+    if (!window.openExpandOverlay) return;
+    const path = (event.currentTarget.getAttribute('data-path') || '').trim();
+    openExpandOverlay('Attacks on ' + path, 'attacks', 25, '', path);
 };
 
 window.triggerExpandSearch = function() {
@@ -1563,8 +1683,18 @@ function _reloadExpandOverlay() {
     }
 
     const url = `${dashboardPath}/htmx/${ov.endpoint}?${params}`;
+
+    let targetUrl = url;
+    if (ov.endpoint === 'campaign') {
+        const cv = ov.cluster ? `?cluster=${encodeURIComponent(ov.cluster)}` : '';
+        targetUrl = `${dashboardPath}/htmx/cluster-events${cv}`;
+    } else if (ov.endpoint === 'similar') {
+        const sv = ov.cluster ? `?tlsh=${encodeURIComponent(ov.cluster)}` : '';
+        targetUrl = `${dashboardPath}/htmx/similar-events${sv}`;
+    }
+
     container.innerHTML = '<div style="text-align: center; padding: 40px; color: var(--text-dim);">Loading...</div>';
-    htmx.ajax('GET', url, { target: container, swap: 'innerHTML' });
+    htmx.ajax('GET', targetUrl, { target: container, swap: 'innerHTML' });
 }
 
 // Escape HTML to prevent XSS when inserting into innerHTML

--- a/src/tlsh_utils.py
+++ b/src/tlsh_utils.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+
+"""
+TLSH fuzzy-hash helpers for near-duplicate payload clustering.
+
+Wraps the optional `tlsh` (py-tlsh) C extension with safe guards:
+py-tlsh returns "TNULL" when input is too short or lacks entropy, and throws
+on some operations against such input. All callers must tolerate a None result.
+
+The module imports lazily so Krawl still boots when the C extension is absent
+(only the clustering feature degrades).
+"""
+
+import hashlib
+import logging
+import re
+from email import policy
+from email.parser import Parser
+
+logger = logging.getLogger("krawl")
+
+try:  # pragma: no cover - exercised only when the C extension is installed
+    import tlsh as _tlsh
+except Exception:  # pragma: no cover
+    _tlsh = None
+
+_MIN_TLSH_INPUT = 50
+
+# Similarity threshold for tlsh.diff(): 0 = identical, higher = more different.
+# 200 is the recommended "different" cutoff; variants of the same payload are
+# typically < 100.
+SIMILARITY_THRESHOLD = 150
+
+
+def tlsh_available() -> bool:
+    """True if the TLSH C extension is importable."""
+    return _tlsh is not None
+
+
+def tlsh_hash(data: bytes) -> str | None:
+    """Return the TLSH digest for bytes, or None if unsupported/too small.
+
+    TLSH needs >= ~50 bytes with enough entropy; uniform/near-uniform data
+    produces TNULL which we map to None (meaning "not clusterable").
+    """
+    if _tlsh is None or not data or len(data) < _MIN_TLSH_INPUT:
+        return None
+    try:
+        digest = _tlsh.hash(data)
+    except Exception as e:
+        logger.debug(f"TLSH hash failed: {e}")
+        return None
+    if not digest or digest == "TNULL":
+        return None
+    return digest
+
+
+def sha256_hash(data: bytes) -> str:
+    """Exact SHA-256 of the payload, complementing the fuzzy TLSH digest."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def tlsh_diff(h1: str | None, h2: str | None) -> int | None:
+    """TLSH distance (0 = identical, higher = more different), or None if
+    either digest is unavailable/invalid. Similarity checkers should compare
+    the result against SIMILARITY_THRESHOLD."""
+    if _tlsh is None or not h1 or not h2:
+        return None
+    try:
+        return _tlsh.diff(h1, h2)
+    except Exception:
+        return None
+
+
+def is_similar(h1: str | None, h2: str | None, threshold: int = SIMILARITY_THRESHOLD) -> bool:
+    """True if two TLSH digests are within the similarity threshold."""
+    d = tlsh_diff(h1, h2)
+    return d is not None and d <= threshold
+
+
+_FILE_CONTENT_TYPES = {
+    "application/octet-stream",
+    "application/x-php",
+    "application/x-sh",
+    "application/x-httpd-php",
+    "text/php",
+    "application/zip",
+    "application/x-tar",
+    "application/gzip",
+    "application/pdf",
+    "application/msword",
+}
+
+
+def _is_file_content_type(content_type: str) -> bool:
+    ct = (content_type or "").lower().split(";")[0].strip()
+    return ct in _FILE_CONTENT_TYPES or any(
+        ct.startswith(p)
+        for p in ("image/", "audio/", "video/", "font/", "application/x-ms")
+    )
+
+
+def extract_file_payloads(raw_request: str, max_files: int = 8) -> list[dict]:
+    """Parse file uploads out of a raw HTTP request.
+
+    Returns a list of {filename, content_type, size, content, tlsh_hash, sha256}.
+    Content is retained (it is what TLSH hashes); callers decide what to index.
+    Bytes are used only for hashing — the raw_request column already stores the
+    full body for forensic use.
+    """
+    if not raw_request:
+        return []
+    try:
+        header_end = raw_request.find("\r\n\r\n")
+        if header_end < 0:
+            return []
+        headers_text = raw_request[:header_end]
+        body = raw_request[header_end + 4 :]
+        if not body:
+            return []
+
+        ct_match = re.search(r"[Cc]ontent-[Tt]ype:\s*([^\r\n]+)", headers_text)
+        content_type = ct_match.group(1) if ct_match else ""
+
+        results: list[dict] = []
+        if content_type.startswith("multipart/form-data"):
+            b_match = re.search(r"boundary=([^\s;]+)", content_type)
+            if not b_match:
+                return []
+            if not body.endswith("\r\n"):
+                body += "\r\n"
+            msg = Parser(policy=policy.compat32).parsestr(
+                f"Content-Type: {content_type}\r\n\r\n{body}"
+            )
+            for part in msg.walk():
+                if part.get_content_maintype() == "multipart":
+                    continue
+                disp = part.get("Content-Disposition", "")
+                has_file = "attachment" in disp or part.get_filename()
+                if not has_file:
+                    continue
+                filename = part.get_filename() or ""
+                payload = part.get_payload(decode=True)
+                if payload is None:
+                    payload = b""
+                results.append(
+                    {
+                        "filename": filename,
+                        "content_type": part.get_content_type()
+                        or "application/octet-stream",
+                        "size": len(payload),
+                        "content": payload,
+                        "tlsh_hash": tlsh_hash(payload),
+                        "sha256": sha256_hash(payload),
+                    }
+                )
+                if len(results) >= max_files:
+                    break
+        elif _is_file_content_type(content_type):
+            payload = body.encode("utf-8", errors="replace")
+            results.append(
+                {
+                    "filename": "",
+                    "content_type": content_type.split(";")[0].strip(),
+                    "size": len(payload),
+                    "content": payload,
+                    "tlsh_hash": tlsh_hash(payload),
+                    "sha256": sha256_hash(payload),
+                }
+            )
+        # Drop unhashable/oversized content after hashing; only metadata persists.
+        for r in results:
+            r["content"] = None
+        return results
+    except Exception as e:
+        logger.debug(f"extract_file_payloads failed: {e}")
+        return []

--- a/src/tlsh_utils.py
+++ b/src/tlsh_utils.py
@@ -72,7 +72,9 @@ def tlsh_diff(h1: str | None, h2: str | None) -> int | None:
         return None
 
 
-def is_similar(h1: str | None, h2: str | None, threshold: int = SIMILARITY_THRESHOLD) -> bool:
+def is_similar(
+    h1: str | None, h2: str | None, threshold: int = SIMILARITY_THRESHOLD
+) -> bool:
     """True if two TLSH digests are within the similarity threshold."""
     d = tlsh_diff(h1, h2)
     return d is not None and d <= threshold

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -3,9 +3,11 @@
 import logging
 import re
 import urllib.parse
+from datetime import datetime
 
 from database import DatabaseManager, get_database
 from ip_utils import is_ignored_ip
+from tlsh_utils import tlsh_available, tlsh_hash
 from wordlists import get_wordlists
 
 logger = logging.getLogger("krawl")
@@ -151,6 +153,8 @@ class AccessTracker:
         method: str = "GET",
         raw_request: str = "",
         increment_page_visit: bool = False,
+        referer: str = "",
+        file_payloads: list[dict] | None = None,
     ) -> int:
         """
         Record an access attempt.
@@ -166,6 +170,8 @@ class AccessTracker:
             method: HTTP method
             raw_request: Full raw HTTP request for forensic analysis
             increment_page_visit: Also bump page visit counter in the same DB tx
+            referer: Inbound HTTP Referer header (bait-chain tracking)
+            file_payloads: Uploaded-file dicts to persist as captured_payloads rows
 
         Returns:
             The page visit count (0 when increment_page_visit is False or on error)
@@ -187,6 +193,18 @@ class AccessTracker:
         path_exclude = {"login_attempt"} if method != "POST" else None
         attack_findings = self.detect_attack_type(path, exclude=path_exclude)
 
+        # Bait-chain referer + file payloads are derived from the raw request so
+        # every recording path (honeypot dependency, catch-all POST, deception
+        # middleware) captures them even when the caller didn't thread them through.
+        if not referer and raw_request and config.referer_enabled:
+            _m = re.search(r"\r\nReferer:\s*([^\r\n]+)", raw_request, re.IGNORECASE)
+            if _m:
+                referer = _m.group(1).strip()
+        if file_payloads is None and raw_request and config.tlsh_enabled:
+            from tlsh_utils import extract_file_payloads
+
+            file_payloads = extract_file_payloads(raw_request)
+
         # common_probes and login_attempt are path-based — skip them on body to avoid
         # false positives from form fields like redirect_to=/wp-admin/
         if len(body) > 0:
@@ -198,15 +216,54 @@ class AccessTracker:
             )
             # If credentials were submitted (even on non-login paths like AI-generated pages),
             # tag as login_attempt
-            if method == "POST" and "login_attempt" not in attack_findings:
+            if method == "POST" and not any(
+                t == "login_attempt" for t, _ in attack_findings
+            ):
                 username, password = self.parse_credentials(decoded_body)
                 if username or password:
-                    attack_findings.append("login_attempt")
+                    attack_findings.append(("login_attempt", "/login"))
+
+        attack_types = [t for t, _ in attack_findings]
+        matched_patterns = {t: m for t, m in attack_findings}
+
+        # TLSH fuzzy hash of the payload (decoded body, or path for path-only hits)
+        # for near-duplicate variant clustering across attackers.
+        tlsh_hashes: dict[str, str] = {}
+        if attack_findings and config.tlsh_enabled and tlsh_available():
+            _payload = (urllib.parse.unquote(body) if body else path).encode(
+                "utf-8", errors="replace"
+            )
+            _digest = tlsh_hash(_payload)
+            if _digest:
+                for t in attack_types:
+                    tlsh_hashes[t] = _digest
+
+        # Incremental campaign clustering: assign each distinct digest to a
+        # cluster (or seed a new one) before persisting, so every row carries
+        # its cluster_id and the Recurring Patterns panel needs no per-query O(n²).
+        tlsh_clusters: dict[str, str] = {}
+        if tlsh_hashes and self.db:
+            _seen_ts = datetime.now()
+            _by_digest: dict[str, str] = {}
+            for t, digest in tlsh_hashes.items():
+                cid = _by_digest.get(digest) or self.db.payloads.assign_cluster(
+                    digest, _seen_ts, threshold=config.tlsh_cluster_threshold
+                )
+                if cid:
+                    _by_digest[digest] = cid
+                    tlsh_clusters[t] = cid
+        if file_payloads and self.db:
+            _seen_ts = datetime.now()
+            for fp in file_payloads:
+                if fp.get("tlsh_hash") and not fp.get("cluster_id"):
+                    fp["cluster_id"] = self.db.payloads.assign_cluster(
+                        fp["tlsh_hash"], _seen_ts, threshold=config.tlsh_cluster_threshold
+                    )
 
         is_suspicious = (
             self.is_suspicious_user_agent(user_agent)
             or self.is_honeypot_path(path)
-            or len(attack_findings) > 0
+            or len(attack_types) > 0
         )
         is_honeypot = self.is_honeypot_path(path)
 
@@ -220,8 +277,13 @@ class AccessTracker:
                     method=method,
                     is_suspicious=is_suspicious,
                     is_honeypot_trigger=is_honeypot,
-                    attack_types=attack_findings if attack_findings else None,
+                    attack_types=attack_types if attack_types else None,
+                    matched_patterns=matched_patterns if matched_patterns else None,
+                    tlsh_hashes=tlsh_hashes if tlsh_hashes else None,
+                    tlsh_clusters=tlsh_clusters if tlsh_clusters else None,
                     raw_request=raw_request if raw_request else None,
+                    referer=referer if referer else None,
+                    file_payloads=file_payloads,
                     increment_page_visit=increment_page_visit,
                     max_pages_limit=self.max_pages_limit if increment_page_visit else 0,
                 )
@@ -231,16 +293,17 @@ class AccessTracker:
 
     def detect_attack_type(
         self, data: str, exclude: set[str] | None = None
-    ) -> list[str]:
+    ) -> list[tuple[str, str]]:
         """
-        Returns a list of all attack types found in path data
+        Returns a list of (attack_type, matched_substring) tuples found in data.
         """
         findings = []
         for name, pattern in self.attack_types.items():
             if exclude and name in exclude:
                 continue
-            if re.search(pattern, data, re.IGNORECASE):
-                findings.append(name)
+            m = re.search(pattern, data, re.IGNORECASE)
+            if m:
+                findings.append((name, m.group(0)[:256]))
         return findings
 
     def is_honeypot_path(self, path: str) -> bool:

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -257,7 +257,9 @@ class AccessTracker:
             for fp in file_payloads:
                 if fp.get("tlsh_hash") and not fp.get("cluster_id"):
                     fp["cluster_id"] = self.db.payloads.assign_cluster(
-                        fp["tlsh_hash"], _seen_ts, threshold=config.tlsh_cluster_threshold
+                        fp["tlsh_hash"],
+                        _seen_ts,
+                        threshold=config.tlsh_cluster_threshold,
                     )
 
         is_suspicious = (

--- a/tests/test_threat_capture.py
+++ b/tests/test_threat_capture.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+
+"""End-to-end check: referer + TLSH + captured file payloads persist through
+tracker.record_access -> database.persist_access (standalone path)."""
+
+import os
+import sqlite3
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import database as dbpkg  # noqa: E402
+
+
+def build_raw_request(method, path, content_type, body=""):
+    return (
+        f"{method} {path} HTTP/1.1\r\n"
+        "Host: krawl.test\r\n"
+        f"Content-Type: {content_type}\r\n"
+        "User-Agent: test-agent\r\n"
+        f"\r\n{body}"
+    )
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        dbpkg.DatabaseManager._instance = None
+        db = dbpkg.DatabaseManager()
+        db.initialize(database_path=os.path.join(tmp, "krawl.db"), mode="standalone")
+
+        from config import get_config
+        from models import CapturedPayload
+        from tlsh_utils import (
+            SIMILARITY_THRESHOLD,
+            tlsh_available,
+            tlsh_diff,
+            tlsh_hash,
+        )
+        from tracker import AccessTracker
+
+        cfg = get_config()
+        tracker = AccessTracker(
+            cfg.max_pages_limit, cfg.ban_duration_seconds, db_manager=db
+        )
+
+        big = "<?php system(\\'x\\'); ?>" + "A9bC7dX2eF" * 60
+        multipart_body = (
+            f'--xxx\r\nContent-Disposition: form-data; name="file"; filename="c99shell.php"\r\n'
+            f"Content-Type: application/x-php\r\n\r\n{big}\r\n--xxx--\r\n"
+        )
+        code = tracker.record_access(
+            ip="203.0.113.9",
+            path="/upload.php",
+            user_agent="UA",
+            body="a=b",
+            method="POST",
+            raw_request=build_raw_request(
+                "POST",
+                "/upload.php",
+                "multipart/form-data; boundary=xxx",
+                multipart_body,
+            ),
+            referer="http://evil.example.com/bait.php",
+            file_payloads=[
+                {
+                    "filename": "c99shell.php",
+                    "content_type": "application/x-php",
+                    "size": len(big),
+                    "tlsh_hash": "T179E0F1CABEAA03FD5ABA1741C04CF490938454BA3419C09FA018516619CD0ABE420409",
+                    "sha256": "b" * 64,
+                }
+            ],
+        )
+        assert code is not None, "record_access returned no code"
+
+        con = sqlite3.connect(os.path.join(tmp, "krawl.db"))
+        try:
+            assert con.execute("SELECT COUNT(*) FROM access_logs").fetchone()[0] == 1
+            ref = con.execute("SELECT referer FROM access_logs").fetchone()[0]
+            assert ref == "http://evil.example.com/bait.php", ref
+            payloads = con.execute(
+                "SELECT filename, tlsh_hash, sha256, access_log_id FROM captured_payloads"
+            ).fetchall()
+            assert len(payloads) == 1, payloads
+            fname, tl, sha, log_id = payloads[0]
+            assert fname == "c99shell.php", fname
+            assert tl.startswith("T"), tl
+            assert len(sha) == 64, sha
+            assert log_id == 1, log_id
+        finally:
+            con.close()
+
+        if tlsh_available():
+            base = "<?php system('x'); ?>" + "".join(
+                f"{c}{i}{c}{i * 2}" for c in "abcXYZ0129" for i in range(6)
+            )
+            variant = base.replace("system('", "shell_ex('")
+            unrelated = "SELECT pg_sleep FROM information_schema.tables WHERE 1=1 -- " * 4
+            h_base = tlsh_hash(base.encode())
+            h_var = tlsh_hash(variant.encode())
+            h_un = tlsh_hash(unrelated.encode())
+            assert h_base and h_var and h_un, "TLSH returned None for test payloads"
+            assert h_var != h_base, "mutated payload must not hash identically"
+            assert tlsh_diff(h_base, h_var) <= SIMILARITY_THRESHOLD, tlsh_diff(h_base, h_var)
+            assert tlsh_diff(h_base, h_un) > SIMILARITY_THRESHOLD, tlsh_diff(h_base, h_un)
+
+            # Integration: a body-flagged attack must land with a cluster_id
+            # end-to-end through record_access -> persist_access.
+            attack_body = (
+                "username=admin&password=x' OR '1'='1'--"
+                "&csrf="
+                + "R4nd0m" * 8
+                + "A9bC7dX2eF" * 4
+            )
+            tracker.record_access(
+                ip="198.51.100.9",
+                path="/login.php",
+                user_agent="UA",
+                body=attack_body,
+                method="POST",
+            )
+            from models import AttackDetection as AD
+
+            live_dets = db.session.query(AD).all()
+            assert live_dets, "no attack detections recorded"
+            for d in live_dets:
+                assert d.cluster_id, (
+                    f"{d.attack_type} attack row missing cluster_id (integration)"
+                )
+
+            db.payloads.add_payload(
+                access_log_id=1,
+                ip="198.51.100.4",
+                filename="c99shell-v2.php",
+                content_type="application/x-php",
+                size=len(variant),
+                tlsh_hash=h_var,
+                sha256="c" * 64,
+            )
+            db.payloads.add_payload(
+                access_log_id=1,
+                ip="198.51.100.5",
+                filename="unrelated.txt",
+                content_type="text/plain",
+                size=len(unrelated),
+                tlsh_hash=h_un,
+                sha256="d" * 64,
+            )
+            similar = db.payloads.get_similar_events(base_hash=h_base)
+            names = {r["filename"] for r in similar if r["kind"] == "file"}
+            assert "c99shell-v2.php" in names, names
+            assert "unrelated.txt" not in names, names
+            print("fuzzy similar events clustering: OK")
+
+            # Incremental campaign clustering (instruction 5/8).
+            from datetime import datetime, timedelta
+
+            t0 = datetime(2026, 1, 1, 12, 0, 0)
+            c1 = db.payloads.assign_cluster(h_base, t0)
+            assert c1, "identical digest must seed a cluster"
+            c1_again = db.payloads.assign_cluster(h_base, t0 + timedelta(hours=1))
+            assert c1_again == c1, "identical digest must join the same cluster"
+            c2 = db.payloads.assign_cluster(h_var, t0 + timedelta(hours=2))
+            assert c2 == c1, "near-variant (diff<=threshold) must join the same cluster"
+            c3 = db.payloads.assign_cluster(h_un, t0 + timedelta(hours=3))
+            assert c3 != c1, "unrelated digest must seed a separate cluster"
+            assert db.payloads.assign_cluster(None, t0) is None
+            s = db.session
+            s.query(CapturedPayload).filter(
+                CapturedPayload.filename == "c99shell-v2.php"
+            ).update({"cluster_id": c1})
+            s.query(CapturedPayload).filter(
+                CapturedPayload.filename == "unrelated.txt"
+            ).update({"cluster_id": c3})
+            s.commit()
+            db.close_session()
+            campaigns = db.payloads.get_campaign_clusters()
+            c_row = next(c for c in campaigns if c["id"] == c1)
+            assert c_row["events"] >= 3, c_row  # capture_count from incremental assigns
+            assert c_row["ips"] >= 1, c_row
+            assert any(c["id"] == c3 and c["events"] == 1 for c in campaigns), campaigns
+            members = db.payloads.get_cluster_events(c1)
+            assert any(m["filename"] == "c99shell-v2.php" for m in members), members
+
+            # One request flagged by several detectors must render as a single
+            # grouped row (common_probes + sql_injection + ... on one upload).
+            from models import AccessLog
+
+            login_log_ids = [
+                r[0]
+                for r in db.session.query(AccessLog.id)
+                .filter(AccessLog.path == "/login.php")
+                .all()
+            ]
+            assert login_log_ids, "no access log for the login.php attack"
+            det_rows = (
+                db.session.query(AD.tlsh_hash, AD.attack_type)
+                .filter(AD.access_log_id.in_(login_log_ids))
+                .all()
+            )
+            assert det_rows, "no detections for the login.php attack"
+            hash0 = det_rows[0][0]
+            assert hash0, "login attack has no TLSH hash"
+            expected = sorted({t for _, t in det_rows})
+            c_attack = db.payloads.assign_cluster(hash0, t0 + timedelta(hours=4))
+            (
+                db.session.query(AD)
+                .filter(AD.access_log_id.in_(login_log_ids))
+                .update({"cluster_id": c_attack})
+            )
+            db.session.commit()
+            db.close_session()
+            attack_rows = [
+                m for m in db.payloads.get_cluster_events(c_attack)
+                if m["kind"] == "attack"
+            ]
+            assert len(attack_rows) == 1, attack_rows
+            assert sorted(attack_rows[0]["attack_types"]) == expected, attack_rows
+            print("grouped multi-detection campaign rows: OK")
+            print("incremental campaign clustering: OK")
+        else:  # pragma: no cover
+            print("fuzzy similar events: SKIPPED (py-tlsh not installed)")
+        print("threat capture standalone persistence: OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<img width="1556" height="1052" alt="immagine" src="https://github.com/user-attachments/assets/36eb8ea2-d983-4efc-a24d-49e409e0a564" />

# Summary

Threat actors reuse the same webshells, scan tools, and payload templates with minor variations. This enhancement fingerprints captured payloads (uploaded files + flagged request bodies) with TLSH fuzzy hashing, groups near-duplicate variants into campaign clusters, tracks inbound Referer headers for bait-chain analysis, and surfaces it all in the dashboard.
What's new
Campaign clustering (backend)
- py-tlsh fuzzy hashing of captured files and flagged request bodies; variants within the configured threshold join the same campaign (payload_clusters table, representative-hash membership).
- scripts/backfill_clusters.py to cluster pre-existing rows.
Threats dashboard tab
- Attack Campaigns chart: top 5 campaigns by volume, with 1D / 7D / 30D window selector and period paging; click a bar to open its members.
- Campaign Members table: attack-type badges, campaign-hash identity (mono hint), Most Hit Target column (clickable → campaign drill-down).
- TL Hash cells: show the campaign hash (→ campaign members) for clustered rows, member TLSH (→ similar threats) otherwise.
- Captured Files global index, Similar Threats and Cluster Events drill-down overlays, and a file viewer/download modal.
- Clickable paths on Recent Suspicious Activity and Top Paths jump straight to the matching attacks.

Closing #258 #250 #251 