### PR TITLE
fix: postgres-compatible backfill scalar for campaign clustering

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.3.8
-appVersion: 2.3.8
+version: 2.3.9
+appVersion: 2.3.9
 keywords:
   - honeypot
   - security

--- a/src/database/payloads.py
+++ b/src/database/payloads.py
@@ -30,6 +30,14 @@ def _request_body(raw_request: str | None) -> str | None:
     return unquote(body) if body else None
 
 
+def _scalar_min_max(db) -> tuple[Any, Any]:
+    """Two-argument scalar min/max: sqlite's func.min(col, val) works, but
+    postgres only has aggregate min/max and needs LEAST/GREATEST instead."""
+    if db.engine.dialect.name == "postgresql":
+        return func.least, func.greatest
+    return func.min, func.max
+
+
 applogger = get_app_logger()
 
 
@@ -316,6 +324,7 @@ class PayloadRepo:
                 if d is not None and d <= threshold and (best is None or d < best):
                     best, match_id = d, cid
             if match_id:
+                smin, smax = _scalar_min_max(self._db)
                 session.execute(
                     PayloadCluster.__table__.update()
                     .where(PayloadCluster.id == match_id)
@@ -323,8 +332,8 @@ class PayloadRepo:
                         # Backfilled (past-dated) members may arrive after the
                         # cluster already saw fresher ones; widen the window
                         # instead of blindly overwriting last_seen backward.
-                        first_seen=func.min(PayloadCluster.first_seen, timestamp),
-                        last_seen=func.max(PayloadCluster.last_seen, timestamp),
+                        first_seen=smin(PayloadCluster.first_seen, timestamp),
+                        last_seen=smax(PayloadCluster.last_seen, timestamp),
                         capture_count=PayloadCluster.capture_count + 1,
                     )
                 )

--- a/src/tasks/hash_payloads.py
+++ b/src/tasks/hash_payloads.py
@@ -83,7 +83,9 @@ def _advance_watermark(db, value: int) -> None:
         db.close_session()
 
 
-def _hash_attack_bodies(db, watermark: int, threshold: int) -> tuple[int, int, int, int]:
+def _hash_attack_bodies(
+    db, watermark: int, threshold: int
+) -> tuple[int, int, int, int]:
     """Hash + cluster attack bodies for logs above the watermark.
 
     Returns (logs_seen, hashed, clustered, new_watermark).
@@ -136,11 +138,15 @@ def _hash_files(db, threshold: int) -> int:
     try:
         files = (
             session.query(
-                CapturedPayload.id, CapturedPayload.filename,
-                AccessLog.timestamp, AccessLog.raw_request,
+                CapturedPayload.id,
+                CapturedPayload.filename,
+                AccessLog.timestamp,
+                AccessLog.raw_request,
             )
             .join(AccessLog, AccessLog.id == CapturedPayload.access_log_id)
-            .filter(CapturedPayload.tlsh_hash.is_(None), AccessLog.raw_request.isnot(None))
+            .filter(
+                CapturedPayload.tlsh_hash.is_(None), AccessLog.raw_request.isnot(None)
+            )
             .limit(MAX_LOGS_PER_RUN)
             .all()
         )

--- a/tests/test_threat_capture.py
+++ b/tests/test_threat_capture.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import sys
 import tempfile
+import types
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -33,14 +34,44 @@ def main():
         # task runs in the test write to the DB the assertions read.
         dbpkg.initialize_database(os.path.join(tmp, "krawl.db"))
 
+        from sqlalchemy import create_mock_engine
+        from sqlalchemy.sql import func as sa_func
+
         from config import get_config
-        from models import CapturedPayload
+        from database.payloads import _scalar_min_max
+        from models import AccessLog, CapturedPayload, PayloadCluster
         from tlsh_utils import (
             SIMILARITY_THRESHOLD,
             tlsh_available,
             tlsh_diff,
             tlsh_hash,
         )
+
+        # The cluster backfill scalar must compile for both SQLite (min/max)
+        # and Postgres (LEAST/GREATEST); func.min(a,b) is undefined on Postgres.
+        for dialect, marker in (("postgresql", "least("), ("sqlite", "min(")):
+            smin, smax = _scalar_min_max(
+                types.SimpleNamespace(
+                    engine=types.SimpleNamespace(
+                        dialect=types.SimpleNamespace(name=dialect)
+                    )
+                )
+            )
+            compiled: list[str] = []
+
+            def _capture(*a, buf: list[str] = compiled) -> None:
+                buf.append(str(a[0]))
+
+            eng = create_mock_engine(f"{dialect}://", _capture)
+            eng.execute(
+                PayloadCluster.__table__.update().values(
+                    first_seen=smin(PayloadCluster.first_seen, sa_func.now()),
+                    last_seen=smax(PayloadCluster.last_seen, sa_func.now()),
+                )
+            )
+            assert marker in " ".join(compiled), (dialect, compiled)
+        print("backfill scalar compiles on sqlite + postgres: OK")
+
         from tracker import AccessTracker
 
         cfg = get_config()


### PR DESCRIPTION
func.min/func.max as two-arg scalars work on SQLite but are undefined on PostgreSQL (aggregate-only). Route the cluster backfill window through LEAST/GREATEST on postgres and min/max elsewhere. Test compiles the merge statement against both dialects so this can't regress.