### PR TITLE
Feat shared task manager

### DIFF
--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -145,6 +145,8 @@ Tasks that maintain **per-pod** state are deliberately not gated and run everywh
 
 Running a task by hand from **Settings → Maintenance** is never gated by this mechanism. It runs immediately on the pod serving the request, deduplicated only against other concurrent manual runs.
 
+**Settings → Maintenance** shows which pod last ran each task. A pod chip means one pod owns each occurrence; "runs on every pod" means the task is not gated. The chip is highlighted when it names the pod currently serving the dashboard.
+
 > **Tip**: `redis-cli --scan --pattern 'krawl:task:*'` shows the active leases, and `redis-cli get krawl:task:lock:<job>` names the pod holding one.
 
 ### Metrics Across Pods

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -7,6 +7,8 @@ Krawl supports two deployment modes: **standalone** and **scalable**. The mode i
 - [Standalone Mode](#standalone-mode)
 - [Scalable Mode](#scalable-mode)
   - [Redis Cache Tiers](#redis-cache-tiers)
+  - [Scheduled Tasks Across Pods](#scheduled-tasks-across-pods)
+  - [Metrics Across Pods](#metrics-across-pods)
 - [Running with Docker Compose](#running-with-docker-compose)
   - [Standalone](#standalone)
   - [Scalable](#scalable)
@@ -122,6 +124,34 @@ In scalable mode, Redis is used across three cache tiers to reduce database load
 In standalone mode, only the warmup cache is used (in-memory dict). The hot-path and table caches are no-ops since there's only one process and the database is local.
 
 > **Tip**: In scalable mode, you can disable `dashboard.cache_warmup` in your config. The table-tier cache already reduces DB load for dashboard requests without needing a background task.
+
+---
+
+### Scheduled Tasks Across Pods
+
+Every pod runs its own scheduler. Tasks whose effect is global are gated so exactly one pod runs each occurrence, using a Redis lease under `krawl:task:lock:<job>`. A task opts in with `"single_pod": True` in its `TASK_CONFIG`.
+
+The lease is not released when the task finishes — it expires. Jobs are scheduled with up to 240 seconds of jitter, so pods fire the same cron minutes apart; a lease released on completion would just be picked up by the next pod, and the task would run everywhere anyway. Lease length is twice the jitter window, clamped below the task's period, so a daily task holds it for 480 seconds rather than a day.
+
+Tasks that maintain **per-pod** state are deliberately not gated and run everywhere, every time:
+
+| Task | Per-pod state it maintains |
+|------|----------------------------|
+| `flush-access-logs` | This pod's access-log write buffer |
+| `metrics-flush` | This pod's metric counters |
+| `refresh-ban-cache` | This pod's banned-IP set, read on every request |
+
+`refresh-banlist` is a hybrid. One pod fetches the external sources and publishes the merged result to `krawl:task:banlist`; the others adopt that payload into their own in-process set. A pod starting up adopts the published list too, so joining a running cluster costs no external requests.
+
+Running a task by hand from **Settings → Maintenance** is never gated by this mechanism. It runs immediately on the pod serving the request, deduplicated only against other concurrent manual runs.
+
+> **Tip**: `redis-cli --scan --pattern 'krawl:task:*'` shows the active leases, and `redis-cli get krawl:task:lock:<job>` names the pod holding one.
+
+### Metrics Across Pods
+
+Prometheus scrapes each pod separately, and the cumulative counters are shared in Redis, so every pod reports the same cluster-wide totals as its own series. **Aggregate them with `max()`, not `sum()`** — summing multiplies every total by the replica count.
+
+The bundled Grafana dashboard already does this: `sum()` appears only on `krawl_write_buffer_dropped_total`, which is genuinely per-process, alongside the other per-pod diagnostics (`krawl_write_buffer_rows`, `krawl_seen_ledger_entries`, `krawl_local_paths_set_entries`, `krawl_cache_backend_redis`).
 
 ---
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krawl-chart
 description: A Helm chart for Krawl honeypot server
 type: application
-version: 2.3.11
-appVersion: 2.3.11
+version: 2.3.12
+appVersion: 2.3.12
 keywords:
   - honeypot
   - security

--- a/src/app.py
+++ b/src/app.py
@@ -15,7 +15,6 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from config import get_config
-from dashboard_cache import flush_all as flush_cache
 from dashboard_cache import initialize_cache
 from database import get_database, initialize_database
 from generators import random_server_header
@@ -131,10 +130,6 @@ async def lifespan(app: FastAPI):
     else:
         with _phase(app_logger, "In-memory cache init"):
             initialize_cache(mode="standalone")
-
-    # Flush stale cache from previous run so the pod starts fresh
-    with _phase(app_logger, "Cache flush"):
-        flush_cache()
 
     # Seed event-driven metric counters (from metrics_summary or a one-time
     # recompute). In scalable mode only the first pod actually seeds.

--- a/src/app.py
+++ b/src/app.py
@@ -173,9 +173,12 @@ async def lifespan(app: FastAPI):
     # Initial banlist sync (before accepting traffic)
     if config.banlist_sources:
         with _phase(app_logger, "Initial banlist sync"):
-            from banlist_sync import refresh_banlist_sources
+            from banlist_sync import load_published, refresh_banlist_sources
 
-            refresh_banlist_sources()
+            # A pod joining a running cluster adopts what a peer already
+            # fetched; only a cold cluster pays for the external requests.
+            if not load_published():
+                refresh_banlist_sources()
 
     # Store in app.state for dependency injection
     app.state.config = config

--- a/src/banlist_sync.py
+++ b/src/banlist_sync.py
@@ -1,3 +1,4 @@
+import json
 import threading
 import time
 
@@ -11,6 +12,10 @@ _global_banlist: frozenset[str] = frozenset()
 _banlist_sources: list[dict] = []
 _last_refresh: float = 0.0
 _lock = threading.Lock()
+
+# Outside krawl:cache:: this payload is durable shared state with its own TTL,
+# not a disposable cache entry.
+PUBLISHED_KEY: str = "krawl:task:banlist"
 
 
 def get_global_banlist() -> frozenset[str]:
@@ -88,3 +93,80 @@ def refresh_banlist_sources(*, source_urls: list[str] | None = None) -> None:
         f"[BanlistSync] Global banlist now has {len(combined)} IPs "
         f"across {len(sources_info)} sources"
     )
+
+    # Three refresh intervals, so a payload whose publisher permanently
+    # disappeared ages out instead of being served forever.
+    from config import get_config as _get_config
+
+    publish(_get_config().banlist_refresh_interval * 3)
+
+
+def publish(ttl_seconds: int) -> bool:
+    """Publish the current banlist so peer pods need not fetch the sources.
+
+    Returns True when a payload was written. Standalone mode has no peers, so it
+    returns False without touching anything.
+
+    The per-source status records travel with the IPs, so the dashboard's source
+    health reflects the fetch the cluster actually performed rather than
+    whichever pod happened to answer the request.
+    """
+    from dashboard_cache import get_backend, get_redis_client
+
+    if get_backend() != "scalable":
+        return False
+
+    redis_client = get_redis_client()
+    if redis_client is None:
+        return False
+
+    with _lock:
+        payload = json.dumps(
+            {
+                "ips": sorted(_global_banlist),
+                "sources": list(_banlist_sources),
+            }
+        )
+
+    redis_client.setex(PUBLISHED_KEY, ttl_seconds, payload)
+    get_app_logger().info(
+        f"[BanlistSync] Published {len(_global_banlist)} IPs for peer pods"
+    )
+    return True
+
+
+def load_published() -> bool:
+    """Adopt the banlist a peer pod published. True when one was found.
+
+    Leaves the current list untouched and returns False when nothing has been
+    published yet, so a cold cluster falls through to fetching the sources.
+    """
+    global _global_banlist, _last_refresh
+
+    from dashboard_cache import get_backend, get_redis_client
+
+    if get_backend() != "scalable":
+        return False
+
+    redis_client = get_redis_client()
+    if redis_client is None:
+        return False
+
+    raw = redis_client.get(PUBLISHED_KEY)
+    if not raw:
+        return False
+
+    payload = json.loads(raw)
+
+    # Rebind rather than mutate: the ban-check middleware reads this frozenset
+    # on every request and must never observe it half-populated.
+    with _lock:
+        _global_banlist = frozenset(payload.get("ips", []))
+        _banlist_sources.clear()
+        _banlist_sources.extend(payload.get("sources", []))
+        _last_refresh = time.time()
+
+    get_app_logger().info(
+        f"[BanlistSync] Adopted published banlist: {len(_global_banlist)} IPs"
+    )
+    return True

--- a/src/dashboard_cache.py
+++ b/src/dashboard_cache.py
@@ -267,29 +267,6 @@ def invalidate_table_cache() -> None:
                 break
 
 
-def flush_all() -> None:
-    """Flush all Krawl cache keys.
-
-    In scalable mode, deletes all Redis keys with the krawl:cache: prefix.
-    In standalone mode, clears the in-memory dict.
-    Called on startup so each pod restart begins with a fresh cache.
-    """
-    if _backend == "scalable" and _redis_client is not None:
-        cursor = 0
-        while True:
-            cursor, keys = _redis_client.scan(
-                cursor, match=f"{_REDIS_PREFIX}*", count=200
-            )
-            if keys:
-                _redis_client.delete(*keys)
-            if cursor == 0:
-                break
-        return
-
-    with _lock:
-        _cache.clear()
-
-
 def pagination(page: int, page_size: int, total: int) -> dict:
     """Build the pagination block shared by every paginated response.
 

--- a/src/metrics_counters.py
+++ b/src/metrics_counters.py
@@ -1,11 +1,12 @@
 """
 Event-driven metric counters backed by the cache layer.
 
-Counters live under the krawl:counter: prefix so they survive the krawl:cache:*
-flush that runs on every pod startup (see dashboard_cache.flush_all). In
-scalable mode they are Redis keys (atomic INCRBY, shared across pods); in
-standalone mode they are a locked in-memory dict. Values feed Prometheus gauges
-(set at scrape time) and the dashboard's aggregate counts.
+Counters live under the krawl:counter: prefix, separate from the krawl:cache:
+keyspace: cache entries are disposable and TTL'd, counters are durable state
+that must survive independently of them. In scalable mode they are Redis keys
+(atomic INCRBY, shared across pods); in standalone mode they are a locked
+in-memory dict. Values feed Prometheus gauges (set at scrape time) and the
+dashboard's aggregate counts.
 
 Encoding: a labeled counter is stored as "metric|label"; an unlabeled one as
 "metric". Distinctness estimators (e.g. seen request paths) live under

--- a/src/metrics_counters.py
+++ b/src/metrics_counters.py
@@ -313,21 +313,20 @@ HEAVY_METRICS = (
 # never purged), so their current count already equals the cumulative total.
 _TALLIED_METRICS = ("total_accesses", "unique_ips")
 
-_RECONCILE_LOCK = "krawl:counter:_reconcile_lock"
+# Namespaced under krawl:task: with every other cross-pod lease. The old
+# krawl:counter:_reconcile_lock key simply expires; nothing reads it.
+_RECONCILE_JOB = "counter-reconcile"
 
 
 def _acquire_reconcile_lock(ttl: int = 600) -> bool:
     """Return True if this process should run the (expensive) full recompute.
 
-    Scalable: a short-lived Redis lock so only one pod recomputes per window.
-    Standalone: always True (single process).
+    Scalable: one pod per window, via the shared cross-pod lease. Standalone:
+    always True, there being one process.
     """
-    if get_backend() == "scalable":
-        r = get_redis_client()
-        if r is not None:
-            return bool(r.set(_RECONCILE_LOCK, "1", nx=True, ex=ttl))
-        return True
-    return True
+    import task_lock
+
+    return task_lock.claim(_RECONCILE_JOB, ttl)
 
 
 def _recompute_heavy(db) -> None:

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -13,7 +13,6 @@ import hmac
 import io
 import re
 import secrets
-import threading
 import time
 import zipfile
 from datetime import UTC, datetime, timedelta
@@ -1677,55 +1676,33 @@ async def webhook_cloudflare_delete(request: Request):
 # authenticated view over that registry — there is no separate job runner, and
 # adding a task file is all it takes to make it appear in the panel.
 
-_RUN_LOCK_PREFIX = "krawl:taskrun:"
 _RUN_LOCK_TTL = 3600  # a stuck task must not block its own next run forever
-
-_local_running: set[str] = set()
-_local_running_lock = threading.Lock()
 
 
 def _acquire_run_lock(name: str) -> bool:
     """Claim the right to run `name`. False when it is already running.
 
-    Redis in scalable mode so one click does not start the task on every
-    replica; a process-local set in standalone. Same split as auth_store.
+    One click must not start the task on every replica, and a second click must
+    not start it twice on this one. Both are the shared cross-pod lease; unlike
+    the scheduler's use of it, this one is released on completion.
     """
-    from dashboard_cache import get_backend, get_redis_client
+    import task_lock
 
-    if get_backend() == "scalable":
-        r = get_redis_client()
-        if r is not None:
-            return bool(
-                r.set(f"{_RUN_LOCK_PREFIX}{name}", "1", nx=True, ex=_RUN_LOCK_TTL)
-            )
-    with _local_running_lock:
-        if name in _local_running:
-            return False
-        _local_running.add(name)
-        return True
+    return task_lock.claim(name, _RUN_LOCK_TTL)
 
 
 def _release_run_lock(name: str) -> None:
-    from dashboard_cache import get_backend, get_redis_client
+    """Free the task for another manual run now that this one has finished."""
+    import task_lock
 
-    if get_backend() == "scalable":
-        r = get_redis_client()
-        if r is not None:
-            r.delete(f"{_RUN_LOCK_PREFIX}{name}")
-            return
-    with _local_running_lock:
-        _local_running.discard(name)
+    task_lock.release(name)
 
 
 def _is_running(name: str) -> bool:
-    from dashboard_cache import get_backend, get_redis_client
+    """True while a manual run of `name` is in flight anywhere in the cluster."""
+    import task_lock
 
-    if get_backend() == "scalable":
-        r = get_redis_client()
-        if r is not None:
-            return bool(r.exists(f"{_RUN_LOCK_PREFIX}{name}"))
-    with _local_running_lock:
-        return name in _local_running
+    return task_lock.is_held(name)
 
 
 @router.get("/api/tasks", dependencies=[Depends(require_auth)])

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -1708,6 +1708,7 @@ def _is_running(name: str) -> bool:
 @router.get("/api/tasks", dependencies=[Depends(require_auth)])
 async def list_tasks():
     """List every discovered task with its schedule and current state."""
+    import task_lock
     from tasks_master import get_tasksmaster
 
     tm = get_tasksmaster()
@@ -1731,6 +1732,8 @@ async def list_tasks():
             "enabled": bool(t.get("enabled")),
             "next_run": next_runs.get(name),
             "running": _is_running(name),
+            "single_pod": bool(t.get("single_pod")),
+            "last_run": task_lock.get_last_run(name),
             "options": None,
         }
         # The purge task is the only one taking arguments; surface its targets
@@ -1743,7 +1746,10 @@ async def list_tasks():
             ]
         tasks.append(entry)
 
-    return JSONResponse(content={"tasks": tasks}, headers=_no_cache_headers())
+    return JSONResponse(
+        content={"tasks": tasks, "this_pod": task_lock.POD_UID},
+        headers=_no_cache_headers(),
+    )
 
 
 class RunTaskRequest(BaseModel):

--- a/src/task_lock.py
+++ b/src/task_lock.py
@@ -16,6 +16,8 @@ the claim. A honeypot that silently stops doing maintenance is worse than one
 that does it twice.
 """
 
+import datetime
+import json
 import os
 import threading
 import time
@@ -105,3 +107,60 @@ def is_held(job_id: str) -> bool:
     if redis_client is None:
         return False
     return bool(redis_client.exists(f"{LOCK_PREFIX}{job_id}"))
+
+
+LAST_RUN_PREFIX: str = "krawl:task:last_run:"
+
+# Long enough that a task on a weekly-ish schedule still shows its last run, and
+# short enough that a task deleted from the folder stops appearing eventually.
+LAST_RUN_TTL: int = 14 * 24 * 3600
+
+# Standalone has no Redis; the panel still wants to show the last run.
+_local_last_runs: dict[str, str] = {}
+
+
+def record_run(task_name: str, ok: bool) -> None:
+    """Record that this pod just ran `task_name`, successfully or not.
+
+    Deliberately separate from the lease. A lease is held for twice the jitter
+    window and then expires -- a daily task holds one for 480 seconds out of
+    86400 -- so it cannot answer "who ran this", only "who is mid-window right
+    now". The dashboard needs the durable answer.
+    """
+    payload = json.dumps(
+        {
+            "pod": POD_UID,
+            "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "ok": bool(ok),
+        }
+    )
+
+    if get_backend() != "scalable":
+        with _local_lock:
+            _local_last_runs[task_name] = payload
+        return
+
+    redis_client = get_redis_client()
+    if redis_client is not None:
+        redis_client.setex(f"{LAST_RUN_PREFIX}{task_name}", LAST_RUN_TTL, payload)
+
+
+def get_last_run(task_name: str) -> dict | None:
+    """The last recorded run of `task_name`, or None if it has not run.
+
+    Returns {"pod": str, "at": ISO-8601 str, "ok": bool}.
+    """
+    if get_backend() != "scalable":
+        with _local_lock:
+            payload = _local_last_runs.get(task_name)
+    else:
+        redis_client = get_redis_client()
+        payload = (
+            redis_client.get(f"{LAST_RUN_PREFIX}{task_name}")
+            if redis_client is not None
+            else None
+        )
+
+    if not payload:
+        return None
+    return json.loads(payload)

--- a/src/task_lock.py
+++ b/src/task_lock.py
@@ -130,7 +130,7 @@ def record_run(task_name: str, ok: bool) -> None:
     payload = json.dumps(
         {
             "pod": POD_UID,
-            "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "at": datetime.datetime.now(datetime.UTC).isoformat(),
             "ok": bool(ok),
         }
     )

--- a/src/task_lock.py
+++ b/src/task_lock.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+"""Cross-pod lease for work that must happen once per cluster, not once per pod.
+
+Scalable mode runs N pods, each with its own BackgroundScheduler, so anything
+with a global effect -- a backup, a retention sweep, a third-party API call --
+happens N times unless one pod claims it first. This is that claim.
+
+Keys live under krawl:task:, deliberately outside krawl:cache:. Cache entries
+are disposable and short-TTL'd; a lease is neither, and mixing the two invites
+exactly the kind of bulk delete that would release every lock in the cluster at
+once. krawl:counter: draws the same line for the same reason.
+
+Every function fails open: standalone mode and an unreachable Redis both grant
+the claim. A honeypot that silently stops doing maintenance is worse than one
+that does it twice.
+"""
+
+import os
+import threading
+import time
+import uuid
+
+from dashboard_cache import get_backend, get_redis_client
+
+LOCK_PREFIX: str = "krawl:task:lock:"
+
+# Reserved for the work-sharding scheme that issue #296 defers. Nothing reads or
+# writes it yet; it is declared so the namespace is not taken by something else.
+QUEUE_PREFIX: str = "krawl:task:queue:"
+
+# Stored as the lease value so `redis-cli get` names the holder. HOSTNAME is the
+# pod name under Kubernetes; the uuid covers bare docker and local runs.
+POD_UID: str = os.environ.get("HOSTNAME") or f"pod-{uuid.uuid4().hex[:8]}"
+
+# Standalone has no Redis, but the maintenance panel still needs two concurrent
+# clicks to be rejected. Mirrors the process-local fallback in auth_store.
+_local_leases: dict[str, float] = {}
+_local_lock = threading.Lock()
+
+
+def _local_claim(job_id: str, lease_seconds: int) -> bool:
+    """Claim against the process-local lease table used in standalone mode."""
+    now = time.time()
+    with _local_lock:
+        expires = _local_leases.get(job_id)
+        if expires is not None and expires > now:
+            return False
+        _local_leases[job_id] = now + lease_seconds
+        return True
+
+
+def claim(job_id: str, lease_seconds: int) -> bool:
+    """Claim the right to run `job_id` for the next `lease_seconds`.
+
+    Returns True for exactly one pod per lease window in scalable mode, and for
+    the single process in standalone mode.
+
+    The lease is deliberately NOT released when the work finishes; callers let
+    it expire. TasksMaster schedules every job with up to TASK_JITTER seconds of
+    jitter, so releasing on completion would simply hand the same occurrence to
+    the next pod to fire. The lease is the "this occurrence already ran" marker,
+    not a mutex. See TasksMaster._lease_seconds.
+    """
+    if get_backend() != "scalable":
+        return _local_claim(job_id, lease_seconds)
+
+    redis_client = get_redis_client()
+    if redis_client is None:
+        return True
+
+    return bool(
+        redis_client.set(f"{LOCK_PREFIX}{job_id}", POD_UID, nx=True, ex=lease_seconds)
+    )
+
+
+def release(job_id: str) -> None:
+    """Drop a lease early, for callers that want a mutex rather than a lease.
+
+    The scheduler never calls this. The maintenance panel does: a task run by
+    hand should be runnable again the moment it finishes.
+    """
+    if get_backend() != "scalable":
+        with _local_lock:
+            _local_leases.pop(job_id, None)
+        return
+
+    redis_client = get_redis_client()
+    if redis_client is not None:
+        redis_client.delete(f"{LOCK_PREFIX}{job_id}")
+
+
+def is_held(job_id: str) -> bool:
+    """True while someone holds the lease.
+
+    Advisory only -- the lease can expire between this check and its use. Callers
+    that need the answer to be binding should use claim() instead.
+    """
+    if get_backend() != "scalable":
+        with _local_lock:
+            expires = _local_leases.get(job_id)
+            return expires is not None and expires > time.time()
+
+    redis_client = get_redis_client()
+    if redis_client is None:
+        return False
+    return bool(redis_client.exists(f"{LOCK_PREFIX}{job_id}"))

--- a/src/tasks/analyze_ips.py
+++ b/src/tasks/analyze_ips.py
@@ -20,6 +20,8 @@ TASK_CONFIG = {
     "enabled": True,
     # runs every minute anyway; a boot run only duplicates it.
     "run_when_loaded": False,
+    # One pod per minute analyses the batch; the others would redo the same rows.
+    "single_pod": True,
 }
 
 # Upper bound on IPs analysed per run; the remainder is picked up next minute.

--- a/src/tasks/analyze_ips.py
+++ b/src/tasks/analyze_ips.py
@@ -416,3 +416,19 @@ def main():
             ip, analyzed_metrics, category, category_scores, last_analysis
         )
     return
+
+
+def on_skip() -> None:
+    """Another pod owns this occurrence; still refresh this pod's gauges.
+
+    krawl_generated_pages_today, krawl_ips_needing_reevaluation,
+    krawl_unenriched_ips and krawl_auth_locked_ips are prometheus_client Gauges
+    living in this process's memory, not in Redis. A pod that never sets them
+    exports 0, and the dashboard's max() then reports whichever pod last held
+    the lease -- a stale high-water mark instead of the current value.
+
+    Four indexed COUNTs. Only the analysis loop above is worth deduplicating.
+    """
+    db_manager = get_database()
+    metrics.refresh_ai(db_manager)
+    metrics.refresh_system(db_manager)

--- a/src/tasks/dashboard_warmup.py
+++ b/src/tasks/dashboard_warmup.py
@@ -23,6 +23,8 @@ TASK_CONFIG = {
     "cron": "*/5 * * * *",
     "enabled": True,
     "run_when_loaded": True,
+    # Warms the shared Redis cache; N pods writing it is N times the work.
+    "single_pod": True,
 }
 
 

--- a/src/tasks/db_dump.py
+++ b/src/tasks/db_dump.py
@@ -20,6 +20,8 @@ TASK_CONFIG = {
     "enabled": config.backups_enabled,
     # a backup per pod restart is wasted I/O; the cron is the schedule.
     "run_when_loaded": False,
+    # N pods would write N identical backups per schedule.
+    "single_pod": True,
 }
 
 

--- a/src/tasks/db_retention.py
+++ b/src/tasks/db_retention.py
@@ -27,6 +27,8 @@ TASK_CONFIG = {
     "cron": "0 9 * * *",  # Run daily at 9 AM
     "enabled": True,
     "run_when_loaded": False,
+    # A shared-database sweep; running it N times repeats the same deletes.
+    "single_pod": True,
 }
 
 app_logger = get_app_logger()

--- a/src/tasks/fetch_ip_rep.py
+++ b/src/tasks/fetch_ip_rep.py
@@ -15,6 +15,8 @@ TASK_CONFIG = {
     "enabled": True,
     # runs every 5 minutes anyway; enrichment is not needed to serve traffic.
     "run_when_loaded": False,
+    # Calls a third-party reputation API; N pods means N times the quota.
+    "single_pod": True,
 }
 
 

--- a/src/tasks/flag_stale_ips.py
+++ b/src/tasks/flag_stale_ips.py
@@ -11,6 +11,8 @@ TASK_CONFIG = {
     "enabled": True,
     # a daily 08:00 job — running it on every restart makes a daily sweep happen N times a day.
     "run_when_loaded": False,
+    # A shared-database sweep; the flags are global, not per pod.
+    "single_pod": True,
 }
 
 # Set to True to force all IPs to be flagged for reevaluation on next run.

--- a/src/tasks/hash_payloads.py
+++ b/src/tasks/hash_payloads.py
@@ -39,6 +39,8 @@ TASK_CONFIG = {
     # runs every minute anyway; a boot run only piles the history sweep on top
     # of startup, which is how this OOM-killed the pod into a crash loop.
     "run_when_loaded": False,
+    # One pod per minute hashes the batch; the others would redo the same rows.
+    "single_pod": True,
 }
 
 # Upper bound on access logs hashed per run; the remainder is picked up next

--- a/src/tasks/pre_retention_cleanup.py
+++ b/src/tasks/pre_retention_cleanup.py
@@ -25,6 +25,8 @@ TASK_CONFIG = {
     "enabled": True,
     # a daily 08:30 job, same problem, and it is the heavier of the two.
     "run_when_loaded": False,
+    # A shared-database sweep, and the heavier of the two.
+    "single_pod": True,
 }
 
 # Batch size for processing old logs to limit memory usage

--- a/src/tasks/refresh_banlist.py
+++ b/src/tasks/refresh_banlist.py
@@ -1,4 +1,4 @@
-from banlist_sync import refresh_banlist_sources
+from banlist_sync import load_published, refresh_banlist_sources
 from config import get_config
 from logger import get_app_logger
 
@@ -8,6 +8,10 @@ TASK_CONFIG = {
     # the lifespan already does an initial banlist sync before traffic is accepted; this repeated it.
     "run_when_loaded": False,
     "interval_seconds": 3600,
+    # One pod fetches the external sources; the rest adopt what it published via
+    # on_skip() below. Not gated by single_pod alone: the list lives in a
+    # per-pod frozenset, so a follower that merely skipped would go stale.
+    "single_pod": True,
 }
 
 
@@ -23,3 +27,19 @@ def main():
     TASK_CONFIG["interval_seconds"] = config.banlist_refresh_interval
 
     refresh_banlist_sources()
+
+
+def on_skip() -> None:
+    """Another pod owns this refresh; adopt its result rather than go stale.
+
+    The global banlist is a process-local frozenset read by the ban-check
+    middleware on every request. Skipping without adopting would leave this pod
+    enforcing an ever-older list.
+    """
+    if not get_config().banlist_sources:
+        return
+
+    if not load_published():
+        get_app_logger().debug(
+            "[RefreshBanlist] Nothing published yet; keeping the current list"
+        )

--- a/src/tasks/sync_cloudflare.py
+++ b/src/tasks/sync_cloudflare.py
@@ -8,6 +8,8 @@ TASK_CONFIG = {
     # pushes again 60 seconds later regardless.
     "run_when_loaded": False,
     "interval_seconds": 60,
+    # Pushes the banlist to CloudFlare; one push per interval is enough.
+    "single_pod": True,
 }
 
 

--- a/src/tasks_master.py
+++ b/src/tasks_master.py
@@ -8,6 +8,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
+import task_lock
 from logger import get_app_logger
 
 app_logger = get_app_logger()
@@ -108,6 +109,7 @@ class TasksMaster:
                     "enabled": module.TASK_CONFIG.get("enabled", False),
                     "run_when_loaded": module.TASK_CONFIG.get("run_when_loaded", False),
                     "interval_seconds": module.TASK_CONFIG.get("interval_seconds"),
+                    "single_pod": module.TASK_CONFIG.get("single_pod", False),
                 }
 
                 tasks.append(task)
@@ -132,6 +134,7 @@ class TasksMaster:
             module_name = os.path.splitext(task_to_run.get("filename"))[0]
             task_enabled = task_to_run.get("enabled", False)
             interval_seconds = task_to_run.get("interval_seconds")
+            single_pod = task_to_run.get("single_pod", False)
 
             # if no crontab set for this task, we use 15 as the default.
             task_cron = task_to_run.get("cron") or self.TASK_DEFAULT_CRON
@@ -153,6 +156,7 @@ class TasksMaster:
                         task_cron,
                         run_when_loaded,
                         interval_seconds=interval_seconds,
+                        single_pod=single_pod,
                     )
                     if interval_seconds:
                         app_logger.info(
@@ -175,8 +179,70 @@ class TasksMaster:
                     f"Error scheduling task: {e}", extra={"tasks": task_to_run}
                 )
 
+    @staticmethod
+    def _trigger_period(trigger) -> int:
+        """Seconds between two consecutive unjittered fire times of `trigger`.
+
+        Jitter is applied by the scheduler after the trigger produces a time, so
+        what this measures is the schedule's true period.
+        """
+        if isinstance(trigger, IntervalTrigger):
+            return int(trigger.interval.total_seconds())
+
+        now = datetime.datetime.now(trigger.timezone)
+        first = trigger.get_next_fire_time(None, now)
+        second = trigger.get_next_fire_time(first, first)
+        return int((second - first).total_seconds())
+
+    @classmethod
+    def _lease_seconds(cls, trigger) -> int:
+        """How long a single_pod task holds its claim on one occurrence.
+
+        Two constraints pull in opposite directions. The lease must outlast
+        TASK_JITTER, or a pod firing late finds it expired and runs the same
+        occurrence a second time. And it must expire before the next occurrence,
+        or it blocks that one too.
+
+        Twice the jitter window satisfies the first with margin for clock skew;
+        clamping to just under the period satisfies the second. A daily task
+        therefore holds 480 seconds rather than 24 hours -- long enough to cover
+        jitter, short enough that a leader that died leaves no day-long tombstone.
+        """
+        period = cls._trigger_period(trigger)
+        return min(max(period - 5, 5), 2 * cls.TASK_JITTER)
+
+    @staticmethod
+    def _guarded(fn, module, job_id: str, lease_seconds: int):
+        """Wrap a single_pod task so exactly one pod runs each occurrence.
+
+        A pod that loses the claim calls the module's on_skip() when it defines
+        one. That hook exists for tasks where skipping silently would leave the
+        pod stale rather than merely idle: refresh_banlist adopts the leader's
+        published list through it, and analyze_ips refreshes its process-local
+        Prometheus gauges.
+        """
+
+        @functools.wraps(fn)
+        def run(*args, **kwargs):
+            if task_lock.claim(job_id, lease_seconds):
+                return fn(*args, **kwargs)
+
+            app_logger.debug(f"{job_id}: another pod holds this occurrence; skipping")
+            on_skip = getattr(module, "on_skip", None)
+            if on_skip is not None:
+                return on_skip()
+            return None
+
+        return run
+
     def _schedule_task(
-        self, task_name, module_name, task_cron, run_when_loaded, interval_seconds=None
+        self,
+        task_name,
+        module_name,
+        task_cron,
+        run_when_loaded,
+        interval_seconds=None,
+        single_pod=False,
     ):
         try:
             # Dynamically import the module
@@ -197,6 +263,19 @@ class TasksMaster:
                         task_cron = self.TASK_DEFAULT_CRON
                     trigger = CronTrigger.from_crontab(task_cron)
 
+                # The gate lives here rather than inside main(), so a manual run
+                # from the maintenance panel stays unconditional.
+                job_func = module.main
+                if single_pod:
+                    lease_seconds = self._lease_seconds(trigger)
+                    job_func = self._guarded(
+                        module.main, module, job_identifier, lease_seconds
+                    )
+                    app_logger.info(
+                        f"{task_name} runs on one pod per occurrence "
+                        f"({lease_seconds}s lease)"
+                    )
+
                 # schedule the task / job
                 if run_when_loaded:
                     app_logger.info(
@@ -204,7 +283,7 @@ class TasksMaster:
                     )
 
                     self.scheduler.add_job(
-                        module.main,
+                        job_func,
                         trigger,
                         id=job_identifier,
                         jitter=self.TASK_JITTER,
@@ -214,7 +293,7 @@ class TasksMaster:
                     )
                 else:
                     self.scheduler.add_job(
-                        module.main,
+                        job_func,
                         trigger,
                         id=job_identifier,
                         jitter=self.TASK_JITTER,

--- a/src/tasks_master.py
+++ b/src/tasks_master.py
@@ -307,10 +307,24 @@ class TasksMaster:
             app_logger.error(f"Failed to load {module_name}: {e}")
 
     def job_listener(self, event):
-        if event.exception:
-            app_logger.error(f"Job {event.job_id} failed: {event.exception}")
-        else:
+        """Log every completion, and record which pod it happened on.
+
+        The job id is built as "<module>__<task name>" in _schedule_task, so the
+        task name the API and the dashboard use is its second half.
+        """
+        ok = event.exception is None
+        if ok:
             app_logger.info(f"Job {event.job_id} completed successfully.")
+        else:
+            app_logger.error(f"Job {event.job_id} failed: {event.exception}")
+
+        _, _, task_name = event.job_id.partition("__")
+        if task_name:
+            try:
+                task_lock.record_run(task_name, ok=ok)
+            except Exception as e:
+                # Never let bookkeeping turn a completed job into a failed one.
+                app_logger.error(f"Could not record run of {task_name}: {e}")
 
     def run_scheduled_tasks(self):
         """

--- a/src/templates/jinja2/dashboard/partials/settings_panel.html
+++ b/src/templates/jinja2/dashboard/partials/settings_panel.html
@@ -30,7 +30,8 @@
 
         <div class="auth-modal-body" x-show="tab === 'maintenance'">
             <p class="auth-modal-description">
-                Run a scheduled job now. Running one here does not change when it next runs on its own.
+                Run a scheduled job now. Running one here does not change when it next runs on its own,
+                and it always runs on the pod serving this page.
             </p>
 
             <p class="form-status" x-show="status" x-text="status" :class="statusOk ? 'text-ok' : 'text-danger'" x-cloak></p>
@@ -45,14 +46,39 @@
                         <div class="task-main">
                             <div class="task-name" x-text="task.name"></div>
                             <div class="task-meta">
-                                {# A disabled task still carries TasksMaster's default cron. Showing it
-                                   would claim a schedule the task does not actually have. #}
-                                <span x-text="!task.enabled ? 'on demand only'
-                                    : (task.interval_seconds ? `every ${task.interval_seconds}s` : task.cron)"></span>
-                                <span x-show="task.next_run" x-cloak>
-                                    · next <span x-text="task.next_run ? new Date(task.next_run).toLocaleString() : ''"></span>
+                                <span class="task-schedule">
+                                    {# A disabled task still carries TasksMaster's default cron. Showing it
+                                       would claim a schedule the task does not actually have. #}
+                                    <span x-text="!task.enabled ? 'on demand only'
+                                        : (task.interval_seconds ? `every ${task.interval_seconds}s` : task.cron)"></span>
+                                    <span x-show="task.next_run" x-cloak>
+                                        · next <span x-text="task.next_run ? new Date(task.next_run).toLocaleString() : ''"></span>
+                                    </span>
+                                    <span class="task-state" x-show="task.running" x-cloak>· running</span>
                                 </span>
-                                <span class="task-state" x-show="task.running" x-cloak>· running</span>
+
+                                {# Which pod does the work. A chip means one pod owns each
+                                   occurrence; the plain words mean every pod runs it. The
+                                   chip is tinted when it names the pod serving this page. #}
+                                <span class="task-owner">
+                                    <template x-if="!task.single_pod">
+                                        <span>runs on every pod</span>
+                                    </template>
+                                    <template x-if="task.single_pod && !task.last_run">
+                                        <span>not yet run</span>
+                                    </template>
+                                    <template x-if="task.single_pod && task.last_run">
+                                        <span class="task-owner-run">
+                                            <span class="task-pod"
+                                                  :class="{ 'task-pod-self': task.last_run.pod === thisPod }"
+                                                  :title="task.last_run.pod === thisPod ? 'This pod' : 'Another pod'"
+                                                  x-text="task.last_run.pod"></span>
+                                            <span :class="{ 'task-owner-failed': !task.last_run.ok }"
+                                                  x-text="(task.last_run.ok ? '' : 'failed ') +
+                                                      new Date(task.last_run.at).toLocaleTimeString()"></span>
+                                        </span>
+                                    </template>
+                                </span>
                             </div>
 
                             {# Only the purge task takes arguments; render them as checkboxes. #}

--- a/src/templates/static/css/dashboard.css
+++ b/src/templates/static/css/dashboard.css
@@ -3256,12 +3256,49 @@ tbody {
     font-size: var(--fs-sm);
     color: var(--text-strong);
 }
+/* Schedule on the left, which pod does the work on the right. They wrap onto
+   separate lines before either has to truncate. */
 .task-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--s1) var(--s3);
     margin-top: 2px;
     font-size: var(--fs-2xs);
     color: var(--text-faint);
 }
+.task-schedule { min-width: 0; }
 .task-state { color: var(--ok); }
+
+.task-owner,
+.task-owner-run {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--s1);
+}
+
+/* A hostname is an identifier, so it is set in mono like every other piece of
+   log data here -- and left in its real case, unlike the uppercased .cfg-badge
+   labels elsewhere in this modal. */
+.task-pod {
+    font-family: var(--font-mono);
+    padding: 1px var(--s2);
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    color: var(--text-dim);
+    white-space: nowrap;
+}
+
+/* The pod serving this page. The only question the operator cannot answer from
+   any other view. */
+.task-pod-self {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    background: var(--tint-accent);
+}
+
+.task-owner-failed { color: var(--danger); }
 .task-options {
     display: flex;
     flex-direction: column;
@@ -3297,6 +3334,7 @@ tbody {
 @media (max-width: 600px) {
     .task-row { flex-direction: column; align-items: stretch; }
     .task-run-btn { align-self: flex-start; }
+    .task-meta { justify-content: flex-start; }
 }
 /* Category checkboxes carry their category's color. */
 .export-check input[value="attacker"] { accent-color: var(--cat-attacker); }

--- a/src/templates/static/js/dashboard.js
+++ b/src/templates/static/js/dashboard.js
@@ -100,6 +100,9 @@ document.addEventListener('alpine:init', () => {
     Alpine.data('settingsPanel', () => ({
         tab: 'maintenance',
         tasks: [],
+        // Which pod is serving this page, so a task's last-run pod can be shown
+        // as "this one" rather than just another hostname.
+        thisPod: '',
         selected: {},
         loading: true,
         busy: null,
@@ -122,6 +125,7 @@ document.addEventListener('alpine:init', () => {
                 if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
                 const data = await resp.json();
                 this.tasks = data.tasks || [];
+                this.thisPod = data.this_pod || '';
                 // Seed a selection array for every task exposing options, so
                 // x-model has something to bind to.
                 for (const t of this.tasks) {

--- a/tests/test_analyze_ips_on_skip.py
+++ b/tests/test_analyze_ips_on_skip.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+"""A pod that skips analyze-ips must still refresh its own Prometheus gauges.
+
+These gauges are process-local, so a pod that never sets them exports 0. The
+Grafana dashboard reads them with max(), which then returns whichever pod last
+held the lease -- a stale high-water mark rather than the current value.
+
+Usage: python tests/test_analyze_ips_on_skip.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import metrics
+import tasks.analyze_ips as analyze_ips
+
+
+def test_on_skip_refreshes_gauges_without_analysing():
+    calls = []
+
+    original_refresh_ai = metrics.refresh_ai
+    original_refresh_system = metrics.refresh_system
+    original_get_database = analyze_ips.get_database
+
+    metrics.refresh_ai = lambda db: calls.append("refresh_ai")
+    metrics.refresh_system = lambda db: calls.append("refresh_system")
+    analyze_ips.get_database = lambda: object()
+
+    try:
+        analyze_ips.on_skip()
+    finally:
+        metrics.refresh_ai = original_refresh_ai
+        metrics.refresh_system = original_refresh_system
+        analyze_ips.get_database = original_get_database
+
+    assert calls == ["refresh_ai", "refresh_system"], f"got {calls}"
+
+
+def test_on_skip_is_discoverable_by_the_guard():
+    """The guard finds this hook with getattr(module, 'on_skip', None)."""
+    assert callable(getattr(analyze_ips, "on_skip", None))
+
+
+if __name__ == "__main__":
+    test_on_skip_refreshes_gauges_without_analysing()
+    test_on_skip_is_discoverable_by_the_guard()
+    print("PASS: analyze_ips on_skip")

--- a/tests/test_banlist_publish.py
+++ b/tests/test_banlist_publish.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+"""One pod fetches the external banlists; the rest adopt what it published.
+
+Without this, N pods fetch every configured URL every hour and end up with
+different lists depending on when each fetch landed and which sources failed
+for which pod.
+
+Usage: python tests/test_banlist_publish.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import banlist_sync
+import dashboard_cache
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+
+def use_scalable():
+    redis_client = FakeRedis()
+    dashboard_cache._backend = "scalable"
+    dashboard_cache._redis_client = redis_client
+    return redis_client
+
+
+def seed_leader_state(ips, sources):
+    banlist_sync._global_banlist = frozenset(ips)
+    banlist_sync._banlist_sources.clear()
+    banlist_sync._banlist_sources.extend(sources)
+
+
+def clear_follower_state():
+    banlist_sync._global_banlist = frozenset()
+    banlist_sync._banlist_sources.clear()
+
+
+def test_publish_then_adopt_round_trips():
+    use_scalable()
+    sources = [{"url": "https://example.test/list.txt", "status": "ok", "count": 2}]
+    seed_leader_state({"1.2.3.4", "5.6.7.8"}, sources)
+
+    assert banlist_sync.publish(10800) is True
+
+    clear_follower_state()
+    assert banlist_sync.load_published() is True
+    assert banlist_sync.get_global_banlist() == frozenset({"1.2.3.4", "5.6.7.8"})
+    assert banlist_sync.get_banlist_sources() == sources
+
+
+def test_adopted_list_answers_the_membership_check():
+    """The hot path reads the same frozenset, so adoption must feed it."""
+    use_scalable()
+    seed_leader_state({"9.9.9.9"}, [])
+    banlist_sync.publish(10800)
+
+    clear_follower_state()
+    assert banlist_sync.is_globally_banned("9.9.9.9") is False
+    banlist_sync.load_published()
+    assert banlist_sync.is_globally_banned("9.9.9.9") is True
+
+
+def test_load_published_is_false_when_nothing_was_published():
+    use_scalable()
+    clear_follower_state()
+    assert banlist_sync.load_published() is False
+    assert banlist_sync.get_global_banlist() == frozenset()
+
+
+def test_standalone_never_publishes():
+    dashboard_cache._backend = "standalone"
+    dashboard_cache._redis_client = None
+    seed_leader_state({"1.1.1.1"}, [])
+    assert banlist_sync.publish(10800) is False
+    assert banlist_sync.load_published() is False
+
+
+def test_published_key_avoids_the_flushed_cache_prefix():
+    redis_client = use_scalable()
+    seed_leader_state({"1.1.1.1"}, [])
+    banlist_sync.publish(10800)
+    assert banlist_sync.PUBLISHED_KEY == "krawl:task:banlist"
+    for key in redis_client.store:
+        assert not key.startswith("krawl:cache:"), f"{key} is wiped on pod boot"
+
+
+if __name__ == "__main__":
+    test_publish_then_adopt_round_trips()
+    test_adopted_list_answers_the_membership_check()
+    test_load_published_is_false_when_nothing_was_published()
+    test_standalone_never_publishes()
+    test_published_key_avoids_the_flushed_cache_prefix()
+    print("PASS: banlist publish and adopt")

--- a/tests/test_no_startup_flush.py
+++ b/tests/test_no_startup_flush.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+"""Pod startup must not discard the cluster's shared cache.
+
+In scalable mode krawl:cache:* is shared by every pod. Flushing it on boot means
+one pod restarting throws away work the others are still serving, and a
+crash-looping pod does it over and over. In standalone the process starts with an
+empty dict anyway, so the flush was only ever a no-op there.
+
+Usage: python tests/test_no_startup_flush.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import dashboard_cache
+
+
+def test_flush_all_is_gone():
+    assert not hasattr(dashboard_cache, "flush_all"), (
+        "flush_all had one caller (app startup) and wiped the shared cluster cache"
+    )
+
+
+def test_app_does_not_import_a_flush():
+    source = (Path(__file__).resolve().parent.parent / "src" / "app.py").read_text()
+    assert "flush_all" not in source, "app.py still imports the startup flush"
+    assert "flush_cache" not in source, "app.py still calls the startup flush"
+
+
+def test_cache_still_works_without_it():
+    """Deleting the flush must not disturb ordinary cache use."""
+    dashboard_cache._backend = "standalone"
+    dashboard_cache._redis_client = None
+    dashboard_cache.set_cached("probe", {"value": 1})
+    assert dashboard_cache.get_cached("probe") == {"value": 1}
+
+
+if __name__ == "__main__":
+    test_flush_all_is_gone()
+    test_app_does_not_import_a_flush()
+    test_cache_still_works_without_it()
+    print("PASS: no startup cache flush")

--- a/tests/test_single_pod_flags.py
+++ b/tests/test_single_pod_flags.py
@@ -28,6 +28,7 @@ EXPECTED_SINGLE_POD = {
     "flag-stale-ips",
     "hash-payloads",
     "pre-retention-cleanup",
+    "refresh-banlist",     # gated, but followers adopt via on_skip()
     "sync-cloudflare",
 }
 
@@ -36,7 +37,6 @@ EXPECTED_EVERY_POD = {
     "flush-access-logs",   # drains this pod's access-log write buffer
     "metrics-flush",       # flushes this pod's counters
     "refresh-ban-cache",   # fills this pod's banned-IP frozenset
-    "refresh-banlist",     # fills this pod's global banlist frozenset
     "purge",               # disabled; only ever run from the maintenance panel
 }
 

--- a/tests/test_single_pod_flags.py
+++ b/tests/test_single_pod_flags.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""Exactly the right tasks are gated to one pod.
+
+The unflagged four maintain PER-POD state: a blanket gate would silently stop
+each pod flushing its own buffers and filling its own in-process caches, which
+fails quietly and is very hard to spot in production.
+
+Usage: python tests/test_single_pod_flags.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from tasks_master import TasksMaster
+
+# Global effect: runs once per cluster.
+EXPECTED_SINGLE_POD = {
+    "analyze-ips",
+    "dashboard-warmup",
+    "db-retention",
+    "dump-krawl-data",
+    "fetch-ip-rep",
+    "flag-stale-ips",
+    "hash-payloads",
+    "pre-retention-cleanup",
+    "sync-cloudflare",
+}
+
+# Per-pod state: must run everywhere, every time.
+EXPECTED_EVERY_POD = {
+    "flush-access-logs",   # drains this pod's access-log write buffer
+    "metrics-flush",       # flushes this pod's counters
+    "refresh-ban-cache",   # fills this pod's banned-IP frozenset
+    "refresh-banlist",     # fills this pod's global banlist frozenset
+    "purge",               # disabled; only ever run from the maintenance panel
+}
+
+
+def test_flags_match_intent():
+    tasks = TasksMaster(BackgroundScheduler()).tasks
+    flagged = {t["name"] for t in tasks if t.get("single_pod")}
+    unflagged = {t["name"] for t in tasks if not t.get("single_pod")}
+
+    missing = EXPECTED_SINGLE_POD - flagged
+    assert not missing, f"these should be gated to one pod: {sorted(missing)}"
+
+    wrongly_gated = EXPECTED_EVERY_POD & flagged
+    assert not wrongly_gated, (
+        f"these keep per-pod state and must run everywhere: {sorted(wrongly_gated)}"
+    )
+
+    unexpected = flagged - EXPECTED_SINGLE_POD
+    assert not unexpected, (
+        f"new gated tasks -- confirm they hold no per-pod state: {sorted(unexpected)}"
+    )
+
+    unaccounted = unflagged - EXPECTED_EVERY_POD
+    assert not unaccounted, (
+        f"new ungated tasks -- confirm they are safe to run N times: {sorted(unaccounted)}"
+    )
+
+
+if __name__ == "__main__":
+    test_flags_match_intent()
+    print("PASS: single_pod flags")

--- a/tests/test_task_last_run.py
+++ b/tests/test_task_last_run.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+"""The dashboard needs a durable record of which pod last ran each task.
+
+The lease itself cannot answer this: a daily task holds it for 480 seconds out
+of 86400, so a panel reading the lock would be blank 99% of the time.
+
+Usage: python tests/test_task_last_run.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import dashboard_cache
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+
+def use_scalable():
+    dashboard_cache._backend = "scalable"
+    dashboard_cache._redis_client = FakeRedis()
+
+
+def test_record_then_read_round_trips():
+    use_scalable()
+    import task_lock
+
+    task_lock.record_run("db-retention", ok=True)
+    entry = task_lock.get_last_run("db-retention")
+
+    assert entry is not None, "a recorded run must be readable"
+    assert entry["pod"] == task_lock.POD_UID
+    assert entry["ok"] is True
+    assert entry["at"], "the record must carry a timestamp"
+
+
+def test_failure_is_recorded_as_such():
+    use_scalable()
+    import task_lock
+
+    task_lock.record_run("db-dump", ok=False)
+    assert task_lock.get_last_run("db-dump")["ok"] is False
+
+
+def test_unrun_task_has_no_record():
+    use_scalable()
+    import task_lock
+
+    assert task_lock.get_last_run("never-ran") is None
+
+
+def test_record_works_in_standalone():
+    dashboard_cache._backend = "standalone"
+    dashboard_cache._redis_client = None
+    import task_lock
+
+    task_lock.record_run("db-dump", ok=True)
+    entry = task_lock.get_last_run("db-dump")
+    assert entry is not None and entry["pod"] == task_lock.POD_UID
+
+
+def test_record_keys_stay_out_of_the_cache_namespace():
+    use_scalable()
+    import task_lock
+
+    task_lock.record_run("db-dump", ok=True)
+    assert task_lock.LAST_RUN_PREFIX == "krawl:task:last_run:"
+    for key in dashboard_cache._redis_client.store:
+        assert not key.startswith("krawl:cache:"), f"{key} belongs to the disposable cache"
+
+
+def test_job_listener_records_the_run():
+    """job_listener already sees every completion; it is where the record belongs."""
+    use_scalable()
+    import task_lock
+    from apscheduler.schedulers.background import BackgroundScheduler
+    from tasks_master import TasksMaster
+
+    master = TasksMaster(BackgroundScheduler())
+
+    class FakeEvent:
+        job_id = "db_retention__db-retention"
+        exception = None
+
+    master.job_listener(FakeEvent())
+    entry = task_lock.get_last_run("db-retention")
+    assert entry is not None, "job_listener must record the run"
+    assert entry["ok"] is True
+
+    class FakeFailure:
+        job_id = "db_dump__dump-krawl-data"
+        exception = RuntimeError("boom")
+
+    master.job_listener(FakeFailure())
+    assert task_lock.get_last_run("dump-krawl-data")["ok"] is False
+
+
+if __name__ == "__main__":
+    test_record_then_read_round_trips()
+    test_failure_is_recorded_as_such()
+    test_unrun_task_has_no_record()
+    test_record_works_in_standalone()
+    test_record_keys_stay_out_of_the_cache_namespace()
+    test_job_listener_records_the_run()
+    print("PASS: task last-run record")

--- a/tests/test_task_lease.py
+++ b/tests/test_task_lease.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+"""Lease length must outlast the scheduler's jitter but expire before the next run.
+
+TasksMaster gives every job up to TASK_JITTER seconds of jitter, so two pods fire
+the same cron minutes apart. A lease shorter than that window is already expired
+when the late pod fires, and the occurrence runs twice. A lease longer than the
+period blocks the following occurrence.
+
+Usage: python tests/test_task_lease.py
+"""
+
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
+import dashboard_cache
+from tasks_master import TasksMaster
+
+JITTER = TasksMaster.TASK_JITTER
+
+
+def test_trigger_period_for_cron():
+    assert TasksMaster._trigger_period(CronTrigger.from_crontab("0 9 * * *")) == 86400
+    assert TasksMaster._trigger_period(CronTrigger.from_crontab("*/1 * * * *")) == 60
+    assert TasksMaster._trigger_period(CronTrigger.from_crontab("*/5 * * * *")) == 300
+
+
+def test_trigger_period_for_interval():
+    assert TasksMaster._trigger_period(IntervalTrigger(seconds=30)) == 30
+    assert TasksMaster._trigger_period(IntervalTrigger(seconds=3600)) == 3600
+
+
+def test_lease_covers_jitter_without_blocking_the_next_run():
+    for crontab in ("0 9 * * *", "*/15 * * * *", "*/5 * * * *"):
+        trigger = CronTrigger.from_crontab(crontab)
+        period = TasksMaster._trigger_period(trigger)
+        lease = TasksMaster._lease_seconds(trigger)
+        assert lease < period, f"{crontab}: lease {lease} would block the next run"
+        assert lease >= JITTER, f"{crontab}: lease {lease} does not cover {JITTER}s jitter"
+
+
+def test_short_period_lease_stays_below_the_period():
+    """Sub-jitter periods cannot cover the jitter window; they must still not block."""
+    for seconds in (30, 60):
+        trigger = IntervalTrigger(seconds=seconds)
+        lease = TasksMaster._lease_seconds(trigger)
+        assert 0 < lease < seconds, f"{seconds}s interval got lease {lease}"
+
+
+def test_daily_lease_is_not_a_day_long():
+    """A crashed leader must not leave a 24-hour tombstone."""
+    lease = TasksMaster._lease_seconds(CronTrigger.from_crontab("0 9 * * *"))
+    assert lease <= 2 * JITTER, f"daily lease {lease} is longer than it needs to be"
+
+
+def _fake_module(with_on_skip: bool):
+    module = types.ModuleType("fake_task")
+    module.calls = []
+    module.main = lambda: module.calls.append("main")
+    if with_on_skip:
+        module.on_skip = lambda: module.calls.append("on_skip")
+    return module
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+
+def test_guard_runs_the_leader_and_skips_the_rest():
+    dashboard_cache._backend = "scalable"
+    dashboard_cache._redis_client = _FakeRedis()
+
+    module = _fake_module(with_on_skip=False)
+    guarded = TasksMaster._guarded(module.main, module, "fake-job", 60)
+
+    guarded()
+    guarded()
+    assert module.calls == ["main"], f"expected one run, got {module.calls}"
+
+
+def test_guard_calls_on_skip_when_the_claim_is_lost():
+    dashboard_cache._backend = "scalable"
+    dashboard_cache._redis_client = _FakeRedis()
+
+    module = _fake_module(with_on_skip=True)
+    guarded = TasksMaster._guarded(module.main, module, "fake-job-2", 60)
+
+    guarded()
+    guarded()
+    assert module.calls == ["main", "on_skip"], f"got {module.calls}"
+
+
+if __name__ == "__main__":
+    test_trigger_period_for_cron()
+    test_trigger_period_for_interval()
+    test_lease_covers_jitter_without_blocking_the_next_run()
+    test_short_period_lease_stays_below_the_period()
+    test_daily_lease_is_not_a_day_long()
+    test_guard_runs_the_leader_and_skips_the_rest()
+    test_guard_calls_on_skip_when_the_claim_is_lost()
+    print("PASS: task lease and guard")

--- a/tests/test_task_lock.py
+++ b/tests/test_task_lock.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+"""The cross-pod lease must hand a job to exactly one pod per window.
+
+Usage: python tests/test_task_lock.py
+"""
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import dashboard_cache
+
+
+class FakeRedis:
+    """Only the calls task_lock makes, with real NX and EX semantics."""
+
+    def __init__(self):
+        self.store: dict[str, tuple[str, float | None]] = {}
+
+    def _alive(self, key: str) -> bool:
+        entry = self.store.get(key)
+        if entry is None:
+            return False
+        expires = entry[1]
+        if expires is not None and expires <= time.time():
+            del self.store[key]
+            return False
+        return True
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and self._alive(key):
+            return None
+        self.store[key] = (value, time.time() + ex if ex else None)
+        return True
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+    def exists(self, key):
+        return 1 if self._alive(key) else 0
+
+
+def use_scalable(redis_client) -> None:
+    """Point the cache module at a fake Redis, as scalable mode would."""
+    dashboard_cache._backend = "scalable"
+    dashboard_cache._redis_client = redis_client
+
+
+def use_standalone() -> None:
+    dashboard_cache._backend = "standalone"
+    dashboard_cache._redis_client = None
+
+
+def test_one_pod_wins():
+    use_scalable(FakeRedis())
+    import task_lock
+
+    first = task_lock.claim("db-retention", 60)
+    second = task_lock.claim("db-retention", 60)
+    assert first is True, "the first pod must win the claim"
+    assert second is False, f"a second pod must lose it, got {second}"
+
+
+def test_different_jobs_do_not_collide():
+    use_scalable(FakeRedis())
+    import task_lock
+
+    assert task_lock.claim("db-retention", 60) is True
+    assert task_lock.claim("db-dump", 60) is True, "distinct jobs share no lease"
+
+
+def test_lease_expiry_frees_the_job():
+    use_scalable(FakeRedis())
+    import task_lock
+
+    assert task_lock.claim("db-dump", 1) is True
+    assert task_lock.claim("db-dump", 1) is False
+    time.sleep(1.1)
+    assert task_lock.claim("db-dump", 1) is True, "an expired lease must be reclaimable"
+
+
+def test_standalone_always_claims():
+    """One process, so a released job must be immediately reclaimable."""
+    use_standalone()
+    import task_lock
+
+    task_lock._local_leases.clear()
+    assert task_lock.claim("db-dump", 60) is True
+    task_lock.release("db-dump")
+    assert task_lock.claim("db-dump", 60) is True, "standalone must never stay gated"
+
+
+def test_standalone_still_rejects_a_concurrent_run():
+    """The maintenance panel needs a second click rejected even without Redis."""
+    use_standalone()
+    import task_lock
+
+    task_lock._local_leases.clear()
+    assert task_lock.claim("manual", 60) is True
+    assert task_lock.claim("manual", 60) is False
+
+
+def test_missing_redis_fails_open():
+    dashboard_cache._backend = "scalable"
+    dashboard_cache._redis_client = None
+    import task_lock
+
+    assert task_lock.claim("db-dump", 60) is True, "no Redis must not stop maintenance"
+
+
+def test_release_frees_the_job():
+    use_scalable(FakeRedis())
+    import task_lock
+
+    assert task_lock.claim("manual-run", 3600) is True
+    assert task_lock.is_held("manual-run") is True
+    task_lock.release("manual-run")
+    assert task_lock.is_held("manual-run") is False
+    assert task_lock.claim("manual-run", 3600) is True
+
+
+def test_lock_keys_stay_out_of_the_cache_namespace():
+    """krawl:cache:* is disposable and TTL'd; a lease is neither."""
+    redis_client = FakeRedis()
+    use_scalable(redis_client)
+    import task_lock
+
+    task_lock.claim("db-dump", 60)
+    assert task_lock.LOCK_PREFIX == "krawl:task:lock:"
+    for key in redis_client.store:
+        assert not key.startswith("krawl:cache:"), f"{key} belongs to the disposable cache"
+
+
+def test_holder_is_recorded():
+    """A held lease names its holder, so redis-cli shows which pod has it."""
+    redis_client = FakeRedis()
+    use_scalable(redis_client)
+    import task_lock
+
+    task_lock.claim("db-dump", 60)
+    value, _ = redis_client.store[f"{task_lock.LOCK_PREFIX}db-dump"]
+    assert value == task_lock.POD_UID, f"expected {task_lock.POD_UID}, got {value}"
+
+
+if __name__ == "__main__":
+    test_one_pod_wins()
+    test_different_jobs_do_not_collide()
+    test_lease_expiry_frees_the_job()
+    test_standalone_always_claims()
+    test_standalone_still_rejects_a_concurrent_run()
+    test_missing_redis_fails_open()
+    test_release_frees_the_job()
+    test_lock_keys_stay_out_of_the_cache_namespace()
+    test_holder_is_recorded()
+    print("PASS: task_lock")

--- a/tests/test_task_lock.py
+++ b/tests/test_task_lock.py
@@ -6,7 +6,6 @@ Usage: python tests/test_task_lock.py
 """
 
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
@@ -15,17 +14,27 @@ import dashboard_cache
 
 
 class FakeRedis:
-    """Only the calls task_lock makes, with real NX and EX semantics."""
+    """Only the calls task_lock makes, with real NX and EX semantics.
+
+    Time is driven by `now` rather than the wall clock. Sleeping past a 1-second
+    TTL leaves ~100ms of margin, which a loaded machine will occasionally miss --
+    and expiry is exactly what these tests are asserting, so it must not depend
+    on the OS scheduler.
+    """
 
     def __init__(self):
         self.store: dict[str, tuple[str, float | None]] = {}
+        self.now = 1_000_000.0
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
 
     def _alive(self, key: str) -> bool:
         entry = self.store.get(key)
         if entry is None:
             return False
         expires = entry[1]
-        if expires is not None and expires <= time.time():
+        if expires is not None and expires <= self.now:
             del self.store[key]
             return False
         return True
@@ -33,7 +42,7 @@ class FakeRedis:
     def set(self, key, value, nx=False, ex=None):
         if nx and self._alive(key):
             return None
-        self.store[key] = (value, time.time() + ex if ex else None)
+        self.store[key] = (value, self.now + ex if ex else None)
         return True
 
     def delete(self, key):
@@ -73,13 +82,14 @@ def test_different_jobs_do_not_collide():
 
 
 def test_lease_expiry_frees_the_job():
-    use_scalable(FakeRedis())
+    redis_client = FakeRedis()
+    use_scalable(redis_client)
     import task_lock
 
-    assert task_lock.claim("db-dump", 1) is True
-    assert task_lock.claim("db-dump", 1) is False
-    time.sleep(1.1)
-    assert task_lock.claim("db-dump", 1) is True, "an expired lease must be reclaimable"
+    assert task_lock.claim("db-dump", 60) is True
+    assert task_lock.claim("db-dump", 60) is False
+    redis_client.advance(61)
+    assert task_lock.claim("db-dump", 60) is True, "an expired lease must be reclaimable"
 
 
 def test_standalone_always_claims():
@@ -145,6 +155,36 @@ def test_holder_is_recorded():
     assert value == task_lock.POD_UID, f"expected {task_lock.POD_UID}, got {value}"
 
 
+def test_reconcile_lock_delegates():
+    """metrics_counters keeps its API but stops hand-rolling the lock."""
+    use_scalable(FakeRedis())
+    import metrics_counters
+    import task_lock
+
+    assert metrics_counters._acquire_reconcile_lock(60) is True
+    assert metrics_counters._acquire_reconcile_lock(60) is False
+    # Delegation, not just equivalent behaviour: one lock implementation, one
+    # namespace. Three hand-rolled copies of SET NX EX was the thing to fix.
+    keys = list(dashboard_cache._redis_client.store)
+    assert keys and all(k.startswith(task_lock.LOCK_PREFIX) for k in keys), keys
+
+
+def test_run_lock_delegates_and_releases():
+    """The maintenance panel wants a mutex: claim, then release on completion."""
+    use_scalable(FakeRedis())
+    import task_lock
+    from routes import api
+
+    assert api._acquire_run_lock("db-dump") is True
+    keys = list(dashboard_cache._redis_client.store)
+    assert keys and all(k.startswith(task_lock.LOCK_PREFIX) for k in keys), keys
+    assert api._acquire_run_lock("db-dump") is False
+    assert api._is_running("db-dump") is True
+    api._release_run_lock("db-dump")
+    assert api._is_running("db-dump") is False
+    assert api._acquire_run_lock("db-dump") is True
+
+
 if __name__ == "__main__":
     test_one_pod_wins()
     test_different_jobs_do_not_collide()
@@ -155,4 +195,6 @@ if __name__ == "__main__":
     test_release_frees_the_job()
     test_lock_keys_stay_out_of_the_cache_namespace()
     test_holder_is_recorded()
+    test_reconcile_lock_delegates()
+    test_run_lock_delegates_and_releases()
     print("PASS: task_lock")


### PR DESCRIPTION
This pull request introduces a robust cross-pod task lease system to ensure that scheduled tasks with global effects only run once per cluster, not once per pod, in scalable deployments. It also improves the handling of the banlist for new pods joining a cluster, refines metric counter durability, and enhances the dashboard's visibility into task execution. Additionally, it removes unnecessary cache flushes on pod startup and consolidates task locking logic into a new `task_lock` module.

**Cross-pod task lease system and task execution improvements:**
- Added a new `task_lock.py` module implementing a Redis-backed lease system for scheduled and manual tasks, preventing duplicate execution across pods and providing APIs to claim, release, and inspect leases and last run info (`claim`, `release`, `is_held`, `record_run`, `get_last_run`).
- Updated scheduled task documentation to explain the new lease system, how tasks are gated to a single pod, and how per-pod and hybrid tasks are handled. [[1]](diffhunk://#diff-9ac02f1c2289520aeb58725683781053f5ba6bf828b2e8585540596060f1f416R10-R11) [[2]](diffhunk://#diff-9ac02f1c2289520aeb58725683781053f5ba6bf828b2e8585540596060f1f416R130-R159)

**Banlist synchronization and adoption:**
- Enhanced banlist handling so that when a new pod joins an existing cluster, it adopts the already-fetched banlist from Redis, avoiding redundant external requests; only a cold cluster fetches sources. Added `publish` and `load_published` functions to `banlist_sync.py`. [[1]](diffhunk://#diff-b5d1afbbeb6738799c797f5da1d4110d0496e352a10d05394f79fac49fc4cbc2R96-R172) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L181-R180)

**Metric counters and cache management:**
- Refined metric counter documentation and implementation to clarify that counters are durable and not subject to cache flushes. Updated the cross-pod reconcile lock to use the new task lease system. [[1]](diffhunk://#diff-848fc706bd9a6ca1f4c65a3e80ec4d91bc479e44e3f8012b404a5e66dc480d85L4-R9) [[2]](diffhunk://#diff-848fc706bd9a6ca1f4c65a3e80ec4d91bc479e44e3f8012b404a5e66dc480d85L315-R329)
- Removed the global cache flush on pod startup, as it is no longer necessary with the improved task and counter management. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L18) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L135-L138) [[3]](diffhunk://#diff-6ec317b620883fa5f5a0919c4fd74a2fc6d884f81122b2be0ef1764a763110afL270-L292)

**Dashboard and API improvements:**
- Updated the task API and dashboard to show which pod last ran each task, whether a task is single-pod, and the current pod's identity. All task locking now uses the shared lease system. [[1]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667L1680-R1711) [[2]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667R1735-R1736) [[3]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667L1769-R1752) [[4]](diffhunk://#diff-e12f5f62c2b9b3d71e28640fe6ca1ee11176093e88faf119d2ea15d465062d68R23-R24)

**Codebase simplification:**
- Removed redundant threading-based local locks and old cache flush logic, consolidating all lock handling in the new `task_lock` module. [[1]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667L16) [[2]](diffhunk://#diff-ea25b0a7e80f9287a1bdb2885f0219320c914469f2446248935d83f162f91667L1680-R1711)

These changes ensure that scheduled and manual tasks behave correctly and efficiently in both standalone and scalable deployments, improving reliability and operational transparency.