### PR TITLE
Fix ram surge on buffer full

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,13 @@ COPY --chown=krawl:krawl helm/Chart.yaml /app/Chart.yaml
 EXPOSE 5000
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000", "--app-dir", "src", "--no-server-header"]
+# --limit-concurrency: the DB calls on the request path run through
+# asyncio.to_thread, whose executor has 32 threads and an UNBOUNDED queue. A
+# slow disk (or just enough traffic) makes each call slower than arrivals, and
+# every queued request pins its scope, body (64 KiB) and raw_request (16 KiB)
+# until it is served -- that queue was the only thing in the process with no
+# ceiling, and it is what walks RSS into the GiBs. Uvicorn sheds with a 503
+# past this many in flight, which is the right answer for a honeypot: it
+# already drops buffered rows under the same pressure. Raise it if the pod has
+# memory to spare, lower it if it still grows -- roughly 80 KiB per slot.
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000", "--app-dir", "src", "--no-server-header", "--limit-concurrency", "512", "--backlog", "256"]

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.3.10
-appVersion: 2.3.10
+version: 2.3.11
+appVersion: 2.3.11
 keywords:
   - honeypot
   - security

--- a/src/ban_cache.py
+++ b/src/ban_cache.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+"""In-process set of banned IPs, so the per-request ban check skips the DB.
+
+Same shape as banlist_sync, read one line apart in the middleware.
+
+Must never be missing a banned IP or the fast path lets one through, so it is
+a superset: force bans included, ban expiry left to get_ban_info.
+"""
+
+import threading
+
+from logger import get_app_logger
+from sanitizer import sanitize_ip
+
+# ponytail: a flood can ban more IPs than we want resident. Past the cap the
+# fast path turns itself off rather than answer from a truncated set (which
+# would let banned IPs through). ~85 bytes per IPv4 string, so the cap is
+# ~17 MiB. Raise it if the warning shows up and the pod has the headroom.
+MAX_BANNED_IPS = 200_000
+
+_banned: frozenset[str] = frozenset()
+_ready = False  # no authoritative answers until the first successful refresh
+_lock = threading.Lock()
+
+
+def is_ready() -> bool:
+    """True when the set may be trusted to answer "not banned".
+
+    False before the first refresh, and after one that overflowed the cap: the
+    caller must fall back to querying the database.
+    """
+    return _ready
+
+
+def is_banned(ip: str) -> bool:
+    """Membership test against the banned set, without copying it.
+
+    Sanitized on the way in: the set holds IPs as the database stores them,
+    and comparing a raw header value against those would miss a banned IP.
+    """
+    return sanitize_ip(ip) in _banned
+
+
+def add(ip: str) -> None:
+    """Record a ban applied by this process, so it takes effect immediately.
+
+    Without this a freshly banned client keeps being served until the next
+    refresh. Other replicas still wait for theirs.
+    """
+    global _banned
+    safe = sanitize_ip(ip)
+    with _lock:
+        if safe not in _banned:
+            _banned = _banned | {safe}
+
+
+def refresh(db=None, ban_duration_seconds: int = 600) -> int:
+    """Reload the banned set from the database. Returns the number held."""
+    global _banned, _ready
+
+    if db is None:
+        from database import get_database
+
+        db = get_database()
+
+    ips = db.ip_stats.get_banned_ips(ban_duration_seconds, limit=MAX_BANNED_IPS + 1)
+
+    if len(ips) > MAX_BANNED_IPS:
+        with _lock:
+            _ready = False
+        get_app_logger().warning(
+            f"[BanCache] {len(ips)}+ banned IPs exceeds the {MAX_BANNED_IPS} cap; "
+            "falling back to per-request database lookups"
+        )
+        return 0
+
+    # Frozen and swapped wholesale: the middleware reads this on every request.
+    with _lock:
+        _banned = frozenset(ips)
+        _ready = True
+    return len(_banned)

--- a/src/database/core.py
+++ b/src/database/core.py
@@ -690,6 +690,10 @@ class DatabaseManager:
 
                 delete_cached_short(f"ban:{sanitized_ip}")
 
+                import ban_cache
+
+                ban_cache.add(sanitized_ip)
+
         return page_visit_count, was_new_ip, was_first_honeypot
 
     def increment_page_visit(self, ip: str, max_pages_limit: int) -> int:
@@ -735,6 +739,10 @@ class DatabaseManager:
                 from dashboard_cache import delete_cached_short
 
                 delete_cached_short(f"ban:{sanitized_ip}")
+
+                import ban_cache
+
+                ban_cache.add(sanitized_ip)
 
             return ip_stats.page_visit_count
 

--- a/src/database/ip_stats.py
+++ b/src/database/ip_stats.py
@@ -25,6 +25,21 @@ applogger = get_app_logger()
 _MAX_BAN_MULTIPLIER = 1024
 
 
+def _publish_ban_change(sanitized_ip: str, banned: bool) -> None:
+    """Make a manual ban/unban visible to the two caches in front of the query.
+
+    Both were being skipped here, so a force-ban from the dashboard did nothing
+    until the cached "not banned" answer expired.
+    """
+    from dashboard_cache import delete_cached_short
+
+    delete_cached_short(f"ban:{sanitized_ip}")
+    if banned:
+        import ban_cache
+
+        ban_cache.add(sanitized_ip)
+
+
 class IpStatsRepo:
     """Queries and mutations centered on the ip_stats table."""
 
@@ -225,6 +240,7 @@ class IpStatsRepo:
         ip_stats.ban_override = override
         try:
             session.commit()
+            _publish_ban_change(sanitized_ip, banned=override is True)
             return True
         except Exception as e:
             session.rollback()
@@ -253,6 +269,7 @@ class IpStatsRepo:
         ip_stats.ban_override = True
         try:
             session.commit()
+            _publish_ban_change(sanitized_ip, banned=True)
             return True
         except Exception as e:
             session.rollback()
@@ -1118,6 +1135,41 @@ class IpStatsRepo:
             if elapsed < effective:
                 live.append(r)
         return live
+
+    def get_banned_ips(
+        self, ban_duration_seconds: int, limit: int = 200_000
+    ) -> list[str]:
+        """Every IP that might currently be banned -- a superset, deliberately.
+
+        Feeds the in-process fast path in ban_cache, which may only skip the
+        real check for IPs this does NOT return. So the predicate errs wide: it
+        takes any row with a force ban or a ban_timestamp inside the widest
+        possible window, and leaves exemptions and exact expiry to
+        get_ban_info. A stray IP costs one slow lookup; a missing one would let
+        a banned client through.
+
+        Reads one column, not whole ORM rows: this runs against every banned IP
+        on a schedule, and _timedout_candidates' hydration is wasted here.
+        """
+        coarse_floor = datetime.now() - timedelta(
+            seconds=ban_duration_seconds * _MAX_BAN_MULTIPLIER
+        )
+        session = self._db.session
+        try:
+            rows = (
+                session.query(IpStats.ip)
+                .filter(
+                    or_(
+                        IpStats.ban_override.is_(True),
+                        IpStats.ban_timestamp >= coarse_floor,
+                    )
+                )
+                .limit(limit)
+                .all()
+            )
+            return [r[0] for r in rows if r[0]]
+        finally:
+            self._db.close_session()
 
     def get_timedout_ips(self, ban_duration_seconds: int) -> list[str]:
         """IP strings currently serving an automatic time-ban (for export)."""

--- a/src/middleware/ban_check.py
+++ b/src/middleware/ban_check.py
@@ -11,6 +11,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+import ban_cache
 from dependencies import get_client_ip
 from ip_utils import is_ignored_ip
 
@@ -37,8 +38,18 @@ class BanCheckMiddleware(BaseHTTPMiddleware):
         get_app_logger().debug(
             f"[BanCheck] Checking ban for {client_ip} - {request.url.path}"
         )
-        ban_info = await asyncio.to_thread(tracker.get_ban_info, client_ip)
-        if ban_info["is_banned"]:
+        # Fast path: the banned set is small and held in memory, so the common
+        # answer costs a set lookup instead of a thread and a database read.
+        # The set is a superset of the banned IPs, so a miss in it is
+        # conclusive -- but only once it is loaded. See ban_cache.
+        # This skips the lookup, not the rest of the middleware: the global
+        # banlist below is a separate source and still applies.
+        if not ban_cache.is_ready() or ban_cache.is_banned(client_ip):
+            ban_info = await asyncio.to_thread(tracker.get_ban_info, client_ip)
+        else:
+            ban_info = None
+
+        if ban_info is not None and ban_info["is_banned"]:
             from logger import get_access_logger
 
             get_access_logger().info(

--- a/src/tasks/refresh_ban_cache.py
+++ b/src/tasks/refresh_ban_cache.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+"""Keep the in-process banned-IP set current.
+
+Cheap enough to run often: one indexed query returning one column, against a
+set that is small by construction. The interval is the window in which a ban
+applied by *another* replica is not yet enforced here; bans applied by this
+process take effect immediately via ban_cache.add().
+"""
+
+import ban_cache
+from config import get_config
+from logger import get_app_logger
+
+TASK_CONFIG = {
+    "name": "refresh-ban-cache",
+    "enabled": True,
+    # The set answers "not banned" authoritatively, so it must be loaded before
+    # the fast path is used. It refuses to answer until this has run once.
+    "run_when_loaded": True,
+    "interval_seconds": 30,
+}
+
+
+def main():
+    count = ban_cache.refresh(
+        ban_duration_seconds=get_config().ban_duration_seconds,
+    )
+    get_app_logger().debug(f"[RefreshBanCache] {count} banned IPs held in memory")

--- a/tests/test_ban_cache.py
+++ b/tests/test_ban_cache.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+"""Checks for the in-memory banned-IP fast path.
+
+The fast path skips a database read on every request, so the property that
+matters is one-sided: it may never answer "not banned" for an IP that is. Each
+check below is a way that could break.
+
+Usage: python tests/test_ban_cache.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import ban_cache
+
+
+class FakeRepo:
+    """Stands in for ip_stats.get_banned_ips."""
+
+    def __init__(self, ips):
+        self.ips = ips
+        self.calls = 0
+
+    def get_banned_ips(self, ban_duration_seconds, limit=200_000):
+        self.calls += 1
+        return list(self.ips)[:limit]
+
+
+class FakeDB:
+    def __init__(self, ips):
+        self.ip_stats = FakeRepo(ips)
+
+
+def reset():
+    ban_cache._banned = frozenset()
+    ban_cache._ready = False
+
+
+def test_not_ready_before_first_refresh():
+    """An empty set must not be mistaken for "nobody is banned"."""
+    reset()
+    assert ban_cache.is_ready() is False, (
+        "the fast path must refuse to answer until the set is loaded, "
+        "or every banned IP is served during startup"
+    )
+
+
+def test_refresh_loads_and_answers():
+    reset()
+    db = FakeDB(["203.0.113.7", "198.51.100.2"])
+    assert ban_cache.refresh(db=db) == 2
+    assert ban_cache.is_ready() is True
+    assert ban_cache.is_banned("203.0.113.7") is True
+    assert ban_cache.is_banned("192.0.2.1") is False
+
+
+def test_local_ban_takes_effect_immediately():
+    """A ban this process applies must not wait for the next refresh."""
+    reset()
+    ban_cache.refresh(db=FakeDB([]))
+    assert ban_cache.is_banned("203.0.113.9") is False
+    ban_cache.add("203.0.113.9")
+    assert ban_cache.is_banned("203.0.113.9") is True
+
+
+def test_overflow_disables_the_fast_path():
+    """Truncating the set would let the IPs past the cap through, so past the
+    cap it stops answering instead."""
+    reset()
+    ban_cache.refresh(db=FakeDB([]))
+    assert ban_cache.is_ready() is True
+
+    too_many = [f"10.{i // 65536 % 256}.{i // 256 % 256}.{i % 256}" for i in range(50)]
+    original = ban_cache.MAX_BANNED_IPS
+    try:
+        ban_cache.MAX_BANNED_IPS = 10
+        assert ban_cache.refresh(db=FakeDB(too_many)) == 0
+        assert ban_cache.is_ready() is False, (
+            "an overflowed set must fall back to the database, not answer "
+            "from a truncated one"
+        )
+    finally:
+        ban_cache.MAX_BANNED_IPS = original
+
+
+def test_lookup_is_sanitized():
+    """The set holds IPs as the database stores them; the middleware passes a
+    header value. Comparing the two raw would miss a banned IP."""
+    reset()
+    from sanitizer import sanitize_ip
+
+    raw = "  203.0.113.7  "
+    stored = sanitize_ip(raw)
+    ban_cache.refresh(db=FakeDB([stored]))
+    assert ban_cache.is_banned(raw) is True, (
+        f"{raw!r} must match its stored form {stored!r}"
+    )
+
+
+if __name__ == "__main__":
+    test_not_ready_before_first_refresh()
+    print("OK: no authoritative answers before the first refresh")
+    test_refresh_loads_and_answers()
+    print("OK: refresh loads the set and answers membership")
+    test_local_ban_takes_effect_immediately()
+    print("OK: a locally applied ban is enforced without waiting for a refresh")
+    test_overflow_disables_the_fast_path()
+    print("OK: past the cap the fast path disables itself")
+    test_lookup_is_sanitized()
+    print("OK: lookups are sanitized to the stored form")
+    reset()


### PR DESCRIPTION
This pull request introduces a significant performance and correctness improvement to the IP banning system by adding an in-memory fast path for banned IP checks. It implements a new `ban_cache` module that holds a superset of banned IPs in memory, allowing most requests to skip database lookups. The cache is kept up-to-date both via periodic refresh and immediate updates on local bans, with robust fallbacks and safety checks. The PR also includes integration with the middleware, database, and a new test suite for the cache.

Key changes:

**In-memory banned IP cache and integration**
* Added a new `ban_cache` module that maintains a thread-safe, in-process set of banned IPs, providing a fast path for ban checks and reducing database load. The cache is updated both periodically and immediately when a ban is applied locally. If the set grows too large, the cache disables itself to avoid truncation errors. (`src/ban_cache.py` [[1]](diffhunk://#diff-352d90453ff6bc2ea13e27c77e0129f28e7a64c55b54b186b0bec10124b4e34fR1-R82) `src/tasks/refresh_ban_cache.py` [[2]](diffhunk://#diff-edae167a5e15f2cd7dc2277d302b186066ac7fb769e0bd743b513cdb4516cd22R1-R29) `src/middleware/ban_check.py` [[3]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7R14) [[4]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7R41-R52)
* Introduced a scheduled task to refresh the in-memory ban set every 30 seconds, ensuring bans applied on other replicas are enforced promptly. (`src/tasks/refresh_ban_cache.py` [src/tasks/refresh_ban_cache.pyR1-R29](diffhunk://#diff-edae167a5e15f2cd7dc2277d302b186066ac7fb769e0bd743b513cdb4516cd22R1-R29))
* Modified the ban-checking middleware to use the in-memory cache as an authoritative source for "not banned" answers, falling back to the database only when necessary. (`src/middleware/ban_check.py` [[1]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7R14) [[2]](diffhunk://#diff-4e6966bbf5cc21a0a616ebb102777dcca79e61c49dc5ead30ccf594a6b729cc7R41-R52)

**Database and ban logic updates**
* Added a `get_banned_ips` method to `IpStatsRepo` for efficiently retrieving all possibly banned IPs to feed the cache, ensuring no banned IP is missed. (`src/database/ip_stats.py` [src/database/ip_stats.pyR1139-R1173](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR1139-R1173))
* Updated ban/unban logic to immediately update both the dashboard and in-process caches, so manual bans take effect without waiting for cache expiry. (`src/database/ip_stats.py` [[1]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR28-R42) [[2]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR243) [[3]](diffhunk://#diff-5c40830cbcc11b5c696ba0dffc80adef4d685041ffcc37cd8beea0553b9b289aR272) `src/database/core.py` [[4]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64R693-R696) [[5]](diffhunk://#diff-7ed8611a1686f79449a3b53cbf9a181bfcf7853300c39071d002df3114e77a64R743-R746)

**Testing and configuration**
* Added a comprehensive test suite for the in-memory ban cache, verifying correctness and edge cases such as cache overflow and IP sanitization. (`tests/test_ban_cache.py` [tests/test_ban_cache.pyR1-R114](diffhunk://#diff-0d06b038bf1b0d94d5c839f1b3b636d0dba7d94f7fff792665b9635476198149R1-R114))
* Updated Docker and Helm configurations to reflect the new version and to tune Uvicorn concurrency/backlog, accommodating the new memory usage patterns. (`Dockerfile` [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L39-R48) `helm/Chart.yaml` [[2]](diffhunk://#diff-ab3e9fcf0ffe762ed2805586f2e116f0c38db08c3b34d6ba2cfa90e871a1d918L5-R6)